### PR TITLE
Add transform contract validation for dataset transforms

### DIFF
--- a/packages/seisai-dataset/src/seisai_dataset/infer_window_dataset.py
+++ b/packages/seisai-dataset/src/seisai_dataset/infer_window_dataset.py
@@ -20,6 +20,7 @@ from .builder.builder import BuildPlan, InputOnlyPlan
 from .config import LoaderConfig
 from .file_info import build_file_info
 from .trace_subset_preproc import TraceSubsetLoader
+from .transform_contract import Transform2D, validate_transform_rng_meta
 
 
 DomainName = Literal['shot', 'recv', 'cmp']
@@ -145,7 +146,7 @@ class InferenceGatherWindowsDataset(Dataset):
 		*,
 		plan: BuildPlan | InputOnlyPlan,
 		cfg: InferenceGatherWindowsConfig | None = None,
-		transform=None,
+		transform: Transform2D | None = None,
 		ffid_byte=segyio.TraceField.FieldRecord,
 		chno_byte=segyio.TraceField.TraceNumber,
 		cmp_byte=segyio.TraceField.CDP,
@@ -189,7 +190,9 @@ class InferenceGatherWindowsDataset(Dataset):
 
 		if transform is None:
 			transform = ViewCompose([PerTraceStandardize()])
-		self.transform = transform
+		self.transform: Transform2D = validate_transform_rng_meta(
+			transform, name='transform'
+		)
 
 		self.ffid_byte = ffid_byte
 		self.chno_byte = chno_byte

--- a/packages/seisai-dataset/src/seisai_dataset/sample_flow.py
+++ b/packages/seisai-dataset/src/seisai_dataset/sample_flow.py
@@ -3,10 +3,14 @@ import random
 import numpy as np
 import torch
 
+from .transform_contract import Transform2D, validate_transform_rng_meta
+
 
 class SampleFlow:
-	def __init__(self, transform, plan) -> None:
-		self.transform = transform
+	def __init__(self, transform: Transform2D | object, plan) -> None:
+		self.transform: Transform2D = validate_transform_rng_meta(
+			transform, name='transform'
+		)
 		self.plan = plan
 
 	def draw_sample(

--- a/packages/seisai-dataset/src/seisai_dataset/segy_gather_pair_dataset.py
+++ b/packages/seisai-dataset/src/seisai_dataset/segy_gather_pair_dataset.py
@@ -12,6 +12,7 @@ from .file_info import PairFileInfo, build_file_info_dataclass
 from .sample_flow import SampleFlow
 from .trace_subset_preproc import TraceSubsetLoader
 from .trace_subset_sampler import TraceSubsetSampler
+from .transform_contract import Transform2D
 
 
 class SegyGatherPairDataset(Dataset):
@@ -21,7 +22,7 @@ class SegyGatherPairDataset(Dataset):
 		self,
 		input_segy_files: list[str],
 		target_segy_files: list[str],
-		transform,
+		transform: Transform2D,
 		plan: BuildPlan,
 		*,
 		ffid_byte: int = segyio.TraceField.FieldRecord,

--- a/packages/seisai-dataset/src/seisai_dataset/segy_gather_pipeline_dataset.py
+++ b/packages/seisai-dataset/src/seisai_dataset/segy_gather_pipeline_dataset.py
@@ -30,6 +30,7 @@ from .gate_fblc import FirstBreakGate
 from .sample_flow import SampleFlow
 from .trace_subset_preproc import TraceSubsetLoader
 from .trace_subset_sampler import TraceSubsetSampler
+from .transform_contract import Transform2D, validate_transform_rng_meta
 
 
 class SampleTransformer:
@@ -60,11 +61,13 @@ class SampleTransformer:
 	def __init__(
 		self,
 		subsetloader: TraceSubsetLoader,
-		transform,
+		transform: Transform2D,
 	) -> None:
 		"""Initialize the transformer with a subset loader and transform callable."""
 		self.subsetloader = subsetloader
-		self.transform = transform
+		self.transform: Transform2D = validate_transform_rng_meta(
+			transform, name='transform'
+		)
 
 	def load_transform(
 		self,
@@ -214,7 +217,7 @@ class SegyGatherPipelineDataset(Dataset):
 		self,
 		segy_files: list[str],
 		fb_files: list[str],
-		transform,
+		transform: Transform2D,
 		fbgate: FirstBreakGate,
 		plan: BuildPlan,
 		*,

--- a/packages/seisai-dataset/src/seisai_dataset/transform_contract.py
+++ b/packages/seisai-dataset/src/seisai_dataset/transform_contract.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+import inspect
+from typing import Protocol, cast
+
+import numpy as np
+import torch
+
+
+class RNGLike(Protocol):
+	def random(self, *args, **kwargs):
+		pass
+
+	def uniform(self, *args, **kwargs):
+		pass
+
+	def integers(self, *args, **kwargs):
+		pass
+
+
+ArrayLike2D = np.ndarray | torch.Tensor
+TransformOut2D = ArrayLike2D | tuple[ArrayLike2D, dict]
+
+
+class Transform2D(Protocol):
+	def __call__(
+		self,
+		x: ArrayLike2D,
+		*,
+		rng: RNGLike,
+		return_meta: bool = False,
+	) -> TransformOut2D:
+		pass
+
+
+def validate_transform_rng_meta(
+	transform: object,
+	*,
+	name: str = 'transform',
+) -> Transform2D:
+	if not callable(transform):
+		raise TypeError(f'{name} must be callable, got {type(transform).__name__}')
+	try:
+		signature = inspect.signature(transform)
+	except (TypeError, ValueError) as exc:
+		msg = (
+			f'{name} must accept rng and return_meta keyword arguments; '
+			f'cannot determine signature: {exc}'
+		)
+		raise TypeError(msg) from exc
+
+	params = signature.parameters
+	has_kwargs = any(
+		param.kind == inspect.Parameter.VAR_KEYWORD for param in params.values()
+	)
+	if has_kwargs:
+		return cast(Transform2D, transform)
+
+	missing = [key for key in ('rng', 'return_meta') if key not in params]
+	if missing:
+		missing_str = ', '.join(missing)
+		msg = (
+			f'{name} must accept keyword parameters rng and return_meta; '
+			f'missing {missing_str} in signature {signature}'
+		)
+		raise TypeError(msg)
+
+	return cast(Transform2D, transform)

--- a/packages/seisai-dataset/tests/test_transform_contract.py
+++ b/packages/seisai-dataset/tests/test_transform_contract.py
@@ -1,0 +1,31 @@
+import pytest
+from seisai_dataset.sample_flow import SampleFlow
+from seisai_dataset.transform_contract import validate_transform_rng_meta
+from seisai_transforms.augment import ViewCompose
+
+
+class _DummyPlan:
+	def run(self, _sample, *, rng):
+		return None
+
+
+def test_validate_transform_rng_meta_accepts_viewcompose():
+	transform = ViewCompose([])
+	validated = validate_transform_rng_meta(transform, name='transform')
+	assert validated is transform
+
+
+def test_validate_transform_rng_meta_rejects_missing_rng():
+	def bad_transform(x):
+		return x
+
+	with pytest.raises(TypeError):
+		validate_transform_rng_meta(bad_transform, name='transform')
+
+
+def test_sample_flow_rejects_bad_transform():
+	def bad_transform(x):
+		return x
+
+	with pytest.raises(TypeError):
+		SampleFlow(bad_transform, _DummyPlan())


### PR DESCRIPTION
### Motivation

- Eliminate Pylance type errors around `transform` callables and kw-args (`rng`/`return_meta`) and provide fail-fast runtime feedback when an incompatible transform is passed.  
- Ensure datasets that call `transform(x, rng=..., return_meta=True)` validate the callable at initialization rather than at data access time.

### Description

- Add `packages/seisai-dataset/src/seisai_dataset/transform_contract.py` defining `RNGLike`, `ArrayLike2D`, `TransformOut2D`, `Transform2D` (as a `Protocol`) and `validate_transform_rng_meta` which inspects a callable's signature and raises `TypeError` with the signature included when it cannot accept `rng`/`return_meta` (or when signature cannot be determined).  
- Wire validation and typing into runtime code by calling `validate_transform_rng_meta` and annotating `Transform2D` in `SampleFlow`, `InferenceGatherWindowsDataset`, `SampleTransformer` / `SegyGatherPipelineDataset`, and annotate `SegyGatherPairDataset` transform parameter to clear IDE redlines.  
- Keep signature-check try/except minimal and convert `inspect.signature` failures into `TypeError` per policy, and allow callables that accept `**kwargs`.  
- Add lightweight tests at `packages/seisai-dataset/tests/test_transform_contract.py` covering acceptance of a valid `ViewCompose`, rejection of a simple `def bad(x): ...` that lacks `rng`, and that `SampleFlow` init fails fast with a bad transform.

### Testing

- Ran `pytest -q packages/seisai-dataset/tests`, which aborted during collection with `ModuleNotFoundError: No module named 'seisai_dataset'` (7 import errors), so the test run did not complete successfully in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697f3a2a0ce8832b8bff7247c168f4a5)