### PR TITLE
[fbpick-coarse] Replace train/validation datasets with global-anchor datasets

### DIFF
--- a/cli/_entrypoint.py
+++ b/cli/_entrypoint.py
@@ -21,3 +21,4 @@ def run_pipeline_train_entrypoint(
 
 	pipeline_args = ['--config', str(args.config)]
 	pipeline_args += unknown
+	pipeline_main(pipeline_args)

--- a/packages/seisai-engine/src/seisai_engine/pipelines/fbpick/coarse/__init__.py
+++ b/packages/seisai-engine/src/seisai_engine/pipelines/fbpick/coarse/__init__.py
@@ -1,4 +1,5 @@
 from .build_dataset import (
+    GlobalAnchorCoarseDataset,
     build_fbgate,
     build_labeled_infer_dataset,
     build_raw_infer_dataset,
@@ -46,9 +47,9 @@ from .train import (
 )
 
 __all__ = [
-    'COARSE_IN_CHANS',
     'COARSE_INPUT_CHANNELS',
     'COARSE_INPUT_MODE_GLOBAL_ANCHOR_RESIZE',
+    'COARSE_IN_CHANS',
     'COARSE_TIME_LEN',
     'COARSE_TRACE_LEN',
     'CoarseInferConfig',
@@ -57,12 +58,13 @@ __all__ = [
     'CoarseTraceAnchorCfg',
     'CoarseTrainBundle',
     'CoarseTrainConfig',
+    'GlobalAnchorCoarseDataset',
     'TraceAnchorSelection',
     'TraceSegment',
-    'build_criterion',
-    'build_fbgate',
     'build_coarse_fb_labels_for_anchors',
     'build_coarse_time_grid',
+    'build_criterion',
+    'build_fbgate',
     'build_labeled_infer_dataset',
     'build_model',
     'build_plan',

--- a/packages/seisai-engine/src/seisai_engine/pipelines/fbpick/coarse/build_dataset.py
+++ b/packages/seisai-engine/src/seisai_engine/pipelines/fbpick/coarse/build_dataset.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
+import random
 from collections.abc import Sequence
 
 import numpy as np
+import torch
 from seisai_dataset import (
     BuildPlan,
     FirstBreakGate,
@@ -13,7 +15,6 @@ from seisai_dataset import (
     SegyGatherPipelineDataset,
 )
 from seisai_dataset.config import LoaderConfig
-from seisai_dataset.sample_flow import SampleFlow
 from seisai_dataset.segy_gather_base import SampleTransformer
 from seisai_dataset.trace_subset_preproc import TraceSubsetLoader
 from seisai_dataset.transform_flow_utils import (
@@ -24,7 +25,16 @@ from seisai_dataset.transform_flow_utils import (
 from seisai_transforms.augment import PerTraceStandardize, ViewCompose
 from seisai_utils.fs import validate_files_exist
 
+from .config import COARSE_TIME_LEN, COARSE_TRACE_LEN
+from .time_axis import (
+    build_coarse_fb_labels_for_anchors,
+    build_coarse_time_grid,
+    resample_waveform_time_axis,
+)
+from .trace_anchor import select_trace_anchors
+
 __all__ = [
+    'GlobalAnchorCoarseDataset',
     'PickAwareCropSampleTransformer',
     'build_fbgate',
     'build_infer_transform',
@@ -33,6 +43,303 @@ __all__ = [
     'build_train_dataset',
     'build_train_transform',
 ]
+
+
+class GlobalAnchorCoarseDataset(SegyGatherPipelineDataset):
+    def __init__(
+        self,
+        *,
+        segy_files: list[str],
+        fb_files: list[str],
+        sampling_overrides: list[dict[str, object] | None] | None,
+        plan: BuildPlan,
+        fbgate: FirstBreakGate,
+        trace_len: int,
+        time_len: int,
+        standardize_eps: float,
+        anchor_mode: str,
+        gap_ratio: float,
+        min_gap_m: float | None,
+        primary_keys: Sequence[str],
+        secondary_key_fixed: bool,
+        verbose: bool,
+        progress: bool,
+        max_trials: int,
+        use_header_cache: bool,
+        waveform_mode: str,
+        segy_endian: str,
+    ) -> None:
+        trace_len_int = int(trace_len)
+        time_len_int = int(time_len)
+        if trace_len_int != COARSE_TRACE_LEN:
+            msg = f'trace_len must be {COARSE_TRACE_LEN} for global-anchor coarse'
+            raise ValueError(msg)
+        if time_len_int != COARSE_TIME_LEN:
+            msg = f'time_len must be {COARSE_TIME_LEN} for global-anchor coarse'
+            raise ValueError(msg)
+
+        mode = str(anchor_mode).strip().lower()
+        if mode not in ('random', 'center'):
+            msg = 'anchor_mode must be "random" or "center"'
+            raise ValueError(msg)
+
+        self.trace_len = trace_len_int
+        self.time_len = time_len_int
+        self.anchor_mode = mode
+        self.gap_ratio = float(gap_ratio)
+        self.min_gap_m = None if min_gap_m is None else float(min_gap_m)
+        self._standardize_transform = build_train_transform(
+            standardize_eps=float(standardize_eps)
+        )
+
+        super().__init__(
+            segy_files=list(segy_files),
+            fb_files=list(fb_files),
+            sampling_overrides=sampling_overrides,
+            transform=self._standardize_transform,
+            fbgate=fbgate,
+            plan=plan,
+            subset_traces=trace_len_int,
+            trace_decimate_prob=0.0,
+            trace_decimate_stride_range=(1, 1),
+            primary_keys=tuple(primary_keys),
+            secondary_key_fixed=bool(secondary_key_fixed),
+            waveform_mode=str(waveform_mode),
+            segy_endian=str(segy_endian),
+            verbose=bool(verbose),
+            progress=bool(progress),
+            max_trials=int(max_trials),
+            use_header_cache=bool(use_header_cache),
+        )
+
+    def __getitem__(self, index: int | None = None) -> dict:
+        if self.anchor_mode != 'center':
+            return self._sample_with_retries()
+        idx = 0 if index is None else int(index)
+        rejections = self._init_rejection_counters()
+        for attempt in range(self.max_trials):
+            info = self._choose_file_info_for_index(idx + attempt)
+            out = self._try_build_sample_for_index(info, idx + attempt, rejections)
+            if out is not None:
+                return out
+        raise RuntimeError(self._format_max_trials_error(rejections))
+
+    def _choose_file_info_for_index(self, index: int):
+        if not self.file_infos:
+            msg = 'file_infos is empty'
+            raise RuntimeError(msg)
+        return self.file_infos[int(index) % len(self.file_infos)]
+
+    def _draw_full_gather_random(self, info) -> dict:
+        seed = int(self._rng.integers(0, 2**31 - 1))
+        return self.sampler.draw_full_gather(info, py_random=random.Random(seed))
+
+    def _draw_full_gather_for_index(self, info, index: int) -> dict:
+        seed = int(index) // max(1, len(self.file_infos))
+        return self.sampler.draw_full_gather(info, py_random=random.Random(seed))
+
+    def _try_build_sample(self, info, counters: dict[str, int]) -> dict | None:
+        sample = self._draw_full_gather_random(info)
+        return self._build_global_anchor_sample(
+            info=info,
+            sample=sample,
+            anchor_rng=self._rng,
+            counters=counters,
+        )
+
+    def _try_build_sample_for_index(
+        self,
+        info,
+        index: int,
+        counters: dict[str, int],
+    ) -> dict | None:
+        sample = self._draw_full_gather_for_index(info, index)
+        return self._build_global_anchor_sample(
+            info=info,
+            sample=sample,
+            anchor_rng=None,
+            counters=counters,
+        )
+
+    def _build_global_anchor_sample(
+        self,
+        *,
+        info,
+        sample: dict,
+        anchor_rng: np.random.Generator | None,
+        counters: dict[str, int],
+    ) -> dict | None:
+        indices_full = np.asarray(sample['indices'], dtype=np.int64)
+        if indices_full.ndim != 1 or indices_full.size == 0:
+            self._count_rejection(counters, 'empty')
+            return None
+        if info.fb is None:
+            msg = 'fb labels are required for global-anchor coarse dataset'
+            raise ValueError(msg)
+
+        fb_full = np.asarray(info.fb[indices_full], dtype=np.int64)
+        apply_fb_gates = self._should_apply_fb_gates({})
+        if apply_fb_gates and (not self.gate_evaluator.min_pick_accept(fb_full)):
+            self._count_rejection(counters, 'min_pick')
+            return None
+
+        offsets_full = np.asarray(info.offsets[indices_full], dtype=np.float32)
+        selection = select_trace_anchors(
+            raw_indices=indices_full,
+            offsets_m=offsets_full,
+            trace_len=self.trace_len,
+            mode=self.anchor_mode,
+            gap_ratio=self.gap_ratio,
+            min_gap_m=self.min_gap_m,
+            rng=anchor_rng,
+        )
+        trace_valid = np.asarray(selection.trace_valid, dtype=np.bool_)
+        anchor_raw_indices = np.asarray(selection.anchor_raw_indices, dtype=np.int64)
+
+        valid_indices = anchor_raw_indices[trace_valid]
+        subset_loader = TraceSubsetLoader(
+            LoaderConfig(pad_traces_to=int(valid_indices.size))
+        )
+        x_valid = subset_loader.load_traces(info.mmap, valid_indices)
+        x_resampled_valid = resample_waveform_time_axis(
+            x_valid,
+            out_time_len=self.time_len,
+        )
+        x_view = np.zeros((self.trace_len, self.time_len), dtype=np.float32)
+        x_view[trace_valid] = x_resampled_valid
+        x_view, transform_meta = apply_transform_2d_with_meta(
+            self._standardize_transform,
+            x_view,
+            self._rng,
+            msg_bad_out='global-anchor transform must return 2D numpy or (2D, meta)',
+            msg_bad_meta='global-anchor transform meta must be dict, got {type}',
+            exc_bad_out=ValueError,
+            exc_bad_meta=TypeError,
+        )
+        if x_view.shape != (self.trace_len, self.time_len):
+            msg = (
+                'global-anchor transform must keep fixed shape '
+                f'{(self.trace_len, self.time_len)}, got {x_view.shape}'
+            )
+            raise ValueError(msg)
+        x_view = np.ascontiguousarray(x_view, dtype=np.float32)
+        x_view[~trace_valid] = 0.0
+
+        fb_idx_raw_for_anchors = np.full((self.trace_len,), -1, dtype=np.int64)
+        valid_source_pos = np.asarray(
+            selection.anchor_source_pos[trace_valid],
+            dtype=np.int64,
+        )
+        fb_idx_raw_for_anchors[trace_valid] = fb_full[valid_source_pos]
+        fb_idx_coarse_for_anchors = build_coarse_fb_labels_for_anchors(
+            fb_idx_raw_for_anchors,
+            trace_valid,
+            raw_time_len=int(info.n_samples),
+            coarse_time_len=self.time_len,
+        )
+
+        grid = build_coarse_time_grid(
+            raw_time_len=int(info.n_samples),
+            coarse_time_len=self.time_len,
+            dt_sec=float(info.dt_sec),
+        )
+        meta = {
+            'hflip': False,
+            'factor_h': 1.0,
+            'factor': float(grid.raw_to_coarse_factor),
+            'start': 0,
+            'trace_valid': trace_valid,
+            'fb_idx': fb_idx_raw_for_anchors,
+            'fb_idx_view': fb_idx_coarse_for_anchors,
+            'offsets_view': np.asarray(selection.anchor_offsets_m, dtype=np.float32),
+            'time_view': np.asarray(grid.time_view_sec, dtype=np.float32),
+            'dt_sec': np.float32(grid.dt_sec),
+            'dt_eff_sec': np.float32(grid.dt_eff_sec),
+            'raw_time_len': int(grid.raw_time_len),
+            'coarse_time_len': int(grid.coarse_time_len),
+            'raw_to_coarse_factor': np.float32(grid.raw_to_coarse_factor),
+            'coarse_to_raw_factor': np.float32(grid.coarse_to_raw_factor),
+            'anchor_raw_indices': anchor_raw_indices,
+            'anchor_source_pos': np.asarray(
+                selection.anchor_source_pos,
+                dtype=np.int64,
+            ),
+            'anchor_offsets_m': np.asarray(
+                selection.anchor_offsets_m,
+                dtype=np.float32,
+            ),
+            'segment_id': np.asarray(selection.segment_id, dtype=np.int64),
+            'anchor_bin_start_pos': np.asarray(
+                selection.anchor_bin_start_pos,
+                dtype=np.int64,
+            ),
+            'anchor_bin_stop_pos': np.asarray(
+                selection.anchor_bin_stop_pos,
+                dtype=np.int64,
+            ),
+            'fb_idx_raw_for_anchors': fb_idx_raw_for_anchors,
+            'fb_idx_coarse_for_anchors': fb_idx_coarse_for_anchors,
+            'key_name': sample['key_name'],
+            'primary_value': int(sample['primary_value']),
+            'primary_unique': sample['primary_unique'],
+            'secondary_key': sample['secondary_key'],
+        }
+        meta.update(transform_meta)
+
+        if apply_fb_gates:
+            if not self.gate_evaluator.apply_gates(
+                meta,
+                did_super=bool(sample['did_super']),
+                info=info,
+            ):
+                if self.gate_evaluator.last_reject == 'fblc':
+                    self._count_rejection(counters, 'fblc')
+                return None
+
+        sample_for_plan = self.sample_flow.build_plan_input_base(
+            meta=meta,
+            dt_sec=float(grid.dt_eff_sec),
+            offsets=np.asarray(selection.anchor_offsets_m, dtype=np.float32),
+            indices=anchor_raw_indices,
+            key_name=str(sample['key_name']),
+            secondary_key=str(sample['secondary_key']),
+            primary_unique=str(sample['primary_unique']),
+            extra={
+                'x_view': x_view,
+                'fb_idx': fb_idx_raw_for_anchors,
+                'file_path': info.path,
+                'trace_valid': trace_valid,
+            },
+        )
+        self.sample_flow.run_plan(sample_for_plan, rng=self._rng)
+
+        out = self.sample_flow.build_output_base(
+            sample_for_plan,
+            meta=meta,
+            dt_sec=float(grid.dt_eff_sec),
+            offsets=np.asarray(selection.anchor_offsets_m, dtype=np.float32),
+            indices=anchor_raw_indices,
+            key_name=str(sample['key_name']),
+            secondary_key=str(sample['secondary_key']),
+            primary_unique=str(sample['primary_unique']),
+            extra={
+                'fb_idx': torch.from_numpy(fb_idx_raw_for_anchors),
+                'fb_idx_coarse': torch.from_numpy(fb_idx_coarse_for_anchors),
+                'file_path': info.path,
+                'did_superwindow': bool(sample['did_super']),
+                'anchor_raw_indices': torch.from_numpy(anchor_raw_indices),
+                'anchor_source_pos': torch.from_numpy(
+                    np.asarray(selection.anchor_source_pos, dtype=np.int64)
+                ),
+                'anchor_offsets_m': torch.from_numpy(
+                    np.asarray(selection.anchor_offsets_m, dtype=np.float32)
+                ),
+            },
+        )
+        self._add_trace_valid_output(out, trace_valid)
+        self._add_mask_bool_output(out, sample_for_plan)
+        self._finalize_output(out, sample_for_plan, {}, x_view.shape)
+        return out
 
 
 class PickAwareCropSampleTransformer(SampleTransformer):
@@ -63,7 +370,11 @@ class PickAwareCropSampleTransformer(SampleTransformer):
         W0: int,
         rng: np.random.Generator,
     ) -> int | None:
-        valid = np.asarray(trace_valid, dtype=np.bool_) & (fb_subset > 0) & (fb_subset < W0)
+        valid = (
+            np.asarray(trace_valid, dtype=np.bool_)
+            & (fb_subset > 0)
+            & (fb_subset < W0)
+        )
         if not np.any(valid):
             return None
 
@@ -132,7 +443,7 @@ class PickAwareCropSampleTransformer(SampleTransformer):
             'start': 0,
         }
 
-        if W0 > self.target_len:
+        if self.target_len < W0:
             start = self._choose_start(
                 fb_subset=fb_subset_pad,
                 trace_valid=trace_valid,
@@ -378,8 +689,12 @@ def build_train_dataset(
     plan: BuildPlan,
     fbgate: FirstBreakGate,
     subset_traces: int,
+    trace_len: int,
     time_len: int,
     standardize_eps: float,
+    anchor_mode: str,
+    gap_ratio: float,
+    min_gap_m: float | None,
     trace_decimate_prob: float,
     trace_decimate_stride_range: tuple[int, int],
     primary_keys: Sequence[str],
@@ -390,19 +705,32 @@ def build_train_dataset(
     use_header_cache: bool,
     waveform_mode: str,
     segy_endian: str,
-) -> SegyGatherPipelineDataset:
-    return _build_pick_aware_dataset(
+) -> GlobalAnchorCoarseDataset:
+    if int(subset_traces) != int(trace_len):
+        msg = 'train.subset_traces must match transform.trace_len for fbpick coarse'
+        raise ValueError(msg)
+    if float(trace_decimate_prob) != 0.0:
+        msg = 'train.trace_decimation is not supported for global-anchor fbpick coarse'
+        raise ValueError(msg)
+    if tuple(trace_decimate_stride_range) != (1, 1):
+        msg = 'train.trace_decimation.stride_range must be [1, 1] for fbpick coarse'
+        raise ValueError(msg)
+    if str(anchor_mode) != 'random':
+        msg = 'train global-anchor coarse dataset requires anchor_mode="random"'
+        raise ValueError(msg)
+    validate_files_exist(list(segy_files) + list(fb_files))
+    return GlobalAnchorCoarseDataset(
         segy_files=segy_files,
         fb_files=fb_files,
         sampling_overrides=sampling_overrides,
         plan=plan,
         fbgate=fbgate,
-        subset_traces=subset_traces,
-        target_len=time_len,
+        trace_len=trace_len,
+        time_len=time_len,
         standardize_eps=standardize_eps,
-        start_mode='random',
-        trace_decimate_prob=trace_decimate_prob,
-        trace_decimate_stride_range=trace_decimate_stride_range,
+        anchor_mode=anchor_mode,
+        gap_ratio=gap_ratio,
+        min_gap_m=min_gap_m,
         primary_keys=primary_keys,
         secondary_key_fixed=secondary_key_fixed,
         verbose=verbose,
@@ -422,8 +750,12 @@ def build_labeled_infer_dataset(
     plan: BuildPlan,
     fbgate: FirstBreakGate,
     subset_traces: int,
+    trace_len: int,
     time_len: int,
     standardize_eps: float,
+    anchor_mode: str,
+    gap_ratio: float,
+    min_gap_m: float | None,
     primary_keys: Sequence[str],
     secondary_key_fixed: bool,
     verbose: bool,
@@ -432,19 +764,26 @@ def build_labeled_infer_dataset(
     use_header_cache: bool,
     waveform_mode: str,
     segy_endian: str,
-) -> SegyGatherPipelineDataset:
-    return _build_pick_aware_dataset(
+) -> GlobalAnchorCoarseDataset:
+    if int(subset_traces) != int(trace_len):
+        msg = 'infer.subset_traces must match transform.trace_len for fbpick coarse'
+        raise ValueError(msg)
+    if str(anchor_mode) != 'center':
+        msg = 'validation global-anchor coarse dataset requires anchor_mode="center"'
+        raise ValueError(msg)
+    validate_files_exist(list(segy_files) + list(fb_files))
+    return GlobalAnchorCoarseDataset(
         segy_files=segy_files,
         fb_files=fb_files,
         sampling_overrides=sampling_overrides,
         plan=plan,
         fbgate=fbgate,
-        subset_traces=subset_traces,
-        target_len=time_len,
+        trace_len=trace_len,
+        time_len=time_len,
         standardize_eps=standardize_eps,
-        start_mode='midpoint',
-        trace_decimate_prob=0.0,
-        trace_decimate_stride_range=(1, 1),
+        anchor_mode=anchor_mode,
+        gap_ratio=gap_ratio,
+        min_gap_m=min_gap_m,
         primary_keys=primary_keys,
         secondary_key_fixed=secondary_key_fixed,
         verbose=verbose,

--- a/packages/seisai-engine/src/seisai_engine/pipelines/fbpick/coarse/build_dataset.py
+++ b/packages/seisai-engine/src/seisai_engine/pipelines/fbpick/coarse/build_dataset.py
@@ -195,6 +195,8 @@ class GlobalAnchorCoarseDataset(SegyGatherPipelineDataset):
         )
         trace_valid = np.asarray(selection.trace_valid, dtype=np.bool_)
         anchor_raw_indices = np.asarray(selection.anchor_raw_indices, dtype=np.int64)
+        anchor_source_pos = np.asarray(selection.anchor_source_pos, dtype=np.int64)
+        anchor_offsets_m = np.asarray(selection.anchor_offsets_m, dtype=np.float32)
 
         valid_indices = anchor_raw_indices[trace_valid]
         subset_loader = TraceSubsetLoader(
@@ -227,7 +229,7 @@ class GlobalAnchorCoarseDataset(SegyGatherPipelineDataset):
 
         fb_idx_raw_for_anchors = np.full((self.trace_len,), -1, dtype=np.int64)
         valid_source_pos = np.asarray(
-            selection.anchor_source_pos[trace_valid],
+            anchor_source_pos[trace_valid],
             dtype=np.int64,
         )
         fb_idx_raw_for_anchors[trace_valid] = fb_full[valid_source_pos]
@@ -251,7 +253,7 @@ class GlobalAnchorCoarseDataset(SegyGatherPipelineDataset):
             'trace_valid': trace_valid,
             'fb_idx': fb_idx_raw_for_anchors,
             'fb_idx_view': fb_idx_coarse_for_anchors,
-            'offsets_view': np.asarray(selection.anchor_offsets_m, dtype=np.float32),
+            'offsets_view': anchor_offsets_m,
             'time_view': np.asarray(grid.time_view_sec, dtype=np.float32),
             'dt_sec': np.float32(grid.dt_sec),
             'dt_eff_sec': np.float32(grid.dt_eff_sec),
@@ -259,15 +261,6 @@ class GlobalAnchorCoarseDataset(SegyGatherPipelineDataset):
             'coarse_time_len': int(grid.coarse_time_len),
             'raw_to_coarse_factor': np.float32(grid.raw_to_coarse_factor),
             'coarse_to_raw_factor': np.float32(grid.coarse_to_raw_factor),
-            'anchor_raw_indices': anchor_raw_indices,
-            'anchor_source_pos': np.asarray(
-                selection.anchor_source_pos,
-                dtype=np.int64,
-            ),
-            'anchor_offsets_m': np.asarray(
-                selection.anchor_offsets_m,
-                dtype=np.float32,
-            ),
             'segment_id': np.asarray(selection.segment_id, dtype=np.int64),
             'anchor_bin_start_pos': np.asarray(
                 selection.anchor_bin_start_pos,
@@ -299,7 +292,7 @@ class GlobalAnchorCoarseDataset(SegyGatherPipelineDataset):
         sample_for_plan = self.sample_flow.build_plan_input_base(
             meta=meta,
             dt_sec=float(grid.dt_eff_sec),
-            offsets=np.asarray(selection.anchor_offsets_m, dtype=np.float32),
+            offsets=anchor_offsets_m,
             indices=anchor_raw_indices,
             key_name=str(sample['key_name']),
             secondary_key=str(sample['secondary_key']),
@@ -313,11 +306,13 @@ class GlobalAnchorCoarseDataset(SegyGatherPipelineDataset):
         )
         self.sample_flow.run_plan(sample_for_plan, rng=self._rng)
 
+        # ``indices`` is the generic dataset convention for selected raw trace ids.
+        # Keep ``anchor_raw_indices`` as the explicit global-anchor debug alias.
         out = self.sample_flow.build_output_base(
             sample_for_plan,
             meta=meta,
             dt_sec=float(grid.dt_eff_sec),
-            offsets=np.asarray(selection.anchor_offsets_m, dtype=np.float32),
+            offsets=anchor_offsets_m,
             indices=anchor_raw_indices,
             key_name=str(sample['key_name']),
             secondary_key=str(sample['secondary_key']),
@@ -328,12 +323,8 @@ class GlobalAnchorCoarseDataset(SegyGatherPipelineDataset):
                 'file_path': info.path,
                 'did_superwindow': bool(sample['did_super']),
                 'anchor_raw_indices': torch.from_numpy(anchor_raw_indices),
-                'anchor_source_pos': torch.from_numpy(
-                    np.asarray(selection.anchor_source_pos, dtype=np.int64)
-                ),
-                'anchor_offsets_m': torch.from_numpy(
-                    np.asarray(selection.anchor_offsets_m, dtype=np.float32)
-                ),
+                'anchor_source_pos': torch.from_numpy(anchor_source_pos),
+                'anchor_offsets_m': torch.from_numpy(anchor_offsets_m),
             },
         )
         self._add_trace_valid_output(out, trace_valid)

--- a/packages/seisai-engine/src/seisai_engine/pipelines/fbpick/coarse/config.py
+++ b/packages/seisai-engine/src/seisai_engine/pipelines/fbpick/coarse/config.py
@@ -63,6 +63,10 @@ COARSE_INPUT_CHANNELS = ('waveform', 'offset_ch', 'time_ch')
 COARSE_CKPT_PIPELINE = 'fbpick'
 COARSE_CKPT_OUTPUT_IDS = ('P',)
 COARSE_CKPT_SOFTMAX_AXIS = 'time'
+INFER_PAIR_MESSAGE = (
+    'paths.infer_segy_files and paths.infer_fb_files must be provided together, '
+    'or omit both to reuse the training segy/fb pairs'
+)
 
 
 @dataclass(frozen=True)
@@ -228,6 +232,11 @@ def _load_paths_cfg(cfg: dict, *, allow_missing_infer_pairs: bool) -> CoarsePath
 
     infer_segy_raw = paths.get('infer_segy_files')
     infer_fb_raw = paths.get('infer_fb_files')
+    infer_segy_provided = infer_segy_raw is not None
+    infer_fb_provided = infer_fb_raw is not None
+    if not allow_missing_infer_pairs and infer_segy_provided != infer_fb_provided:
+        raise ValueError(INFER_PAIR_MESSAGE)
+
     if infer_segy_raw is None:
         infer_segy_files = None
     else:
@@ -237,7 +246,7 @@ def _load_paths_cfg(cfg: dict, *, allow_missing_infer_pairs: bool) -> CoarsePath
     else:
         infer_fb_files = tuple(require_list_str(paths, 'infer_fb_files'))
 
-    if not allow_missing_infer_pairs and infer_segy_files is None:
+    if not allow_missing_infer_pairs and not infer_segy_provided:
         infer_segy_files = segy_files
         infer_fb_files = fb_files
     if infer_segy_files is not None and infer_fb_files is not None:

--- a/packages/seisai-engine/src/seisai_engine/pipelines/fbpick/coarse/train.py
+++ b/packages/seisai-engine/src/seisai_engine/pipelines/fbpick/coarse/train.py
@@ -8,7 +8,6 @@ import torch
 from seisai_utils.listfiles import expand_cfg_listfiles, get_cfg_listfile_meta
 
 from seisai_engine.optim import build_optimizer
-from seisai_engine.viewer.fbpick import save_fbpick_debug_png
 from seisai_engine.pipelines.common import (
     TrainSkeletonSpec,
     load_cfg_with_base_dir,
@@ -19,6 +18,7 @@ from seisai_engine.pipelines.common import (
     run_train_skeleton,
     seed_all,
 )
+from seisai_engine.viewer.fbpick import save_fbpick_debug_png
 
 from .build_dataset import (
     build_fbgate,
@@ -181,7 +181,10 @@ def build_train_bundle(
         msg = 'paths.fb_files is required for coarse training'
         raise ValueError(msg)
     if typed.paths.infer_segy_files is None or typed.paths.infer_fb_files is None:
-        msg = 'coarse train infer dataset requires labels; provide infer files or fb_files'
+        msg = (
+            'coarse train infer dataset requires labels; provide infer files '
+            'or fb_files'
+        )
         raise ValueError(msg)
 
     plan = build_plan(
@@ -198,8 +201,12 @@ def build_train_bundle(
         plan=plan,
         fbgate=fbgate,
         subset_traces=typed.train.subset_traces,
+        trace_len=typed.transform.trace_len,
         time_len=typed.transform.time_len,
         standardize_eps=typed.transform.standardize_eps,
+        anchor_mode=typed.trace_anchor.train_mode,
+        gap_ratio=typed.trace_anchor.gap_ratio,
+        min_gap_m=typed.trace_anchor.min_gap_m,
         trace_decimate_prob=typed.train.trace_decimate_prob,
         trace_decimate_stride_range=typed.train.trace_decimate_stride_range,
         primary_keys=typed.dataset.primary_keys,
@@ -218,8 +225,12 @@ def build_train_bundle(
         plan=plan,
         fbgate=fbgate,
         subset_traces=typed.infer.subset_traces,
+        trace_len=typed.transform.trace_len,
         time_len=typed.transform.time_len,
         standardize_eps=typed.transform.standardize_eps,
+        anchor_mode=typed.trace_anchor.infer_mode,
+        gap_ratio=typed.trace_anchor.gap_ratio,
+        min_gap_m=typed.trace_anchor.min_gap_m,
         primary_keys=typed.dataset.primary_keys,
         secondary_key_fixed=typed.dataset.secondary_key_fixed,
         verbose=typed.dataset.verbose,

--- a/packages/seisai-engine/src/seisai_engine/pipelines/fbpick/coarse/train.py
+++ b/packages/seisai-engine/src/seisai_engine/pipelines/fbpick/coarse/train.py
@@ -32,6 +32,7 @@ from .config import (
     COARSE_INPUT_CHANNELS,
     COARSE_TIME_LEN,
     COARSE_TRACE_LEN,
+    INFER_PAIR_MESSAGE,
     CoarseTrainConfig,
     load_coarse_train_config,
 )
@@ -181,11 +182,7 @@ def build_train_bundle(
         msg = 'paths.fb_files is required for coarse training'
         raise ValueError(msg)
     if typed.paths.infer_segy_files is None or typed.paths.infer_fb_files is None:
-        msg = (
-            'coarse train infer dataset requires labels; provide infer files '
-            'or fb_files'
-        )
-        raise ValueError(msg)
+        raise ValueError(INFER_PAIR_MESSAGE)
 
     plan = build_plan(
         sigma_ms=typed.train.fb_sigma_ms,
@@ -238,7 +235,7 @@ def build_train_bundle(
         max_trials=typed.dataset.max_trials,
         use_header_cache=typed.dataset.use_header_cache,
         waveform_mode=typed.dataset.waveform_mode,
-        segy_endian=typed.dataset.train_endian,
+        segy_endian=typed.dataset.infer_endian,
     )
 
     model_sig = dict(typed.model_sig)

--- a/packages/seisai-engine/tests/test_fbpick_coarse.py
+++ b/packages/seisai-engine/tests/test_fbpick_coarse.py
@@ -7,12 +7,10 @@ import numpy as np
 import pytest
 import segyio
 import torch
-from torch.utils.data import DataLoader, Subset
-
 from seisai_engine.pipelines.common import load_checkpoint
-from seisai_engine.pipelines.fbpick.common import COARSE_REQUIRED_KEYS, load_coarse_npz
 from seisai_engine.pipelines.fbpick.coarse import (
     build_fbgate,
+    build_labeled_infer_dataset,
     build_plan,
     build_train_dataset,
     load_coarse_infer_config,
@@ -21,7 +19,9 @@ from seisai_engine.pipelines.fbpick.coarse import (
     run_coarse_infer,
     run_train,
 )
+from seisai_engine.pipelines.fbpick.common import COARSE_REQUIRED_KEYS, load_coarse_npz
 from seisai_engine.train_loop import train_one_epoch
+from torch.utils.data import DataLoader, Subset
 
 
 def write_unstructured_segy(path: str, traces: np.ndarray, dt_us: int) -> None:
@@ -261,17 +261,22 @@ def test_coarse_build_plan_produces_expected_shapes() -> None:
     assert tuple(sample['target'].shape) == (1, 4, 8)
 
 
-def test_pick_aware_crop_keeps_all_valid_picks_in_view(tmp_path: Path) -> None:
+def test_global_anchor_train_dataset_returns_fixed_shape_and_masks_pad_rows(
+    tmp_path: Path,
+) -> None:
     n_traces = 128
-    n_samples = 7000
+    n_samples = 4097
     traces = np.stack(
-        [np.linspace(-1.0, 1.0, n_samples, dtype=np.float32) + i for i in range(n_traces)],
+        [
+            np.linspace(-1.0, 1.0, n_samples, dtype=np.float32) + i
+            for i in range(n_traces)
+        ],
         axis=0,
     )
-    segy_path = str(tmp_path / 'pick_crop.sgy')
+    segy_path = str(tmp_path / 'global_train_pad.sgy')
     write_unstructured_segy(segy_path, traces, dt_us=2000)
-    fb = np.linspace(6400, 6500, n_traces, dtype=np.int64)
-    fb_path = str(tmp_path / 'pick_crop_fb.npy')
+    fb = np.linspace(0, n_samples - 1, n_traces, dtype=np.int64)
+    fb_path = str(tmp_path / 'global_train_pad_fb.npy')
     np.save(fb_path, fb)
 
     ds = build_train_dataset(
@@ -280,9 +285,13 @@ def test_pick_aware_crop_keeps_all_valid_picks_in_view(tmp_path: Path) -> None:
         sampling_overrides=None,
         plan=_make_plan(),
         fbgate=build_fbgate(apply_on='off', min_pick_ratio=0.0, verbose=False),
-        subset_traces=128,
-        time_len=6016,
+        subset_traces=256,
+        trace_len=256,
+        time_len=2048,
         standardize_eps=1.0e-8,
+        anchor_mode='random',
+        gap_ratio=5.0,
+        min_gap_m=None,
         trace_decimate_prob=0.0,
         trace_decimate_stride_range=(1, 1),
         primary_keys=('ffid',),
@@ -301,13 +310,139 @@ def test_pick_aware_crop_keeps_all_valid_picks_in_view(tmp_path: Path) -> None:
     finally:
         ds.close()
 
-    fb_idx_view = np.asarray(sample['meta']['fb_idx_view'], dtype=np.int64)
     trace_valid = np.asarray(sample['meta']['trace_valid'], dtype=np.bool_)
-    assert int(sample['meta']['start']) > 0
-    assert np.all(fb_idx_view[trace_valid] > 0)
-    assert np.all(fb_idx_view[trace_valid] < 6016)
-    assert tuple(sample['input'].shape) == (3, 128, 6016)
-    assert tuple(sample['target'].shape) == (1, 128, 6016)
+    assert tuple(sample['input'].shape) == (3, 256, 2048)
+    assert tuple(sample['target'].shape) == (1, 256, 2048)
+    np.testing.assert_array_equal(trace_valid[:n_traces], np.ones(n_traces, dtype=bool))
+    assert not np.any(trace_valid[n_traces:])
+    torch.testing.assert_close(
+        sample['input'][0, n_traces:],
+        torch.zeros_like(sample['input'][0, n_traces:]),
+    )
+    torch.testing.assert_close(
+        sample['input'][1, n_traces:],
+        torch.zeros_like(sample['input'][1, n_traces:]),
+    )
+    torch.testing.assert_close(
+        sample['target'][:, n_traces:],
+        torch.zeros_like(sample['target'][:, n_traces:]),
+    )
+    np.testing.assert_array_equal(
+        sample['meta']['fb_idx_coarse_for_anchors'][n_traces:],
+        np.full((256 - n_traces,), -1, dtype=np.int64),
+    )
+    assert int(sample['meta']['raw_time_len']) == n_samples
+    assert int(sample['meta']['coarse_time_len']) == 2048
+    assert sample['meta']['time_view'][0] == pytest.approx(0.0)
+    assert sample['meta']['time_view'][-1] == pytest.approx((n_samples - 1) * 0.002)
+    assert sample['meta']['fb_idx_coarse_for_anchors'][0] == 0
+    assert sample['meta']['fb_idx_coarse_for_anchors'][n_traces - 1] == 2047
+
+
+def test_global_anchor_train_dataset_uses_random_anchors(tmp_path: Path) -> None:
+    n_traces = 512
+    n_samples = 2049
+    traces = np.stack(
+        [
+            np.linspace(-1.0, 1.0, n_samples, dtype=np.float32) + i
+            for i in range(n_traces)
+        ],
+        axis=0,
+    )
+    segy_path = str(tmp_path / 'global_train_random.sgy')
+    write_unstructured_segy(segy_path, traces, dt_us=2000)
+    fb = np.full((n_traces,), 1000, dtype=np.int64)
+    fb_path = str(tmp_path / 'global_train_random_fb.npy')
+    np.save(fb_path, fb)
+
+    ds = build_train_dataset(
+        segy_files=[segy_path],
+        fb_files=[fb_path],
+        sampling_overrides=None,
+        plan=_make_plan(),
+        fbgate=build_fbgate(apply_on='off', min_pick_ratio=0.0, verbose=False),
+        subset_traces=256,
+        trace_len=256,
+        time_len=2048,
+        standardize_eps=1.0e-8,
+        anchor_mode='random',
+        gap_ratio=5.0,
+        min_gap_m=None,
+        trace_decimate_prob=0.0,
+        trace_decimate_stride_range=(1, 1),
+        primary_keys=('ffid',),
+        secondary_key_fixed=False,
+        verbose=False,
+        progress=False,
+        max_trials=8,
+        use_header_cache=False,
+        waveform_mode='eager',
+        segy_endian='big',
+    )
+
+    try:
+        ds._rng = np.random.default_rng(123)
+        first = ds[0]
+        ds._rng = np.random.default_rng(124)
+        second = ds[0]
+    finally:
+        ds.close()
+
+    assert tuple(first['input'].shape) == (3, 256, 2048)
+    assert tuple(second['target'].shape) == (1, 256, 2048)
+    assert not torch.equal(first['anchor_source_pos'], second['anchor_source_pos'])
+
+
+def test_global_anchor_validation_dataset_is_deterministic(tmp_path: Path) -> None:
+    n_traces = 512
+    n_samples = 2049
+    traces = np.stack(
+        [
+            np.linspace(-1.0, 1.0, n_samples, dtype=np.float32) + i
+            for i in range(n_traces)
+        ],
+        axis=0,
+    )
+    segy_path = str(tmp_path / 'global_validation.sgy')
+    write_unstructured_segy(segy_path, traces, dt_us=2000)
+    fb = np.full((n_traces,), 1000, dtype=np.int64)
+    fb_path = str(tmp_path / 'global_validation_fb.npy')
+    np.save(fb_path, fb)
+
+    ds = build_labeled_infer_dataset(
+        segy_files=[segy_path],
+        fb_files=[fb_path],
+        sampling_overrides=None,
+        plan=_make_plan(),
+        fbgate=build_fbgate(apply_on='off', min_pick_ratio=0.0, verbose=False),
+        subset_traces=256,
+        trace_len=256,
+        time_len=2048,
+        standardize_eps=1.0e-8,
+        anchor_mode='center',
+        gap_ratio=5.0,
+        min_gap_m=None,
+        primary_keys=('ffid',),
+        secondary_key_fixed=False,
+        verbose=False,
+        progress=False,
+        max_trials=8,
+        use_header_cache=False,
+        waveform_mode='eager',
+        segy_endian='big',
+    )
+
+    try:
+        first = ds[0]
+        second = ds[0]
+    finally:
+        ds.close()
+
+    assert tuple(first['input'].shape) == (3, 256, 2048)
+    assert tuple(first['target'].shape) == (1, 256, 2048)
+    torch.testing.assert_close(first['input'], second['input'])
+    torch.testing.assert_close(first['target'], second['target'])
+    assert torch.equal(first['anchor_source_pos'], second['anchor_source_pos'])
 
 
 def test_coarse_train_smoke_one_epoch(tmp_path: Path) -> None:

--- a/packages/seisai-engine/tests/test_fbpick_coarse.py
+++ b/packages/seisai-engine/tests/test_fbpick_coarse.py
@@ -158,6 +158,53 @@ def test_load_coarse_train_config_returns_fixed_contract_values(
     assert typed.ckpt.softmax_axis == 'time'
 
 
+@pytest.mark.parametrize(
+    'mutate_paths',
+    [
+        lambda paths: paths.__setitem__('infer_segy_files', ['valid.sgy']),
+        lambda paths: paths.__setitem__('infer_fb_files', ['valid.npy']),
+    ],
+)
+def test_load_coarse_train_config_rejects_partial_infer_pairs(
+    tmp_path: Path,
+    mutate_paths,
+) -> None:
+    cfg = _make_training_config(tmp_path, segy_path='train.sgy', fb_path='train.npy')
+    mutate_paths(cfg['paths'])
+
+    with pytest.raises(ValueError) as exc:
+        load_coarse_train_config(cfg)
+
+    assert (
+        'paths.infer_segy_files and paths.infer_fb_files must be provided together'
+        in str(exc.value)
+    )
+
+
+def test_load_coarse_train_config_defaults_missing_infer_pairs_to_training_pairs(
+    tmp_path: Path,
+) -> None:
+    cfg = _make_training_config(tmp_path, segy_path='train.sgy', fb_path='train.npy')
+
+    typed = load_coarse_train_config(cfg)
+
+    assert typed.paths.infer_segy_files == typed.paths.segy_files
+    assert typed.paths.infer_fb_files == typed.paths.fb_files
+
+
+def test_load_coarse_train_config_uses_explicit_infer_pairs(
+    tmp_path: Path,
+) -> None:
+    cfg = _make_training_config(tmp_path, segy_path='train.sgy', fb_path='train.npy')
+    cfg['paths']['infer_segy_files'] = ['valid.sgy']
+    cfg['paths']['infer_fb_files'] = ['valid.npy']
+
+    typed = load_coarse_train_config(cfg)
+
+    assert typed.paths.infer_segy_files == ('valid.sgy',)
+    assert typed.paths.infer_fb_files == ('valid.npy',)
+
+
 def test_load_coarse_infer_config_returns_global_anchor_contract(
     tmp_path: Path,
 ) -> None:
@@ -313,6 +360,24 @@ def test_global_anchor_train_dataset_returns_fixed_shape_and_masks_pad_rows(
     trace_valid = np.asarray(sample['meta']['trace_valid'], dtype=np.bool_)
     assert tuple(sample['input'].shape) == (3, 256, 2048)
     assert tuple(sample['target'].shape) == (1, 256, 2048)
+    assert 'anchor_raw_indices' in sample
+    assert 'anchor_source_pos' in sample
+    assert 'anchor_offsets_m' in sample
+    assert 'anchor_raw_indices' not in sample['meta']
+    assert 'anchor_source_pos' not in sample['meta']
+    assert 'anchor_offsets_m' not in sample['meta']
+    for key in (
+        'trace_valid',
+        'fb_idx_view',
+        'offsets_view',
+        'time_view',
+        'dt_eff_sec',
+    ):
+        assert key in sample['meta']
+    np.testing.assert_array_equal(
+        np.asarray(sample['indices'], dtype=np.int64),
+        sample['anchor_raw_indices'].numpy(),
+    )
     np.testing.assert_array_equal(trace_valid[:n_traces], np.ones(n_traces, dtype=bool))
     assert not np.any(trace_valid[n_traces:])
     torch.testing.assert_close(
@@ -337,6 +402,54 @@ def test_global_anchor_train_dataset_returns_fixed_shape_and_masks_pad_rows(
     assert sample['meta']['time_view'][-1] == pytest.approx((n_samples - 1) * 0.002)
     assert sample['meta']['fb_idx_coarse_for_anchors'][0] == 0
     assert sample['meta']['fb_idx_coarse_for_anchors'][n_traces - 1] == 2047
+
+
+def test_build_train_bundle_uses_train_and_infer_endian_for_dataset_builders(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import seisai_engine.pipelines.fbpick.coarse.train as coarse_train
+
+    cfg = _make_training_config(tmp_path, segy_path='train.sgy', fb_path='train.npy')
+    cfg['paths']['infer_segy_files'] = ['valid.sgy']
+    cfg['paths']['infer_fb_files'] = ['valid.npy']
+    cfg['dataset']['train_endian'] = 'little'
+    cfg['dataset']['infer_endian'] = 'big'
+
+    seen_endian: dict[str, str] = {}
+
+    class StubDataset:
+        def close(self) -> None:
+            return None
+
+    def fake_build_train_dataset(**kwargs):
+        seen_endian['train'] = kwargs['segy_endian']
+        return StubDataset()
+
+    def fake_build_labeled_infer_dataset(**kwargs):
+        seen_endian['infer'] = kwargs['segy_endian']
+        return StubDataset()
+
+    monkeypatch.setattr(coarse_train, 'build_train_dataset', fake_build_train_dataset)
+    monkeypatch.setattr(
+        coarse_train,
+        'build_labeled_infer_dataset',
+        fake_build_labeled_infer_dataset,
+    )
+    monkeypatch.setattr(
+        coarse_train,
+        'build_model',
+        lambda _model_sig: torch.nn.Conv2d(3, 1, kernel_size=1),
+    )
+
+    bundle = coarse_train.build_train_bundle(
+        cfg,
+        base_dir=tmp_path,
+        device=torch.device('cpu'),
+    )
+
+    assert seen_endian == {'train': 'little', 'infer': 'big'}
+    assert bundle.ds_train_full is not bundle.ds_infer_full
 
 
 def test_global_anchor_train_dataset_uses_random_anchors(tmp_path: Path) -> None:


### PR DESCRIPTION
Closes #27

## Summary
- [fbpick-coarse] Replace train/validation datasets with global-anchor datasets

## Changed files
- `cli/_entrypoint.py`
- `packages/seisai-engine/src/seisai_engine/pipelines/fbpick/coarse/__init__.py`
- `packages/seisai-engine/src/seisai_engine/pipelines/fbpick/coarse/build_dataset.py`
- `packages/seisai-engine/src/seisai_engine/pipelines/fbpick/coarse/train.py`
- `packages/seisai-engine/tests/test_fbpick_coarse.py`

## Checks
- `.work/codex/checks.log`: 747 passed, 5 warnings in 56.83s

## Review
- `.work/codex/review.txt`: accept: yes
- findings: blocker 0, major 0, minor 1
