### PR TITLE
Deduplicate `_EPS` constant in view_projection.py

### DIFF
--- a/packages/seisai-transforms/src/seisai_transforms/view_projection.py
+++ b/packages/seisai-transforms/src/seisai_transforms/view_projection.py
@@ -3,6 +3,9 @@ from __future__ import annotations
 import numpy as np
 
 
+_EPS = 1e-6  # 比較時の許容誤差（ほぼ等しいかの判定に使用）
+
+
 def _resample_idx_nearest(v: np.ndarray, factor_h: float) -> np.ndarray:
 	"""(H,) 整数インデックス列を H を保ったまま「最近傍補間」で再サンプルする。
 	目的:
@@ -88,12 +91,6 @@ def project_fb_idx_view(fb_idx: np.ndarray, H: int, W: int, meta: dict) -> np.nd
 	fb = np.round(fb * factor).astype(np.int64) - start  # 0-based & round
 	fb[(fb <= 0) | (fb >= W)] = -1
 	return fb
-
-
-_EPS = 1e-6
-
-
-_EPS = 1e-6
 
 
 def project_offsets_view(offsets: np.ndarray, H: int, meta: dict) -> np.ndarray:


### PR DESCRIPTION
### Motivation
- Remove duplicate `_EPS` definitions in `packages/seisai-transforms/src/seisai_transforms/view_projection.py` and provide a single, documented constant for use in tolerance checks (e.g. comparing `factor_h` to 1.0). 

### Description
- Consolidated two duplicate `_EPS = 1e-6` definitions into a single module-level `
`_EPS` = 1e-6` with a brief comment and left call sites such as `project_offsets_view` and other checks referencing the same constant unchanged. 

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697191de9d94832b87f6caa6f8bdf977)