### PR TITLE
[fbpick-coarse] Implement gap-aware trace anchor selection

### DIFF
--- a/examples/config_infer_fbpick_coarse.yaml
+++ b/examples/config_infer_fbpick_coarse.yaml
@@ -20,6 +20,12 @@ transform:
   time_len: 2048
   standardize_eps: 1.0e-8
 
+trace_anchor:
+  gap_ratio: 5.0
+  min_gap_m: null
+  train_mode: random
+  infer_mode: center
+
 norm_refs:
   time_ref_sec: 20.0
   offset_ref_m: 2000.0

--- a/examples/config_train_fbpick_coarse.yaml
+++ b/examples/config_train_fbpick_coarse.yaml
@@ -22,6 +22,12 @@ transform:
   time_len: 2048
   standardize_eps: 1.0e-8
 
+trace_anchor:
+  gap_ratio: 5.0
+  min_gap_m: null
+  train_mode: random
+  infer_mode: center
+
 norm_refs:
   time_ref_sec: 20.0
   offset_ref_m: 2000.0

--- a/packages/seisai-engine/src/seisai_engine/pipelines/fbpick/coarse/__init__.py
+++ b/packages/seisai-engine/src/seisai_engine/pipelines/fbpick/coarse/__init__.py
@@ -14,12 +14,19 @@ from .config import (
     COARSE_TRACE_LEN,
     CoarseInferConfig,
     CoarseModeCfg,
+    CoarseTraceAnchorCfg,
     CoarseTrainConfig,
     load_coarse_infer_config,
     load_coarse_train_config,
 )
 from .infer import run_coarse_infer
 from .loss import build_criterion
+from .trace_anchor import (
+    TraceAnchorSelection,
+    TraceSegment,
+    select_trace_anchors,
+    split_trace_segments_by_offset_gap,
+)
 from .train import (
     CoarseTrainBundle,
     build_train_bundle,
@@ -37,8 +44,11 @@ __all__ = [
     'COARSE_TRACE_LEN',
     'CoarseInferConfig',
     'CoarseModeCfg',
+    'CoarseTraceAnchorCfg',
     'CoarseTrainBundle',
     'CoarseTrainConfig',
+    'TraceAnchorSelection',
+    'TraceSegment',
     'build_criterion',
     'build_fbgate',
     'build_labeled_infer_dataset',
@@ -54,4 +64,6 @@ __all__ = [
     'load_train_spec',
     'run_coarse_infer',
     'run_train',
+    'select_trace_anchors',
+    'split_trace_segments_by_offset_gap',
 ]

--- a/packages/seisai-engine/src/seisai_engine/pipelines/fbpick/coarse/config.py
+++ b/packages/seisai-engine/src/seisai_engine/pipelines/fbpick/coarse/config.py
@@ -45,6 +45,7 @@ __all__ = [
     'CoarseInferRuntimeCfg',
     'CoarseModeCfg',
     'CoarsePaths',
+    'CoarseTraceAnchorCfg',
     'CoarseTrainCfg',
     'CoarseTrainConfig',
     'CoarseTrainInferCfg',
@@ -99,6 +100,14 @@ class CoarseTransformCfg:
 
 
 @dataclass(frozen=True)
+class CoarseTraceAnchorCfg:
+    gap_ratio: float
+    min_gap_m: float | None
+    train_mode: str
+    infer_mode: str
+
+
+@dataclass(frozen=True)
 class CoarseTrainCfg:
     lr: float
     weight_decay: float
@@ -143,6 +152,7 @@ class CoarseTrainConfig:
     paths: CoarsePaths
     dataset: CoarseDatasetCfg
     transform: CoarseTransformCfg
+    trace_anchor: CoarseTraceAnchorCfg
     norm_refs: FBPickNormRefs
     train: CoarseTrainCfg
     infer: CoarseTrainInferCfg
@@ -156,6 +166,7 @@ class CoarseInferConfig:
     paths: CoarsePaths
     dataset: CoarseDatasetCfg
     transform: CoarseTransformCfg
+    trace_anchor: CoarseTraceAnchorCfg
     norm_refs: FBPickNormRefs
     infer: CoarseInferRuntimeCfg
     model_sig: dict[str, Any]
@@ -323,6 +334,73 @@ def _load_transform_cfg(cfg: dict) -> CoarseTransformCfg:
     )
 
 
+def _load_trace_anchor_cfg(cfg: dict) -> CoarseTraceAnchorCfg:
+    anchor_cfg = require_dict(cfg, 'trace_anchor')
+
+    gap_ratio_raw = require_value(
+        anchor_cfg,
+        'gap_ratio',
+        (int, float),
+        type_message='config.trace_anchor.gap_ratio must be float',
+    )
+    if isinstance(gap_ratio_raw, bool):
+        msg = 'config.trace_anchor.gap_ratio must be float'
+        raise TypeError(msg)
+    gap_ratio = float(gap_ratio_raw)
+    if (not math.isfinite(gap_ratio)) or gap_ratio <= 1.0:
+        msg = 'trace_anchor.gap_ratio must be > 1.0'
+        raise ValueError(msg)
+
+    min_gap_raw = require_value(
+        anchor_cfg,
+        'min_gap_m',
+        (int, float),
+        allow_none=True,
+        type_message='config.trace_anchor.min_gap_m must be float or null',
+    )
+    if min_gap_raw is None:
+        min_gap_m = None
+    else:
+        if isinstance(min_gap_raw, bool):
+            msg = 'config.trace_anchor.min_gap_m must be float or null'
+            raise TypeError(msg)
+        min_gap_m = float(min_gap_raw)
+        if (not math.isfinite(min_gap_m)) or min_gap_m <= 0.0:
+            msg = 'trace_anchor.min_gap_m must be null or > 0'
+            raise ValueError(msg)
+
+    train_mode = str(
+        require_value(
+            anchor_cfg,
+            'train_mode',
+            str,
+            type_message='config.trace_anchor.train_mode must be str',
+        )
+    )
+    if train_mode != 'random':
+        msg = 'trace_anchor.train_mode must be "random"'
+        raise ValueError(msg)
+
+    infer_mode = str(
+        require_value(
+            anchor_cfg,
+            'infer_mode',
+            str,
+            type_message='config.trace_anchor.infer_mode must be str',
+        )
+    )
+    if infer_mode != 'center':
+        msg = 'trace_anchor.infer_mode must be "center"'
+        raise ValueError(msg)
+
+    return CoarseTraceAnchorCfg(
+        gap_ratio=gap_ratio,
+        min_gap_m=min_gap_m,
+        train_mode=train_mode,
+        infer_mode=infer_mode,
+    )
+
+
 def _load_model_sig(cfg: dict) -> dict[str, Any]:
     model_cfg = require_dict(cfg, 'model')
     in_chans = int(require_int(model_cfg, 'in_chans'))
@@ -360,6 +438,7 @@ def load_coarse_train_config(cfg: dict) -> CoarseTrainConfig:
         paths=_load_paths_cfg(cfg, allow_missing_infer_pairs=False),
         dataset=_load_dataset_cfg(cfg),
         transform=_load_transform_cfg(cfg),
+        trace_anchor=_load_trace_anchor_cfg(cfg),
         norm_refs=load_norm_refs_cfg(cfg),
         train=CoarseTrainCfg(
             lr=float(require_float(train_cfg, 'lr')),
@@ -412,6 +491,7 @@ def load_coarse_infer_config(cfg: dict) -> CoarseInferConfig:
         paths=_load_paths_cfg(cfg, allow_missing_infer_pairs=True),
         dataset=_load_dataset_cfg(cfg),
         transform=_load_transform_cfg(cfg),
+        trace_anchor=_load_trace_anchor_cfg(cfg),
         norm_refs=load_norm_refs_cfg(cfg),
         infer=CoarseInferRuntimeCfg(
             subset_traces=subset_traces,

--- a/packages/seisai-engine/src/seisai_engine/pipelines/fbpick/coarse/trace_anchor.py
+++ b/packages/seisai-engine/src/seisai_engine/pipelines/fbpick/coarse/trace_anchor.py
@@ -1,0 +1,355 @@
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+
+import numpy as np
+
+__all__ = [
+    'TraceAnchorSelection',
+    'TraceSegment',
+    'select_trace_anchors',
+    'split_trace_segments_by_offset_gap',
+]
+
+
+@dataclass(frozen=True)
+class TraceSegment:
+    segment_id: int
+    start_pos: int
+    stop_pos: int
+    n_traces: int
+    n_anchor_rows: int = 0
+
+
+@dataclass(frozen=True)
+class TraceAnchorSelection:
+    anchor_raw_indices: np.ndarray
+    anchor_source_pos: np.ndarray
+    anchor_offsets_m: np.ndarray
+    trace_valid: np.ndarray
+    segment_id: np.ndarray
+    segments: tuple[TraceSegment, ...]
+    anchor_bin_start_pos: np.ndarray | None = None
+    anchor_bin_stop_pos: np.ndarray | None = None
+
+
+def _validate_offsets(offsets_m: np.ndarray) -> np.ndarray:
+    offsets = np.asarray(offsets_m, dtype=np.float64)
+    if offsets.ndim != 1:
+        msg = f'offsets_m must be 1D, got shape={offsets.shape}'
+        raise ValueError(msg)
+    if offsets.size == 0:
+        msg = 'offsets_m must be non-empty'
+        raise ValueError(msg)
+    if not np.all(np.isfinite(offsets)):
+        msg = 'offsets_m must be finite'
+        raise ValueError(msg)
+    return offsets
+
+
+def _validate_gap_cfg(
+    *,
+    gap_ratio: float,
+    min_gap_m: float | None,
+) -> tuple[float, float | None]:
+    ratio = float(gap_ratio)
+    if (not math.isfinite(ratio)) or ratio <= 1.0:
+        msg = 'gap_ratio must be > 1.0'
+        raise ValueError(msg)
+    if min_gap_m is None:
+        return ratio, None
+    min_gap = float(min_gap_m)
+    if (not math.isfinite(min_gap)) or min_gap <= 0.0:
+        msg = 'min_gap_m must be None or > 0'
+        raise ValueError(msg)
+    return ratio, min_gap
+
+
+def _make_segments(boundaries: list[int]) -> tuple[TraceSegment, ...]:
+    segments: list[TraceSegment] = []
+    for segment_id, (start, stop) in enumerate(
+        zip(boundaries[:-1], boundaries[1:], strict=True)
+    ):
+        segments.append(
+            TraceSegment(
+                segment_id=int(segment_id),
+                start_pos=int(start),
+                stop_pos=int(stop),
+                n_traces=int(stop - start),
+            )
+        )
+    return tuple(segments)
+
+
+def split_trace_segments_by_offset_gap(
+    offsets_m: np.ndarray,
+    *,
+    gap_ratio: float,
+    min_gap_m: float | None = None,
+) -> tuple[TraceSegment, ...]:
+    offsets = _validate_offsets(offsets_m)
+    ratio, min_gap = _validate_gap_cfg(gap_ratio=gap_ratio, min_gap_m=min_gap_m)
+    n_traces = int(offsets.size)
+    if n_traces == 1:
+        return _make_segments([0, 1])
+
+    diff = np.abs(np.diff(offsets))
+    positive = diff[diff > 0.0]
+    if positive.size == 0:
+        return _make_segments([0, n_traces])
+
+    threshold = float(np.median(positive)) * ratio
+    if min_gap is not None:
+        threshold = max(threshold, min_gap)
+
+    gap_after = np.flatnonzero(diff > threshold)
+    if gap_after.size == 0:
+        return _make_segments([0, n_traces])
+
+    boundaries = [0]
+    boundaries.extend(int(i) + 1 for i in gap_after)
+    boundaries.append(n_traces)
+    return _make_segments(boundaries)
+
+
+def _with_anchor_rows(
+    segments: tuple[TraceSegment, ...],
+    counts: np.ndarray,
+) -> tuple[TraceSegment, ...]:
+    return tuple(
+        TraceSegment(
+            segment_id=segment.segment_id,
+            start_pos=segment.start_pos,
+            stop_pos=segment.stop_pos,
+            n_traces=segment.n_traces,
+            n_anchor_rows=int(count),
+        )
+        for segment, count in zip(segments, counts, strict=True)
+    )
+
+
+def _allocate_anchor_rows(
+    segments: tuple[TraceSegment, ...],
+    *,
+    target_rows: int,
+) -> tuple[TraceSegment, ...]:
+    target = int(target_rows)
+    if target <= 0:
+        msg = 'target_rows must be positive'
+        raise ValueError(msg)
+
+    lengths = np.asarray([s.n_traces for s in segments], dtype=np.int64)
+    if np.any(lengths <= 0):
+        msg = 'segments must be non-empty'
+        raise ValueError(msg)
+    total = int(lengths.sum())
+    if target > total:
+        msg = 'target_rows must be <= total traces'
+        raise ValueError(msg)
+
+    n_segments = int(lengths.size)
+    counts = np.zeros(n_segments, dtype=np.int64)
+    if n_segments > target:
+        order = sorted(range(n_segments), key=lambda i: (-int(lengths[i]), int(i)))
+        for i in order[:target]:
+            counts[i] = 1
+        return _with_anchor_rows(segments, counts)
+
+    ideal = lengths.astype(np.float64) * (float(target) / float(total))
+    counts = np.floor(ideal).astype(np.int64)
+    counts = np.maximum(counts, 1)
+    counts = np.minimum(counts, lengths)
+
+    while int(counts.sum()) < target:
+        candidates = [i for i in range(n_segments) if counts[i] < lengths[i]]
+        if not candidates:
+            break
+        best = max(
+            candidates,
+            key=lambda i: (float(ideal[i] - counts[i]), int(lengths[i]), -int(i)),
+        )
+        counts[best] += 1
+
+    while int(counts.sum()) > target:
+        candidates = [i for i in range(n_segments) if counts[i] > 1]
+        if not candidates:
+            break
+        best = max(
+            candidates,
+            key=lambda i: (float(counts[i] - ideal[i]), -int(lengths[i]), -int(i)),
+        )
+        counts[best] -= 1
+
+    if int(counts.sum()) != target:
+        msg = 'failed to allocate requested trace anchor rows'
+        raise RuntimeError(msg)
+    if np.any(counts > lengths):
+        msg = 'allocated anchor rows exceed segment length'
+        raise RuntimeError(msg)
+    return _with_anchor_rows(segments, counts)
+
+
+def _segment_bins(segment: TraceSegment) -> list[tuple[int, int]]:
+    if segment.n_anchor_rows <= 0:
+        return []
+    edges = np.floor(
+        np.linspace(0, segment.n_traces, segment.n_anchor_rows + 1, dtype=np.float64)
+    ).astype(np.int64)
+    bins: list[tuple[int, int]] = []
+    for left, right in zip(edges[:-1], edges[1:], strict=True):
+        start = int(segment.start_pos + left)
+        stop = int(segment.start_pos + right)
+        if stop <= start:
+            msg = 'trace anchor bin is empty'
+            raise RuntimeError(msg)
+        bins.append((start, stop))
+    return bins
+
+
+def _select_from_bin(
+    start: int,
+    stop: int,
+    *,
+    mode: str,
+    rng: np.random.Generator | None,
+) -> int:
+    if mode == 'center':
+        return int((int(start) + int(stop)) // 2)
+    if mode == 'random':
+        if rng is None:
+            rng = np.random.default_rng()
+        return int(rng.integers(int(start), int(stop)))
+    msg = 'mode must be "random" or "center"'
+    raise ValueError(msg)
+
+
+def _validate_raw_indices(raw_indices: np.ndarray, *, expected_size: int) -> np.ndarray:
+    indices = np.asarray(raw_indices)
+    if indices.ndim != 1:
+        msg = f'raw_indices must be 1D, got shape={indices.shape}'
+        raise ValueError(msg)
+    if int(indices.size) != int(expected_size):
+        msg = 'raw_indices and offsets_m must have the same length'
+        raise ValueError(msg)
+    if not np.issubdtype(indices.dtype, np.integer):
+        msg = 'raw_indices must have integer dtype'
+        raise TypeError(msg)
+    indices = indices.astype(np.int64, copy=False)
+    if np.any(indices < 0):
+        msg = 'raw_indices must be non-negative'
+        raise ValueError(msg)
+    return indices
+
+
+def _empty_selection_arrays(trace_len: int) -> tuple[np.ndarray, ...]:
+    return (
+        -np.ones(trace_len, dtype=np.int64),
+        -np.ones(trace_len, dtype=np.int64),
+        np.zeros(trace_len, dtype=np.float32),
+        np.zeros(trace_len, dtype=np.bool_),
+        -np.ones(trace_len, dtype=np.int64),
+        -np.ones(trace_len, dtype=np.int64),
+        -np.ones(trace_len, dtype=np.int64),
+    )
+
+
+def select_trace_anchors(
+    raw_indices: np.ndarray,
+    offsets_m: np.ndarray,
+    trace_len: int,
+    mode: str,
+    *,
+    gap_ratio: float = 5.0,
+    min_gap_m: float | None = None,
+    rng: np.random.Generator | None = None,
+) -> TraceAnchorSelection:
+    h_out = int(trace_len)
+    if h_out <= 0:
+        msg = 'trace_len must be positive'
+        raise ValueError(msg)
+
+    mode_norm = str(mode)
+    if mode_norm not in ('random', 'center'):
+        msg = 'mode must be "random" or "center"'
+        raise ValueError(msg)
+    if mode_norm == 'random' and rng is None:
+        rng = np.random.default_rng()
+
+    offsets = _validate_offsets(offsets_m)
+    indices = _validate_raw_indices(raw_indices, expected_size=int(offsets.size))
+    segments = split_trace_segments_by_offset_gap(
+        offsets,
+        gap_ratio=gap_ratio,
+        min_gap_m=min_gap_m,
+    )
+
+    (
+        anchor_raw_indices,
+        anchor_source_pos,
+        anchor_offsets_m,
+        trace_valid,
+        segment_id,
+        anchor_bin_start_pos,
+        anchor_bin_stop_pos,
+    ) = _empty_selection_arrays(h_out)
+
+    n_traces = int(indices.size)
+    if n_traces < h_out:
+        row = 0
+        counts = np.zeros(len(segments), dtype=np.int64)
+        for segment in segments:
+            for source_pos in range(segment.start_pos, segment.stop_pos):
+                anchor_raw_indices[row] = indices[source_pos]
+                anchor_source_pos[row] = source_pos
+                anchor_offsets_m[row] = np.float32(offsets[source_pos])
+                trace_valid[row] = True
+                segment_id[row] = segment.segment_id
+                anchor_bin_start_pos[row] = source_pos
+                anchor_bin_stop_pos[row] = source_pos + 1
+                row += 1
+            counts[segment.segment_id] = segment.n_traces
+        return TraceAnchorSelection(
+            anchor_raw_indices=anchor_raw_indices,
+            anchor_source_pos=anchor_source_pos,
+            anchor_offsets_m=anchor_offsets_m,
+            trace_valid=trace_valid,
+            segment_id=segment_id,
+            segments=_with_anchor_rows(segments, counts),
+            anchor_bin_start_pos=anchor_bin_start_pos,
+            anchor_bin_stop_pos=anchor_bin_stop_pos,
+        )
+
+    allocated_segments = _allocate_anchor_rows(segments, target_rows=h_out)
+    row = 0
+    for segment in allocated_segments:
+        for bin_start, bin_stop in _segment_bins(segment):
+            source_pos = _select_from_bin(
+                bin_start,
+                bin_stop,
+                mode=mode_norm,
+                rng=rng,
+            )
+            anchor_raw_indices[row] = indices[source_pos]
+            anchor_source_pos[row] = source_pos
+            anchor_offsets_m[row] = np.float32(offsets[source_pos])
+            trace_valid[row] = True
+            segment_id[row] = segment.segment_id
+            anchor_bin_start_pos[row] = bin_start
+            anchor_bin_stop_pos[row] = bin_stop
+            row += 1
+
+    if row != h_out:
+        msg = 'trace anchor selection did not fill trace_len rows'
+        raise RuntimeError(msg)
+
+    return TraceAnchorSelection(
+        anchor_raw_indices=anchor_raw_indices,
+        anchor_source_pos=anchor_source_pos,
+        anchor_offsets_m=anchor_offsets_m,
+        trace_valid=trace_valid,
+        segment_id=segment_id,
+        segments=allocated_segments,
+        anchor_bin_start_pos=anchor_bin_start_pos,
+        anchor_bin_stop_pos=anchor_bin_stop_pos,
+    )

--- a/packages/seisai-engine/src/seisai_engine/pipelines/fbpick/coarse/trace_anchor.py
+++ b/packages/seisai-engine/src/seisai_engine/pipelines/fbpick/coarse/trace_anchor.py
@@ -276,10 +276,10 @@ def select_trace_anchors(
     if mode_norm == 'random' and rng is None:
         rng = np.random.default_rng()
 
-    offsets = _validate_offsets(offsets_m)
+    offsets = np.asarray(offsets_m)
     indices = _validate_raw_indices(raw_indices, expected_size=int(offsets.size))
     segments = split_trace_segments_by_offset_gap(
-        offsets,
+        offsets_m,
         gap_ratio=gap_ratio,
         min_gap_m=min_gap_m,
     )

--- a/packages/seisai-engine/src/seisai_engine/pipelines/fbpick/coarse/trace_anchor.py
+++ b/packages/seisai-engine/src/seisai_engine/pipelines/fbpick/coarse/trace_anchor.py
@@ -30,8 +30,8 @@ class TraceAnchorSelection:
     trace_valid: np.ndarray
     segment_id: np.ndarray
     segments: tuple[TraceSegment, ...]
-    anchor_bin_start_pos: np.ndarray | None = None
-    anchor_bin_stop_pos: np.ndarray | None = None
+    anchor_bin_start_pos: np.ndarray
+    anchor_bin_stop_pos: np.ndarray
 
 
 def _validate_offsets(offsets_m: np.ndarray) -> np.ndarray:

--- a/packages/seisai-engine/tests/test_fbpick_coarse.py
+++ b/packages/seisai-engine/tests/test_fbpick_coarse.py
@@ -88,6 +88,12 @@ def _make_training_config(tmp_path: Path, *, segy_path: str, fb_path: str) -> di
             'time_len': 2048,
             'standardize_eps': 1.0e-8,
         },
+        'trace_anchor': {
+            'gap_ratio': 5.0,
+            'min_gap_m': None,
+            'train_mode': 'random',
+            'infer_mode': 'center',
+        },
         'norm_refs': {
             'time_ref_sec': 20.0,
             'offset_ref_m': 2000.0,
@@ -140,6 +146,10 @@ def test_load_coarse_train_config_returns_fixed_contract_values(
     assert typed.coarse.input_mode == 'global_anchor_resize'
     assert typed.transform.trace_len == 256
     assert typed.transform.time_len == 2048
+    assert typed.trace_anchor.gap_ratio == pytest.approx(5.0)
+    assert typed.trace_anchor.min_gap_m is None
+    assert typed.trace_anchor.train_mode == 'random'
+    assert typed.trace_anchor.infer_mode == 'center'
     assert typed.train.fb_sigma_ms == pytest.approx(10.0)
     assert typed.model_sig['in_chans'] == 3
     assert typed.model_sig['out_chans'] == 1
@@ -159,6 +169,8 @@ def test_load_coarse_infer_config_returns_global_anchor_contract(
     assert typed.coarse.input_mode == 'global_anchor_resize'
     assert typed.transform.trace_len == 256
     assert typed.transform.time_len == 2048
+    assert typed.trace_anchor.gap_ratio == pytest.approx(5.0)
+    assert typed.trace_anchor.infer_mode == 'center'
     assert typed.model_sig['in_chans'] == 3
 
 
@@ -184,6 +196,22 @@ def test_load_coarse_infer_config_returns_global_anchor_contract(
         (
             lambda cfg: cfg['transform'].__setitem__('time_len', 6000),
             'transform.time_len must be 2048',
+        ),
+        (
+            lambda cfg: cfg['trace_anchor'].__setitem__('gap_ratio', 1.0),
+            'trace_anchor.gap_ratio must be > 1.0',
+        ),
+        (
+            lambda cfg: cfg['trace_anchor'].__setitem__('min_gap_m', 0.0),
+            'trace_anchor.min_gap_m must be null or > 0',
+        ),
+        (
+            lambda cfg: cfg['trace_anchor'].__setitem__('train_mode', 'center'),
+            'trace_anchor.train_mode must be "random"',
+        ),
+        (
+            lambda cfg: cfg['trace_anchor'].__setitem__('infer_mode', 'random'),
+            'trace_anchor.infer_mode must be "center"',
         ),
         (
             lambda cfg: cfg['train'].__setitem__('fb_sigma_ms', 0.0),
@@ -401,6 +429,12 @@ def test_coarse_raw_only_infer_writes_npz(tmp_path: Path) -> None:
             'trace_len': 256,
             'time_len': 2048,
             'standardize_eps': 1.0e-8,
+        },
+        'trace_anchor': {
+            'gap_ratio': 5.0,
+            'min_gap_m': None,
+            'train_mode': 'random',
+            'infer_mode': 'center',
         },
         'norm_refs': {
             'time_ref_sec': 20.0,

--- a/packages/seisai-engine/tests/test_fbpick_trace_anchor.py
+++ b/packages/seisai-engine/tests/test_fbpick_trace_anchor.py
@@ -1,0 +1,168 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from seisai_engine.pipelines.fbpick.coarse import (
+    select_trace_anchors,
+    split_trace_segments_by_offset_gap,
+)
+
+
+def test_split_trace_segments_by_offset_gap_detects_large_jumps() -> None:
+    offsets = np.asarray([0, 10, 20, 300, 310, 320, 1000], dtype=np.float32)
+
+    segments = split_trace_segments_by_offset_gap(
+        offsets,
+        gap_ratio=5.0,
+        min_gap_m=None,
+    )
+
+    assert [(s.start_pos, s.stop_pos, s.n_traces) for s in segments] == [
+        (0, 3, 3),
+        (3, 6, 3),
+        (6, 7, 1),
+    ]
+    assert [s.n_anchor_rows for s in segments] == [0, 0, 0]
+
+
+def test_split_trace_segments_by_offset_gap_keeps_flat_offsets_together() -> None:
+    segments = split_trace_segments_by_offset_gap(
+        np.zeros(4, dtype=np.float32),
+        gap_ratio=5.0,
+        min_gap_m=10.0,
+    )
+
+    assert [(s.start_pos, s.stop_pos, s.n_traces) for s in segments] == [(0, 4, 4)]
+
+
+def test_split_trace_segments_by_offset_gap_rejects_nonfinite_offsets() -> None:
+    with pytest.raises(ValueError, match='offsets_m must be finite'):
+        split_trace_segments_by_offset_gap(
+            np.asarray([0.0, np.nan], dtype=np.float32),
+            gap_ratio=5.0,
+            min_gap_m=None,
+        )
+
+
+def test_select_trace_anchors_pads_when_trace_count_is_shorter_than_output() -> None:
+    selection = select_trace_anchors(
+        np.asarray([10, 11, 12], dtype=np.int64),
+        np.asarray([100.0, 200.0, 300.0], dtype=np.float32),
+        5,
+        'center',
+        gap_ratio=5.0,
+        min_gap_m=None,
+    )
+
+    np.testing.assert_array_equal(
+        selection.anchor_raw_indices,
+        np.asarray([10, 11, 12, -1, -1], dtype=np.int64),
+    )
+    np.testing.assert_array_equal(
+        selection.anchor_source_pos,
+        np.asarray([0, 1, 2, -1, -1], dtype=np.int64),
+    )
+    np.testing.assert_array_equal(
+        selection.trace_valid,
+        np.asarray([True, True, True, False, False], dtype=np.bool_),
+    )
+    np.testing.assert_array_equal(selection.segment_id[3:], np.asarray([-1, -1]))
+    np.testing.assert_allclose(selection.anchor_offsets_m[3:], np.asarray([0.0, 0.0]))
+    assert [s.n_anchor_rows for s in selection.segments] == [3]
+
+
+def test_select_trace_anchors_center_mode_never_bins_across_gap() -> None:
+    raw_indices = np.arange(10, dtype=np.int64)
+    offsets = np.asarray([0, 10, 20, 30, 40, 1000, 1010, 1020, 1030, 1040])
+
+    selection = select_trace_anchors(
+        raw_indices,
+        offsets,
+        4,
+        'center',
+        gap_ratio=5.0,
+        min_gap_m=None,
+    )
+
+    np.testing.assert_array_equal(
+        selection.anchor_source_pos,
+        np.asarray([1, 3, 6, 8], dtype=np.int64),
+    )
+    np.testing.assert_array_equal(selection.segment_id, np.asarray([0, 0, 1, 1]))
+    assert [s.n_anchor_rows for s in selection.segments] == [2, 2]
+    assert selection.anchor_bin_start_pos is not None
+    assert selection.anchor_bin_stop_pos is not None
+    assert all(
+        start >= 0 and stop <= 5
+        for start, stop in zip(
+            selection.anchor_bin_start_pos[:2],
+            selection.anchor_bin_stop_pos[:2],
+            strict=True,
+        )
+    )
+    assert all(
+        start >= 5 and stop <= 10
+        for start, stop in zip(
+            selection.anchor_bin_start_pos[2:],
+            selection.anchor_bin_stop_pos[2:],
+            strict=True,
+        )
+    )
+
+
+def test_select_trace_anchors_prefers_long_segments_when_there_are_too_many() -> None:
+    raw_indices = np.arange(11, dtype=np.int64)
+    offsets = np.asarray(
+        [0, 10, 20, 1000, 1010, 2000, 2010, 3000, 3010, 4000, 4010],
+        dtype=np.float32,
+    )
+
+    selection = select_trace_anchors(
+        raw_indices,
+        offsets,
+        3,
+        'center',
+        gap_ratio=1.5,
+        min_gap_m=50.0,
+    )
+
+    np.testing.assert_array_equal(selection.anchor_source_pos, np.asarray([1, 4, 6]))
+    assert [s.n_anchor_rows for s in selection.segments] == [1, 1, 1, 0, 0]
+
+
+def test_select_trace_anchors_random_mode_is_seed_reproducible() -> None:
+    raw_indices = np.arange(50, dtype=np.int64)
+    offsets = np.arange(50, dtype=np.float32) * 10.0
+
+    first = select_trace_anchors(
+        raw_indices,
+        offsets,
+        5,
+        'random',
+        gap_ratio=5.0,
+        min_gap_m=None,
+        rng=np.random.default_rng(123),
+    )
+    second = select_trace_anchors(
+        raw_indices,
+        offsets,
+        5,
+        'random',
+        gap_ratio=5.0,
+        min_gap_m=None,
+        rng=np.random.default_rng(123),
+    )
+    different_seed = select_trace_anchors(
+        raw_indices,
+        offsets,
+        5,
+        'random',
+        gap_ratio=5.0,
+        min_gap_m=None,
+        rng=np.random.default_rng(124),
+    )
+
+    np.testing.assert_array_equal(first.anchor_source_pos, second.anchor_source_pos)
+    assert not np.array_equal(first.anchor_source_pos, different_seed.anchor_source_pos)
+    assert np.all(first.trace_valid)


### PR DESCRIPTION
Closes #20

## Summary
- [fbpick-coarse] Implement gap-aware trace anchor selection

## Changed files
- `examples/config_infer_fbpick_coarse.yaml`
- `examples/config_train_fbpick_coarse.yaml`
- `packages/seisai-engine/src/seisai_engine/pipelines/fbpick/coarse/__init__.py`
- `packages/seisai-engine/src/seisai_engine/pipelines/fbpick/coarse/config.py`
- `packages/seisai-engine/src/seisai_engine/pipelines/fbpick/coarse/trace_anchor.py`
- `packages/seisai-engine/tests/test_fbpick_coarse.py`
- `packages/seisai-engine/tests/test_fbpick_trace_anchor.py`

## Checks
- `.work/codex/checks.log`: 735 passed, 5 warnings in 56.46s

## Review
- `.work/codex/review.txt`: accept: yes
- findings: blocker 0, major 0, minor 1
