### PR TITLE
Pass pre-sliced fb_subset into SampleTransformer to avoid duplicate slicing

### DIFF
--- a/packages/seisai-dataset/src/seisai_dataset/segy_gather_pipeline_dataset.py
+++ b/packages/seisai-dataset/src/seisai_dataset/segy_gather_pipeline_dataset.py
@@ -22,6 +22,146 @@ from .trace_subset_preproc import TraceSubsetLoader
 from .trace_subset_sampler import TraceSubsetSampler
 
 
+class SampleSelector:
+	def __init__(self, sampler: TraceSubsetSampler) -> None:
+		self.sampler = sampler
+
+	def draw_sample(self, info: dict, rng: np.random.Generator) -> dict:
+		seed = int(rng.integers(0, 2**31 - 1))
+		s = self.sampler.draw(info, py_random=random.Random(seed))
+		return {
+			'indices': np.asarray(s['indices'], dtype=np.int64),
+			'key_name': s['key_name'],
+			'secondary_key': s['secondary_key'],
+			'did_super': bool(s['did_super']),
+			'primary_unique': s['primary_unique'],
+		}
+
+
+class SampleTransformer:
+	def __init__(
+		self,
+		subsetloader: TraceSubsetLoader,
+		transform,
+	) -> None:
+		self.subsetloader = subsetloader
+		self.transform = transform
+
+	def load_transform(
+		self,
+		info: dict,
+		indices: np.ndarray,
+		fb_subset: np.ndarray,
+		rng: np.random.Generator,
+	) -> tuple[np.ndarray, dict, np.ndarray, np.ndarray]:
+		mmap = info['mmap']
+
+		# 波形読み出し
+		x = self.subsetloader.load(mmap, indices)  # (H,W0) float32 を想定
+		offsets = info['offsets'][indices].astype(np.float32)
+
+		# 変換（Crop/Pad / TimeStretch 等）
+		out = self.transform(x, rng=rng, return_meta=True)
+		x_view, meta = out if isinstance(out, tuple) else (out, {})
+		if not isinstance(x_view, np.ndarray) or x_view.ndim != 2:
+			raise ValueError(
+				'transform は 2D numpy または (2D, meta) を返す必要があります'
+			)
+		H, W = x_view.shape
+		W0 = x.shape[1]
+		t_raw = np.arange(W0, dtype=np.float32) * float(info['dt_sec'])
+
+		meta['fb_idx_view'] = project_fb_idx_view(fb_subset, H, W, meta)
+		meta['offsets_view'] = project_offsets_view(offsets, H, meta)
+		meta['time_view'] = project_time_view(t_raw, H, W, meta)
+		return x_view, meta, offsets, fb_subset
+
+
+class GateEvaluator:
+	def __init__(self, fbgate: FirstBreakGate, *, verbose: bool = False) -> None:
+		self.fbgate = fbgate
+		self.verbose = bool(verbose)
+		self.last_reject: str | None = None
+
+	def min_pick_accept(self, fb_subset: np.ndarray) -> bool:
+		ok_pick, _, _ = self.fbgate.min_pick_accept(fb_subset)
+		if not ok_pick:
+			self.last_reject = 'min_pick'
+			return False
+		self.last_reject = None
+		return True
+
+	def apply_gates(self, meta: dict, did_super: bool, info: dict) -> bool:
+		# FBLC gate（After transform）
+		factor = float(meta.get('factor', 1.0))
+		dt_eff_sec = info['dt_sec'] / max(factor, 1e-9)
+		meta['dt_eff_sec'] = float(dt_eff_sec)
+		ok_fblc, p_ms, valid_pairs = self.fbgate.fblc_accept(
+			meta['fb_idx_view'], dt_eff_sec=dt_eff_sec, did_super=did_super
+		)
+		if not ok_fblc:
+			if self.verbose:
+				print(
+					f'Rejecting gather {info["path"]} key={meta.get("key_name", "")}:{meta.get("primary_unique", "")} '
+					f'(FBLC gate; pairs={valid_pairs}, p_ms={p_ms})'
+				)
+			self.last_reject = 'fblc'
+			return False
+
+		self.last_reject = None
+		return True
+
+
+class OutputBuilder:
+	def __init__(self, plan: BuildPlan, rng: np.random.Generator) -> None:
+		if not isinstance(plan, BuildPlan):
+			raise TypeError('plan must be BuildPlan')
+		self.plan = plan
+		self.rng = rng
+
+	def build_output(
+		self,
+		sample: dict,
+		meta: dict,
+		fb_subset: np.ndarray,
+		offsets: np.ndarray,
+		info: dict,
+	) -> dict:
+		dt_eff_sec = float(meta.get('dt_eff_sec', info['dt_sec']))
+		sample_for_plan = {
+			'x_view': sample['x_view'],  # (H,W)
+			'dt_sec': dt_eff_sec,
+			'offsets': offsets,  # (H,)
+			'fb_idx': fb_subset,  # (H,)
+			'meta': meta,
+			'file_path': info['path'],
+			'indices': sample['indices'],
+			'key_name': sample['key_name'],
+			'secondary_key': sample['secondary_key'],
+			'primary_unique': sample['primary_unique'],
+		}
+
+		self.plan.run(sample_for_plan, rng=self.rng)
+		if 'input' not in sample_for_plan or 'target' not in sample_for_plan:
+			raise KeyError("plan must populate 'input' and 'target'")
+
+		return {
+			'input': sample_for_plan['input'],  # torch.Tensor (C,H,W)
+			'target': sample_for_plan['target'],  # torch.Tensor (C2,H,W) など
+			'mask_bool': sample_for_plan.get('mask_bool'),  # (H,T) bool（ある場合）
+			'meta': meta,  # ビュー情報
+			'dt_sec': torch.tensor(dt_eff_sec, dtype=torch.float32),
+			'fb_idx': torch.from_numpy(fb_subset),
+			'offsets': torch.from_numpy(offsets),
+			'file_path': info['path'],
+			'indices': sample['indices'],
+			'key_name': sample['key_name'],
+			'secondary_key': sample['secondary_key'],
+			'primary_unique': sample['primary_unique'],
+			'did_superwindow': sample['did_super'],
+		}
+
+
 class SegyGatherPipelineDataset(Dataset):
 	"""SEG-Y ギャザー読み込み → サンプリング → 変換 → FBLC ゲート → （任意）BuildPlanで入出力生成。
 
@@ -53,6 +193,10 @@ class SegyGatherPipelineDataset(Dataset):
 		valid: bool = False,
 		verbose: bool = False,
 		max_trials: int = 2048,
+		sample_selector: SampleSelector | None = None,
+		sample_transformer: SampleTransformer | None = None,
+		gate_evaluator: GateEvaluator | None = None,
+		output_builder: OutputBuilder | None = None,
 	) -> None:
 		if len(segy_files) == 0 or len(fb_files) == 0:
 			raise ValueError('segy_files / fb_files は空であってはならない')
@@ -63,8 +207,6 @@ class SegyGatherPipelineDataset(Dataset):
 		self.fb_files = list(fb_files)
 		self.transform = transform
 		self.fbgate = fbgate
-		if not isinstance(plan, BuildPlan):
-			raise TypeError('plan must be BuildPlan')
 		self.plan = plan
 
 		self.ffid_byte = ffid_byte
@@ -88,23 +230,36 @@ class SegyGatherPipelineDataset(Dataset):
 
 		self._rng = np.random.default_rng()
 		self.max_trials = int(max_trials)
-		self._last_gate_reject: str | None = None
 
 		# components
-		self.subsetloader = TraceSubsetLoader(
-			LoaderConfig(pad_traces_to=int(subset_traces))
-		)
-		self.sampler = TraceSubsetSampler(
-			TraceSubsetSamplerConfig(
-				primary_keys=self.primary_keys,
-				primary_key_weights=self.primary_key_weights,
-				use_superwindow=self.use_superwindow,
-				sw_halfspan=self.sw_halfspan,
-				sw_prob=self.sw_prob,
-				valid=self.valid,
-				subset_traces=int(subset_traces),
+		if sample_selector is None or sample_transformer is None:
+			subsetloader = TraceSubsetLoader(
+				LoaderConfig(pad_traces_to=int(subset_traces))
 			)
-		)
+		if sample_selector is None:
+			sampler = TraceSubsetSampler(
+				TraceSubsetSamplerConfig(
+					primary_keys=self.primary_keys,
+					primary_key_weights=self.primary_key_weights,
+					use_superwindow=self.use_superwindow,
+					sw_halfspan=self.sw_halfspan,
+					sw_prob=self.sw_prob,
+					valid=self.valid,
+					subset_traces=int(subset_traces),
+				)
+			)
+			sample_selector = SampleSelector(sampler)
+		if sample_transformer is None:
+			sample_transformer = SampleTransformer(subsetloader, transform)
+		if gate_evaluator is None:
+			gate_evaluator = GateEvaluator(fbgate, verbose=self.verbose)
+		if output_builder is None:
+			output_builder = OutputBuilder(plan, self._rng)
+
+		self.sample_selector = sample_selector
+		self.sample_transformer = sample_transformer
+		self.gate_evaluator = gate_evaluator
+		self.output_builder = output_builder
 
 		# ファイルごとのインデックス辞書等を構築
 		self.file_infos: list[dict] = []
@@ -136,140 +291,41 @@ class SegyGatherPipelineDataset(Dataset):
 	def __len__(self) -> int:
 		return 1024
 
-	def _draw_sample(self, info: dict, rng: np.random.Generator) -> dict:
-		seed = int(rng.integers(0, 2**31 - 1))
-		s = self.sampler.draw(info, py_random=random.Random(seed))
-		return {
-			'indices': np.asarray(s['indices'], dtype=np.int64),
-			'key_name': s['key_name'],
-			'secondary_key': s['secondary_key'],
-			'did_super': bool(s['did_super']),
-			'primary_unique': s['primary_unique'],
-		}
-
-	def _load_transform(
-		self,
-		info: dict,
-		indices: np.ndarray,
-		rng: np.random.Generator,
-	) -> tuple[np.ndarray, dict, np.ndarray, np.ndarray]:
-		mmap = info['mmap']
-		fb_all = info['fb']
-		fb_subset = fb_all[indices]
-
-		# 波形読み出し
-		x = self.subsetloader.load(mmap, indices)  # (H,W0) float32 を想定
-		offsets = info['offsets'][indices].astype(np.float32)
-
-		# 変換（Crop/Pad / TimeStretch 等）
-		out = self.transform(x, rng=rng, return_meta=True)
-		x_view, meta = out if isinstance(out, tuple) else (out, {})
-		if not isinstance(x_view, np.ndarray) or x_view.ndim != 2:
-			raise ValueError(
-				'transform は 2D numpy または (2D, meta) を返す必要があります'
-			)
-		H, W = x_view.shape
-		W0 = x.shape[1]
-		t_raw = np.arange(W0, dtype=np.float32) * float(info['dt_sec'])
-
-		meta['fb_idx_view'] = project_fb_idx_view(fb_subset, H, W, meta)
-		meta['offsets_view'] = project_offsets_view(offsets, H, meta)
-		meta['time_view'] = project_time_view(t_raw, H, W, meta)
-		return x_view, meta, offsets, fb_subset
-
-	def _apply_gates(
-		self, meta: dict, did_super: bool, info: dict
-	) -> bool:
-		# FBLC gate（After transform）
-		factor = float(meta.get('factor', 1.0))
-		dt_eff_sec = info['dt_sec'] / max(factor, 1e-9)
-		meta['dt_eff_sec'] = float(dt_eff_sec)
-		ok_fblc, p_ms, valid_pairs = self.fbgate.fblc_accept(
-			meta['fb_idx_view'], dt_eff_sec=dt_eff_sec, did_super=did_super
-		)
-		if not ok_fblc:
-			if self.verbose:
-				print(
-					f'Rejecting gather {info["path"]} key={meta.get("key_name", "")}:{meta.get("primary_unique", "")} '
-					f'(FBLC gate; pairs={valid_pairs}, p_ms={p_ms})'
-				)
-			self._last_gate_reject = 'fblc'
-			return False
-
-		self._last_gate_reject = None
-		return True
-
-	def _build_output(
-		self,
-		sample: dict,
-		meta: dict,
-		fb_subset: np.ndarray,
-		offsets: np.ndarray,
-		info: dict,
-	) -> dict:
-		dt_eff_sec = float(meta.get('dt_eff_sec', info['dt_sec']))
-		sample_for_plan = {
-			'x_view': sample['x_view'],  # (H,W)
-			'dt_sec': dt_eff_sec,
-			'offsets': offsets,  # (H,)
-			'fb_idx': fb_subset,  # (H,)
-			'meta': meta,
-			'file_path': info['path'],
-			'indices': sample['indices'],
-			'key_name': sample['key_name'],
-			'secondary_key': sample['secondary_key'],
-			'primary_unique': sample['primary_unique'],
-		}
-
-		self.plan.run(sample_for_plan, rng=self._rng)
-		if 'input' not in sample_for_plan or 'target' not in sample_for_plan:
-			raise KeyError("plan must populate 'input' and 'target'")
-
-		return {
-			'input': sample_for_plan['input'],  # torch.Tensor (C,H,W)
-			'target': sample_for_plan['target'],  # torch.Tensor (C2,H,W) など
-			'mask_bool': sample_for_plan.get('mask_bool'),  # (H,T) bool（ある場合）
-			'meta': meta,  # ビュー情報
-			'dt_sec': torch.tensor(dt_eff_sec, dtype=torch.float32),
-			'fb_idx': torch.from_numpy(fb_subset),
-			'offsets': torch.from_numpy(offsets),
-			'file_path': info['path'],
-			'indices': sample['indices'],
-			'key_name': sample['key_name'],
-			'secondary_key': sample['secondary_key'],
-			'primary_unique': sample['primary_unique'],
-			'did_superwindow': sample['did_super'] if self.verbose else None,
-		}
-
 	def __getitem__(self, _=None) -> dict:
 		rej_pick = 0
 		rej_fblc = 0
 		for _attempt in range(self.max_trials):
 			fidx = int(self._rng.integers(0, len(self.file_infos)))
 			info = self.file_infos[fidx]
-			sample = self._draw_sample(info, self._rng)
+			sample = self.sample_selector.draw_sample(info, self._rng)
 			indices = sample['indices']
 			did_super = sample['did_super']
 
 			fb_subset = info['fb'][indices]
-			ok_pick, _, _ = self.fbgate.min_pick_accept(fb_subset)
-			if not ok_pick:
+			if not self.gate_evaluator.min_pick_accept(fb_subset):
 				rej_pick += 1
 				continue
 
-			x_view, meta, offsets, fb_subset = self._load_transform(
-				info, indices, self._rng
+			x_view, meta, offsets, fb_subset = (
+				self.sample_transformer.load_transform(
+					info, indices, fb_subset, self._rng
+				)
 			)
 			meta['key_name'] = sample['key_name']
 			meta['primary_unique'] = sample['primary_unique']
 			sample['x_view'] = x_view
 
-			if not self._apply_gates(meta, did_super, info):
-				if self._last_gate_reject == 'fblc':
+			if not self.gate_evaluator.apply_gates(meta, did_super, info):
+				if self.gate_evaluator.last_reject == 'fblc':
 					rej_fblc += 1
 				continue
 
-			return self._build_output(sample, meta, fb_subset, offsets, info)
+			output = self.output_builder.build_output(
+				sample, meta, fb_subset, offsets, info
+			)
+			if not self.verbose:
+				output['did_superwindow'] = None
+			return output
 
 		raise RuntimeError(
 			f'failed to draw a valid sample within max_trials={self.max_trials}; '


### PR DESCRIPTION
### Motivation
- Eliminate redundant double-slicing of `fb_subset` in `packages/seisai-dataset/src/seisai_dataset/segy_gather_pipeline_dataset.py` to avoid unnecessary work while preserving all previous behavior and gating semantics. 
- Make the change minimal and local so existing component structure (`SampleSelector` / `SampleTransformer` / `GateEvaluator` / `OutputBuilder`) and runtime semantics remain intact.

### Description
- Change `SampleTransformer.load_transform` signature to `(..., indices: np.ndarray, fb_subset: np.ndarray, rng: np.random.Generator)` and remove its internal `info['fb'][indices]` re-slicing, returning the passed `fb_subset` unchanged. 
- In `SegyGatherPipelineDataset.__getitem__`, compute `fb_subset = info['fb'][indices]` once and pass it into `self.sample_transformer.load_transform(...)`. 
- Keep early `min_pick` rejection, FBLC gating, meta projections (`fb_idx_view` / `offsets_view` / `time_view`), and `BuildPlan` output assembly unchanged; update type annotations and call sites accordingly. 
- Maintain component wiring and defaults for `SampleSelector`, `SampleTransformer`, `GateEvaluator`, and `OutputBuilder` and preserve `did_superwindow` handling (set to `None` when not `verbose`).

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6971bb71ded8832bb589a937c3b4cee9)