### PR TITLE
Introduce shared pad_indices_offsets_fb and unify padding logic

### DIFF
--- a/packages/seisai-dataset/src/seisai_dataset/segy_gather_pair_dataset.py
+++ b/packages/seisai-dataset/src/seisai_dataset/segy_gather_pair_dataset.py
@@ -196,8 +196,13 @@ class SegyGatherPairDataset(Dataset):
 
 			H = int(x_in.shape[0])
 			offsets = input_info['offsets'][indices].astype(np.float32, copy=False)
-			indices, offsets, _trace_valid, _pad = self.sample_flow.pad_indices_offsets(
-				indices, offsets, H
+			indices, offsets, _fb_subset, _trace_valid, _pad = (
+				self.sample_flow.pad_indices_offsets_fb(
+					indices=indices,
+					offsets=offsets,
+					fb_subset=None,
+					H=H,
+				)
 			)
 
 			seed = int(self._rng.integers(0, 2**31 - 1))

--- a/packages/seisai-dataset/src/seisai_dataset/segy_gather_pipeline_dataset.py
+++ b/packages/seisai-dataset/src/seisai_dataset/segy_gather_pipeline_dataset.py
@@ -45,32 +45,15 @@ class SampleTransformer:
 		W0 = int(x.shape[1])
 
 		# ここで offsets/fb/indices を H に合わせる（仕様）
-		H0 = int(indices.size)
-		if H0 > H:
-			raise ValueError(f'indices length {H0} > loaded H {H}')
-
 		offsets = info['offsets'][indices].astype(np.float32, copy=False)
-		fb_subset = np.asarray(fb_subset, dtype=np.int64)
-
-		trace_valid = np.zeros(H, dtype=np.bool_)
-		trace_valid[:H0] = True
-
-		if H > H0:
-			pad = H - H0
-			offsets = np.concatenate(
-				[offsets, np.zeros(pad, dtype=np.float32)],
-				axis=0,
+		indices, offsets, fb_subset, trace_valid, _pad = (
+			SampleFlow.pad_indices_offsets_fb(
+				indices=indices,
+				offsets=offsets,
+				fb_subset=fb_subset,
+				H=H,
 			)
-			fb_subset = np.concatenate(
-				[fb_subset, -np.ones(pad, dtype=np.int64)],
-				axis=0,
-			)
-			indices = np.concatenate(
-				[indices.astype(np.int64, copy=False), -np.ones(pad, dtype=np.int64)],
-				axis=0,
-			)
-		else:
-			indices = indices.astype(np.int64, copy=False)
+		)
 
 		# 変換（Crop/Pad / TimeStretch 等）
 		out = self.transform(x, rng=rng, return_meta=True)


### PR DESCRIPTION
### Motivation
- Avoid duplicated and drifting padding logic by centralizing indices/offsets/fb_subset padding, trace_valid generation, and validation into a single helper.  
- Ensure SampleTransformer and SegyGatherPairDataset behave identically when padding/subsetting traces.

### Description
- Add `SampleFlow.pad_indices_offsets_fb(...)` (static) to validate `indices`/`fb_subset` sizes, cast types, produce `trace_valid`, pad `offsets` with zeros and pad `indices`/`fb_subset` with `-1` when H > H0.  
- Update `SampleFlow.pad_indices_offsets` to delegate to the new helper to preserve the existing API.  
- Replace inline padding logic in `SampleTransformer.load_transform` to call `SampleFlow.pad_indices_offsets_fb`.  
- Update `SegyGatherPairDataset.__getitem__` to call `sample_flow.pad_indices_offsets_fb` to keep pair-dataset padding consistent with the pipeline dataset.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697eadc3f174832bac616cf57c18630a)