### PR TITLE
Handle remainder gradient accumulation and extract train helpers

### DIFF
--- a/packages/seisai-engine/src/seisai_engine/train_loop.py
+++ b/packages/seisai-engine/src/seisai_engine/train_loop.py
@@ -9,7 +9,106 @@ from seisai_utils.logging import MetricLogger
 from torch import nn
 from torch.utils.data import DataLoader
 
-__all__ = ['train_one_epoch']
+__all__ = ['after_step', 'setup_amp', 'train_one_epoch', 'train_step']
+
+
+def setup_amp(
+	device: torch.device,
+	use_amp: bool,
+	scaler: torch.cuda.amp.GradScaler | None,
+) -> tuple[Callable[[], Any], torch.cuda.amp.GradScaler | None]:
+	do_amp = bool(use_amp and device.type == 'cuda')
+	# 新API（将来の非推奨回避）: torch.amp.autocast('cuda', enabled=True/False)
+	autocast_ctx = (lambda: torch.amp.autocast('cuda')) if do_amp else nullcontext
+	local_scaler = (
+		scaler
+		if (do_amp and scaler is not None)
+		else (torch.cuda.amp.GradScaler() if do_amp else None)
+	)
+	return autocast_ctx, local_scaler
+
+
+def train_step(
+	model: nn.Module,
+	batch: dict[str, torch.Tensor],
+	optimizer: torch.optim.Optimizer,
+	criterion: Callable[..., torch.Tensor],
+	*,
+	device: torch.device,
+	autocast_ctx: Callable[[], Any],
+	local_scaler: torch.cuda.amp.GradScaler | None,
+	gradient_accumulation_steps: int,
+	max_norm: float | None,
+	batch_index: int,
+) -> tuple[torch.Tensor, bool, int]:
+	if not isinstance(batch, dict) or (
+		'input' not in batch or 'target' not in batch
+	):
+		raise KeyError("batch must be a dict containing 'input' and 'target'")
+
+	x = batch['input'].to(device, non_blocking=True)
+	y = batch['target'].to(device, non_blocking=True)
+
+	with autocast_ctx():
+		pred = model(x)
+		loss = criterion(pred, y, batch)
+
+	loss_to_backprop = (
+		loss / gradient_accumulation_steps
+		if gradient_accumulation_steps > 1
+		else loss
+	)
+	if local_scaler is not None:
+		local_scaler.scale(loss_to_backprop).backward()
+	else:
+		loss_to_backprop.backward()
+
+	batch_size = int(x.shape[0])
+
+	did_step = False
+	if (batch_index + 1) % gradient_accumulation_steps == 0:
+		if local_scaler is not None:
+			local_scaler.unscale_(optimizer)
+		if max_norm is not None:
+			torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm)
+
+		if local_scaler is not None:
+			local_scaler.step(optimizer)
+			local_scaler.update()
+		else:
+			optimizer.step()
+
+		optimizer.zero_grad(set_to_none=True)
+		did_step = True
+
+	return loss, did_step, batch_size
+
+
+def after_step(
+	*,
+	model: nn.Module,
+	optimizer: torch.optim.Optimizer,
+	loss: torch.Tensor,
+	meter: MetricLogger,
+	step: int,
+	lr_scheduler: Any | None = None,
+	ema: Any | None = None,
+	on_step: Callable[[int, dict[str, float]], None] | None = None,
+) -> int:
+	if lr_scheduler is not None:
+		lr_scheduler.step()
+
+	step += 1
+	lr0 = float(optimizer.param_groups[0].get('lr', 0.0))
+	meter.update(loss=float(loss.detach().item()), lr=lr0)
+
+	if ema is not None:
+		ema.update(model)
+
+	if on_step is not None:
+		on_step(step, {'loss': float(meter.meters['loss'].global_avg), 'lr': lr0})
+
+	return step
 
 
 def train_one_epoch(
@@ -40,68 +139,71 @@ def train_one_epoch(
 	total_samples = 0
 	step = step_offset
 
-	do_amp = bool(use_amp and device.type == 'cuda')
-	# 新API（将来の非推奨回避）: torch.amp.autocast('cuda', enabled=True/False)
-	autocast_ctx = (lambda: torch.amp.autocast('cuda')) if do_amp else nullcontext
-	local_scaler = (
-		scaler
-		if (do_amp and scaler is not None)
-		else (torch.cuda.amp.GradScaler() if do_amp else None)
-	)
+	autocast_ctx, local_scaler = setup_amp(device, use_amp, scaler)
 
 	optimizer.zero_grad(set_to_none=True)
 
 	saw_any_batch = False
+	last_loss: torch.Tensor | None = None
+	last_i = -1
 	for i, batch in enumerate(meter.log_every(dataloader, print_freq, header='Train')):
-		if not isinstance(batch, dict) or (
-			'input' not in batch or 'target' not in batch
-		):
-			raise KeyError("batch must be a dict containing 'input' and 'target'")
-
 		saw_any_batch = True
+		loss, did_step, batch_size = train_step(
+			model,
+			batch,
+			optimizer,
+			criterion,
+			device=device,
+			autocast_ctx=autocast_ctx,
+			local_scaler=local_scaler,
+			gradient_accumulation_steps=gradient_accumulation_steps,
+			max_norm=max_norm,
+			batch_index=i,
+		)
 
-		x = batch['input'].to(device, non_blocking=True)
-		y = batch['target'].to(device, non_blocking=True)
+		last_loss = loss
+		last_i = i
+		total_samples += batch_size
 
-		with autocast_ctx():
-			pred = model(x)
-			loss = criterion(pred, y, batch)
+		if did_step:
+			step = after_step(
+				model=model,
+				optimizer=optimizer,
+				loss=loss,
+				meter=meter,
+				step=step,
+				lr_scheduler=lr_scheduler,
+				ema=ema,
+				on_step=on_step,
+			)
+
+	# 端数（accumの余り）があれば最後に一度だけstepする
+	if saw_any_batch and (last_i + 1) % gradient_accumulation_steps != 0:
+		if local_scaler is not None:
+			local_scaler.unscale_(optimizer)
+		if max_norm is not None:
+			torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm)
 
 		if local_scaler is not None:
-			local_scaler.scale(loss).backward()
+			local_scaler.step(optimizer)
+			local_scaler.update()
 		else:
-			loss.backward()
+			optimizer.step()
 
-		total_samples += int(x.shape[0])
+		optimizer.zero_grad(set_to_none=True)
 
-		if (i + 1) % gradient_accumulation_steps == 0:
-			if local_scaler is not None:
-				local_scaler.unscale_(optimizer)
-			if max_norm is not None:
-				torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm)
-
-			if local_scaler is not None:
-				local_scaler.step(optimizer)
-				local_scaler.update()
-			else:
-				optimizer.step()
-
-			optimizer.zero_grad(set_to_none=True)
-
-			if lr_scheduler is not None:
-				lr_scheduler.step()
-
-			step += 1
-			lr0 = float(optimizer.param_groups[0].get('lr', 0.0))
-			meter.update(loss=float(loss.detach().item()), lr=lr0)
-
-			if ema is not None:
-				ema.update(model)
-
-			if on_step is not None:
-				on_step(
-					step, {'loss': float(meter.meters['loss'].global_avg), 'lr': lr0}
-				)
+		if last_loss is None:
+			raise RuntimeError('internal error: last_loss is None')
+		step = after_step(
+			model=model,
+			optimizer=optimizer,
+			loss=last_loss,
+			meter=meter,
+			step=step,
+			lr_scheduler=lr_scheduler,
+			ema=ema,
+			on_step=on_step,
+		)
 
 	meter.synchronize_between_processes()
 


### PR DESCRIPTION
### Motivation
- Ensure correct behavior when the epoch ends with leftover batches not reaching `gradient_accumulation_steps` so accumulated gradients are applied exactly once.
- Simplify and structure the training loop by extracting AMP and per-batch logic to helpers for clearer responsibilities.

### Description
- Extracted helper functions `setup_amp`, `train_step`, and `after_step` and exported them via `__all__` to centralize AMP setup, per-batch forward/backward, and post-step bookkeeping.
- Apply loss scaling for accumulation by dividing the computed loss with `loss / gradient_accumulation_steps` inside `train_step` and use the scaler-aware `scale()`/`unscale_()`/`step()` flows when AMP is enabled.
- Track the last batch loss/index with `last_loss` and `last_i` and, if the final batch count is a remainder (i.e. `(last_i + 1) % gradient_accumulation_steps != 0`), perform one final optimizer step, gradient clipping, scaler update, zeroing, and call `after_step` to run scheduler/EMA/logging.
- Add a sanity `RuntimeError` if `last_loss` is unexpectedly `None` before the final `after_step` call.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6971cadbcca4832ba9762ad0fcc1caaf)