### PR TITLE
Import shared is_dist_avail_and_initialized in logging.py

### DIFF
--- a/packages/seisai-utils/src/seisai_utils/logging.py
+++ b/packages/seisai-utils/src/seisai_utils/logging.py
@@ -6,14 +6,7 @@ from collections import defaultdict, deque
 import torch
 import torch.distributed as dist
 
-
-def is_dist_avail_and_initialized() -> bool:
-	if not torch.distributed.is_available():
-		return False
-	if not torch.distributed.is_initialized():
-		return False
-	return True
-
+from seisai_utils.dist import is_dist_avail_and_initialized
 
 class SmoothedValue:
 	"""Track a series of values and provide access to smoothed values over a


### PR DESCRIPTION
### Motivation
- Replace the duplicated distributed-availability check in `packages/seisai-utils/src/seisai_utils/logging.py` with the canonical helper in `seisai_utils.dist` to keep behavior consistent and reduce duplication.

### Description
- Removed the local `is_dist_avail_and_initialized` from `logging.py` and added `from seisai_utils.dist import is_dist_avail_and_initialized`, so `SmoothedValue`/`MetricLogger` use the shared helper.

### Testing
- No automated tests were run for this change; the modification is a small import/refactor and grep/manual inspection confirmed references now use the shared helper.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697eadb22004832b8ef209e6dc5c5049)