### PR TITLE
[fbpick-coarse] Replace tiled coarse inference with global-anchor inference  Issue body

### DIFF
--- a/cli/run_fbpick_coarse_infer.py
+++ b/cli/run_fbpick_coarse_infer.py
@@ -84,13 +84,6 @@ def _resolve_ckpt_path(cfg: dict[str, Any]) -> Path:
 
 
 def _validate_checkpoint_for_infer(ckpt: dict[str, Any], *, model_sig: dict[str, Any]) -> None:
-    from seisai_engine.pipelines.fbpick.coarse.config import (
-        COARSE_IN_CHANS,
-        COARSE_INPUT_MODE_GLOBAL_ANCHOR_RESIZE,
-        COARSE_TIME_LEN,
-        COARSE_TRACE_LEN,
-    )
-
     pipeline = ckpt.get('pipeline')
     if pipeline != 'fbpick':
         msg = f'coarse infer checkpoint pipeline must be "fbpick", got {pipeline!r}'
@@ -120,10 +113,10 @@ def _validate_checkpoint_for_infer(ckpt: dict[str, Any], *, model_sig: dict[str,
         raise ValueError(msg)
 
     expected_meta = {
-        'coarse_input_mode': COARSE_INPUT_MODE_GLOBAL_ANCHOR_RESIZE,
-        'coarse_trace_len': COARSE_TRACE_LEN,
-        'coarse_time_len': COARSE_TIME_LEN,
-        'coarse_in_chans': COARSE_IN_CHANS,
+        'coarse_input_mode': 'global_anchor_resize',
+        'coarse_trace_len': 256,
+        'coarse_time_len': 2048,
+        'coarse_in_chans': 3,
     }
     for key, expected in expected_meta.items():
         actual = ckpt.get(key)
@@ -206,6 +199,7 @@ def run_pipeline(config_path: str | Path) -> Path:
             model=model,
             cfg=single_cfg,
             device=device,
+            ckpt=ckpt,
         )
         if out_path != target_out_path:
             out_path = out_path.replace(target_out_path)

--- a/examples/config_infer_fbpick_coarse.yaml
+++ b/examples/config_infer_fbpick_coarse.yaml
@@ -33,13 +33,8 @@ norm_refs:
 infer:
   ckpt_path: REPLACE_ME_coarse_best.pt
   device: auto
-  subset_traces: 256
   batch_size: 1
   num_workers: 0
-  overlap_h: 192
-  tile_w: 2048
-  overlap_w: 1024
-  tiles_per_batch: 16
   amp: false
   use_tqdm: false
 

--- a/packages/seisai-engine/src/seisai_engine/pipelines/fbpick/coarse/__init__.py
+++ b/packages/seisai-engine/src/seisai_engine/pipelines/fbpick/coarse/__init__.py
@@ -1,9 +1,11 @@
 from .build_dataset import (
     GlobalAnchorCoarseDataset,
+    GlobalAnchorCoarseRawInferDataset,
     build_fbgate,
     build_labeled_infer_dataset,
     build_raw_infer_dataset,
     build_train_dataset,
+    collate_input_meta_list,
 )
 from .build_model import build_model
 from .build_plan import build_plan
@@ -20,7 +22,11 @@ from .config import (
     load_coarse_infer_config,
     load_coarse_train_config,
 )
-from .infer import run_coarse_infer
+from .infer import (
+    restore_anchor_predictions_to_full_traces,
+    run_coarse_infer,
+    validate_checkpoint_for_global_anchor_infer,
+)
 from .loss import build_criterion
 from .time_axis import (
     CoarseTimeGrid,
@@ -59,6 +65,7 @@ __all__ = [
     'CoarseTrainBundle',
     'CoarseTrainConfig',
     'GlobalAnchorCoarseDataset',
+    'GlobalAnchorCoarseRawInferDataset',
     'TraceAnchorSelection',
     'TraceSegment',
     'build_coarse_fb_labels_for_anchors',
@@ -73,6 +80,7 @@ __all__ = [
     'build_train_bundle',
     'build_train_dataset',
     'build_train_spec',
+    'collate_input_meta_list',
     'load_coarse_infer_config',
     'load_coarse_train_config',
     'load_train_bundle',
@@ -80,8 +88,10 @@ __all__ = [
     'project_coarse_indices_to_raw_time',
     'project_fb_indices_to_coarse_time',
     'resample_waveform_time_axis',
+    'restore_anchor_predictions_to_full_traces',
     'run_coarse_infer',
     'run_train',
     'select_trace_anchors',
     'split_trace_segments_by_offset_gap',
+    'validate_checkpoint_for_global_anchor_infer',
 ]

--- a/packages/seisai-engine/src/seisai_engine/pipelines/fbpick/coarse/build_dataset.py
+++ b/packages/seisai-engine/src/seisai_engine/pipelines/fbpick/coarse/build_dataset.py
@@ -1,22 +1,24 @@
 from __future__ import annotations
 
+import contextlib
 import random
 from collections.abc import Sequence
 
 import numpy as np
+import segyio
 import torch
 from seisai_dataset import (
     BuildPlan,
     FirstBreakGate,
     FirstBreakGateConfig,
-    InferenceGatherWindowsConfig,
-    InferenceGatherWindowsDataset,
     InputOnlyPlan,
     SegyGatherPipelineDataset,
 )
-from seisai_dataset.config import LoaderConfig
+from seisai_dataset.config import LoaderConfig, TraceSubsetSamplerConfig
+from seisai_dataset.file_info import build_file_info
 from seisai_dataset.segy_gather_base import SampleTransformer
 from seisai_dataset.trace_subset_preproc import TraceSubsetLoader
+from seisai_dataset.trace_subset_sampler import TraceSubsetSampler
 from seisai_dataset.transform_flow_utils import (
     add_view_projection_meta,
     apply_transform_2d_with_meta,
@@ -24,6 +26,7 @@ from seisai_dataset.transform_flow_utils import (
 )
 from seisai_transforms.augment import PerTraceStandardize, ViewCompose
 from seisai_utils.fs import validate_files_exist
+from torch.utils.data import Dataset
 
 from .config import COARSE_TIME_LEN, COARSE_TRACE_LEN
 from .time_axis import (
@@ -35,6 +38,7 @@ from .trace_anchor import select_trace_anchors
 
 __all__ = [
     'GlobalAnchorCoarseDataset',
+    'GlobalAnchorCoarseRawInferDataset',
     'PickAwareCropSampleTransformer',
     'build_fbgate',
     'build_infer_transform',
@@ -42,7 +46,22 @@ __all__ = [
     'build_raw_infer_dataset',
     'build_train_dataset',
     'build_train_transform',
+    'collate_input_meta_list',
 ]
+
+
+class _NoRandRNG:
+    def random(self, *args, **kwargs):
+        msg = 'random() is not allowed in global-anchor coarse inference'
+        raise RuntimeError(msg)
+
+    def uniform(self, *args, **kwargs):
+        msg = 'uniform() is not allowed in global-anchor coarse inference'
+        raise RuntimeError(msg)
+
+    def integers(self, *args, **kwargs):
+        msg = 'integers() is not allowed in global-anchor coarse inference'
+        raise RuntimeError(msg)
 
 
 class GlobalAnchorCoarseDataset(SegyGatherPipelineDataset):
@@ -331,6 +350,276 @@ class GlobalAnchorCoarseDataset(SegyGatherPipelineDataset):
         self._add_mask_bool_output(out, sample_for_plan)
         self._finalize_output(out, sample_for_plan, {}, x_view.shape)
         return out
+
+
+class GlobalAnchorCoarseRawInferDataset(Dataset):
+    def __init__(
+        self,
+        *,
+        segy_files: Sequence[str],
+        plan: BuildPlan | InputOnlyPlan,
+        trace_len: int,
+        time_len: int,
+        standardize_eps: float,
+        gap_ratio: float,
+        min_gap_m: float | None,
+        primary_keys: Sequence[str],
+        waveform_mode: str,
+        segy_endian: str,
+        use_header_cache: bool,
+    ) -> None:
+        trace_len_int = int(trace_len)
+        time_len_int = int(time_len)
+        if trace_len_int != COARSE_TRACE_LEN:
+            msg = f'trace_len must be {COARSE_TRACE_LEN} for global-anchor coarse'
+            raise ValueError(msg)
+        if time_len_int != COARSE_TIME_LEN:
+            msg = f'time_len must be {COARSE_TIME_LEN} for global-anchor coarse'
+            raise ValueError(msg)
+
+        primary_keys_tuple = tuple(str(key) for key in primary_keys)
+        if len(primary_keys_tuple) != 1:
+            msg = 'global-anchor coarse raw inference requires exactly one primary key'
+            raise ValueError(msg)
+
+        if isinstance(plan, BuildPlan):
+            self.plan = InputOnlyPlan.from_build_plan(plan, include_label_ops=False)
+        elif isinstance(plan, InputOnlyPlan):
+            self.plan = plan
+        else:
+            msg = 'plan must be BuildPlan or InputOnlyPlan'
+            raise TypeError(msg)
+
+        self.segy_files = list(segy_files)
+        if not self.segy_files:
+            msg = 'segy_files must be non-empty'
+            raise ValueError(msg)
+        self.trace_len = trace_len_int
+        self.time_len = time_len_int
+        self.gap_ratio = float(gap_ratio)
+        self.min_gap_m = None if min_gap_m is None else float(min_gap_m)
+        self.primary_key = primary_keys_tuple[0]
+        self.transform = build_infer_transform(standardize_eps=float(standardize_eps))
+        self._rng = _NoRandRNG()
+        self._subset_loader = TraceSubsetLoader(
+            LoaderConfig(pad_traces_to=self.trace_len)
+        )
+        self.sampler = TraceSubsetSampler(
+            TraceSubsetSamplerConfig(
+                primary_keys=(self.primary_key,),
+                primary_key_weights=None,
+                use_superwindow=False,
+                sw_halfspan=0,
+                sw_prob=0.0,
+                secondary_key_fixed=True,
+                subset_traces=self.trace_len,
+                trace_decimate_prob=0.0,
+                trace_decimate_stride_range=(1, 1),
+            )
+        )
+
+        self.file_infos: list[dict] = [
+            build_file_info(
+                segy_path,
+                ffid_byte=segyio.TraceField.FieldRecord,
+                chno_byte=segyio.TraceField.TraceNumber,
+                cmp_byte=segyio.TraceField.CDP,
+                header_cache_dir=None,
+                use_header_cache=bool(use_header_cache),
+                include_centroids=False,
+                waveform_mode=str(waveform_mode),
+                segy_endian=str(segy_endian),
+            )
+            for segy_path in self.segy_files
+        ]
+        self.items: list[tuple[int, str, int]] = []
+        self._build_items()
+
+    def _build_items(self) -> None:
+        for file_idx, info in enumerate(self.file_infos):
+            unique_keys = info.get(f'{self.primary_key}_unique_keys')
+            if not unique_keys:
+                msg = f'no {self.primary_key} gathers found in {info["path"]}'
+                raise RuntimeError(msg)
+            for primary_value in sorted(int(value) for value in unique_keys):
+                self.items.append((int(file_idx), self.primary_key, int(primary_value)))
+        if not self.items:
+            msg = 'global-anchor coarse raw inference found no gathers'
+            raise RuntimeError(msg)
+
+    def close(self) -> None:
+        for info in self.file_infos:
+            segy_obj = info.get('segy_obj')
+            if segy_obj is not None:
+                with contextlib.suppress(Exception):
+                    segy_obj.close()
+        self.file_infos.clear()
+        self.items.clear()
+
+    def __del__(self) -> None:
+        with contextlib.suppress(Exception):
+            self.close()
+
+    def __len__(self) -> int:
+        return len(self.items)
+
+    def _draw_item_full_gather(
+        self,
+        *,
+        info: dict,
+        key_name: str,
+        primary_value: int,
+    ) -> dict:
+        info_for_sample = dict(info)
+        info_for_sample['sampling_override'] = {
+            'primary_keys': [key_name],
+            'primary_ranges': {key_name: [int(primary_value), int(primary_value)]},
+            'secondary_key_fixed': True,
+        }
+        return self.sampler.draw_full_gather(
+            info_for_sample,
+            py_random=random.Random(0),
+        )
+
+    def __getitem__(self, index: int) -> dict:
+        file_idx, key_name, primary_value = self.items[int(index)]
+        info = self.file_infos[file_idx]
+        sample = self._draw_item_full_gather(
+            info=info,
+            key_name=key_name,
+            primary_value=primary_value,
+        )
+        return self._build_sample(info=info, file_idx=file_idx, sample=sample)
+
+    def _build_sample(self, *, info: dict, file_idx: int, sample: dict) -> dict:
+        raw_trace_indices = np.asarray(sample['indices'], dtype=np.int64)
+        if raw_trace_indices.ndim != 1 or raw_trace_indices.size == 0:
+            msg = 'draw_full_gather returned an empty raw gather'
+            raise RuntimeError(msg)
+
+        offsets_full = np.asarray(info['offsets'][raw_trace_indices], dtype=np.float32)
+        selection = select_trace_anchors(
+            raw_indices=raw_trace_indices,
+            offsets_m=offsets_full,
+            trace_len=self.trace_len,
+            mode='center',
+            gap_ratio=self.gap_ratio,
+            min_gap_m=self.min_gap_m,
+            rng=None,
+        )
+
+        trace_valid = np.asarray(selection.trace_valid, dtype=np.bool_)
+        anchor_raw_indices = np.asarray(selection.anchor_raw_indices, dtype=np.int64)
+        anchor_source_pos = np.asarray(selection.anchor_source_pos, dtype=np.int64)
+        anchor_offsets_m = np.asarray(selection.anchor_offsets_m, dtype=np.float32)
+
+        valid_indices = anchor_raw_indices[trace_valid]
+        x_valid = self._subset_loader.load_traces(info['mmap'], valid_indices)
+        x_resampled_valid = resample_waveform_time_axis(
+            x_valid,
+            out_time_len=self.time_len,
+        )
+        x_view = np.zeros((self.trace_len, self.time_len), dtype=np.float32)
+        x_view[trace_valid] = x_resampled_valid
+        x_view, transform_meta = apply_transform_2d_with_meta(
+            self.transform,
+            x_view,
+            self._rng,
+            msg_bad_out=(
+                'global-anchor raw infer transform must return 2D numpy or (2D, meta)'
+            ),
+            msg_bad_meta=(
+                'global-anchor raw infer transform meta must be dict, got {type}'
+            ),
+            exc_bad_out=ValueError,
+            exc_bad_meta=TypeError,
+        )
+        if x_view.shape != (self.trace_len, self.time_len):
+            msg = (
+                'global-anchor raw infer transform must keep fixed shape '
+                f'{(self.trace_len, self.time_len)}, got {x_view.shape}'
+            )
+            raise ValueError(msg)
+        x_view = np.ascontiguousarray(x_view, dtype=np.float32)
+        x_view[~trace_valid] = 0.0
+
+        grid = build_coarse_time_grid(
+            raw_time_len=int(info['n_samples']),
+            coarse_time_len=self.time_len,
+            dt_sec=float(info['dt_sec']),
+        )
+        meta = {
+            'source_file': str(info['path']),
+            'file_path': str(info['path']),
+            'file_idx': int(file_idx),
+            'key_name': str(sample['key_name']),
+            'primary_value': int(sample['primary_value']),
+            'primary_unique': str(sample['primary_unique']),
+            'secondary_key': str(sample['secondary_key']),
+            'raw_trace_indices': raw_trace_indices,
+            'anchor_raw_indices': anchor_raw_indices,
+            'anchor_source_pos': anchor_source_pos,
+            'anchor_offsets_m': anchor_offsets_m,
+            'trace_valid': trace_valid,
+            'segment_id': np.asarray(selection.segment_id, dtype=np.int64),
+            'anchor_bin_start_pos': np.asarray(
+                selection.anchor_bin_start_pos,
+                dtype=np.int64,
+            ),
+            'anchor_bin_stop_pos': np.asarray(
+                selection.anchor_bin_stop_pos,
+                dtype=np.int64,
+            ),
+            'raw_time_len': int(grid.raw_time_len),
+            'coarse_time_len': int(grid.coarse_time_len),
+            'dt_sec': np.float32(grid.dt_sec),
+            'dt_eff_sec': np.float32(grid.dt_eff_sec),
+            'raw_to_coarse_factor': np.float32(grid.raw_to_coarse_factor),
+            'coarse_to_raw_factor': np.float32(grid.coarse_to_raw_factor),
+            'offsets_view': anchor_offsets_m,
+            'time_view': np.asarray(grid.time_view_sec, dtype=np.float32),
+            'offsets_m': offsets_full,
+            'ffid_values': np.asarray(info['ffid_values'], dtype=np.int32),
+            'chno_values': np.asarray(info['chno_values'], dtype=np.int32),
+            'n_traces': int(info['n_traces']),
+            'n_samples_orig': int(info['n_samples']),
+            'hflip': False,
+            'factor_h': 1.0,
+            'factor': float(grid.raw_to_coarse_factor),
+            'start': 0,
+        }
+        meta.update(transform_meta)
+
+        sample_for_plan = {
+            'x_view': x_view,
+            'meta': meta,
+            'dt_sec': float(grid.dt_eff_sec),
+            'offsets': anchor_offsets_m,
+            'indices': anchor_raw_indices,
+            'key_name': str(sample['key_name']),
+            'secondary_key': str(sample['secondary_key']),
+            'primary_unique': str(sample['primary_unique']),
+            'file_path': str(info['path']),
+            'trace_valid': trace_valid,
+        }
+        self.plan.run(sample_for_plan, rng=self._rng)
+        if 'input' not in sample_for_plan:
+            msg = "plan must populate 'input'"
+            raise KeyError(msg)
+        x_in = sample_for_plan['input']
+        if not isinstance(x_in, torch.Tensor):
+            msg = "sample['input'] must be torch.Tensor"
+            raise TypeError(msg)
+        if tuple(x_in.shape) != (3, self.trace_len, self.time_len):
+            msg = (
+                'global-anchor raw infer input must have shape '
+                f'{(3, self.trace_len, self.time_len)}, got {tuple(x_in.shape)}'
+            )
+            raise ValueError(msg)
+        return {
+            'input': x_in,
+            'meta': meta,
+        }
 
 
 class PickAwareCropSampleTransformer(SampleTransformer):
@@ -790,34 +1079,44 @@ def build_raw_infer_dataset(
     *,
     segy_files: list[str],
     plan: BuildPlan | InputOnlyPlan,
-    subset_traces: int,
-    overlap_h: int,
+    trace_len: int,
     time_len: int,
     standardize_eps: float,
+    gap_ratio: float,
+    min_gap_m: float | None,
+    primary_keys: Sequence[str],
     waveform_mode: str,
     segy_endian: str,
     use_header_cache: bool,
-) -> InferenceGatherWindowsDataset:
-    stride_traces = int(subset_traces) - int(overlap_h)
-    if stride_traces <= 0:
-        msg = 'subset_traces - overlap_h must be positive'
-        raise ValueError(msg)
+) -> GlobalAnchorCoarseRawInferDataset:
     validate_files_exist(list(segy_files))
-    cfg = InferenceGatherWindowsConfig(
-        domains=('shot',),
-        secondary_sort={'shot': 'chno', 'recv': 'ffid', 'cmp': 'offset'},
-        win_size_traces=int(subset_traces),
-        stride_traces=int(stride_traces),
-        pad_last=True,
-        target_len=int(time_len),
-    )
-    return InferenceGatherWindowsDataset(
+    return GlobalAnchorCoarseRawInferDataset(
         segy_files=list(segy_files),
-        fb_files=None,
         plan=plan,
-        cfg=cfg,
-        transform=build_infer_transform(standardize_eps=float(standardize_eps)),
+        trace_len=int(trace_len),
+        time_len=int(time_len),
+        standardize_eps=float(standardize_eps),
+        gap_ratio=float(gap_ratio),
+        min_gap_m=min_gap_m,
+        primary_keys=tuple(primary_keys),
         waveform_mode=str(waveform_mode),
         segy_endian=str(segy_endian),
         use_header_cache=bool(use_header_cache),
     )
+
+
+def collate_input_meta_list(batch: Sequence[dict]) -> tuple[torch.Tensor, list[dict]]:
+    if len(batch) == 0:
+        msg = 'empty batch'
+        raise ValueError(msg)
+    xs = [item['input'] for item in batch]
+    metas = [item['meta'] for item in batch]
+    if not all(isinstance(x, torch.Tensor) for x in xs):
+        msg = "batch['input'] must be torch.Tensor"
+        raise TypeError(msg)
+    x0_shape = tuple(xs[0].shape)
+    for x in xs:
+        if tuple(x.shape) != x0_shape:
+            msg = 'all global-anchor coarse infer inputs must share shape'
+            raise ValueError(msg)
+    return torch.stack(xs, dim=0), metas

--- a/packages/seisai-engine/src/seisai_engine/pipelines/fbpick/coarse/config.py
+++ b/packages/seisai-engine/src/seisai_engine/pipelines/fbpick/coarse/config.py
@@ -128,13 +128,8 @@ class CoarseTrainInferCfg:
 
 @dataclass(frozen=True)
 class CoarseInferRuntimeCfg:
-    subset_traces: int
     batch_size: int
     num_workers: int
-    overlap_h: int
-    tile_w: int
-    overlap_w: int
-    tiles_per_batch: int
     amp: bool
     use_tqdm: bool
 
@@ -489,10 +484,9 @@ def load_coarse_infer_config(cfg: dict) -> CoarseInferConfig:
         raise TypeError(msg)
 
     infer_cfg = require_dict(cfg, 'infer')
-    subset_traces = int(require_int(infer_cfg, 'subset_traces'))
-    overlap_h = int(optional_int(infer_cfg, 'overlap_h', 96))
-    if overlap_h < 0 or overlap_h >= subset_traces:
-        msg = 'infer.overlap_h must satisfy 0 <= overlap_h < infer.subset_traces'
+    batch_size = int(optional_int(infer_cfg, 'batch_size', 1))
+    if batch_size != 1:
+        msg = 'global-anchor coarse inference currently requires infer.batch_size == 1'
         raise ValueError(msg)
 
     return CoarseInferConfig(
@@ -503,13 +497,8 @@ def load_coarse_infer_config(cfg: dict) -> CoarseInferConfig:
         trace_anchor=_load_trace_anchor_cfg(cfg),
         norm_refs=load_norm_refs_cfg(cfg),
         infer=CoarseInferRuntimeCfg(
-            subset_traces=subset_traces,
-            batch_size=int(optional_int(infer_cfg, 'batch_size', 1)),
+            batch_size=batch_size,
             num_workers=int(optional_int(infer_cfg, 'num_workers', 0)),
-            overlap_h=overlap_h,
-            tile_w=int(optional_int(infer_cfg, 'tile_w', COARSE_TIME_LEN)),
-            overlap_w=int(optional_int(infer_cfg, 'overlap_w', 1024)),
-            tiles_per_batch=int(optional_int(infer_cfg, 'tiles_per_batch', 16)),
             amp=bool(optional_bool(infer_cfg, 'amp', default=False)),
             use_tqdm=bool(optional_bool(infer_cfg, 'use_tqdm', default=False)),
         ),

--- a/packages/seisai-engine/src/seisai_engine/pipelines/fbpick/coarse/infer.py
+++ b/packages/seisai-engine/src/seisai_engine/pipelines/fbpick/coarse/infer.py
@@ -7,18 +7,28 @@ import numpy as np
 import torch
 from torch.utils.data import DataLoader
 
-from seisai_dataset import InputOnlyPlan, collate_pad_w_right
-from seisai_engine.infer.runner import TiledWConfig, iter_infer_loader_tiled_w
+from seisai_dataset import InputOnlyPlan
 from seisai_engine.pipelines.fbpick.common import (
     build_lineage_payload,
     save_coarse_npz,
 )
 
-from .build_dataset import build_raw_infer_dataset
+from .build_dataset import build_raw_infer_dataset, collate_input_meta_list
 from .build_plan import build_plan
-from .config import load_coarse_infer_config
+from .config import (
+    COARSE_IN_CHANS,
+    COARSE_INPUT_MODE_GLOBAL_ANCHOR_RESIZE,
+    COARSE_TIME_LEN,
+    COARSE_TRACE_LEN,
+    load_coarse_infer_config,
+)
+from .time_axis import project_coarse_indices_to_raw_time
 
-__all__ = ['run_coarse_infer']
+__all__ = [
+    'restore_anchor_predictions_to_full_traces',
+    'run_coarse_infer',
+    'validate_checkpoint_for_global_anchor_infer',
+]
 
 
 def _softmax_last_axis(logits_hw: np.ndarray) -> np.ndarray:
@@ -28,16 +38,210 @@ def _softmax_last_axis(logits_hw: np.ndarray) -> np.ndarray:
     return exp / denom
 
 
+def _extract_anchor_predictions(logits_hw: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
+    logits = np.asarray(logits_hw, dtype=np.float32)
+    if logits.ndim != 2:
+        msg = f'anchor logits must be 2D, got shape={logits.shape}'
+        raise ValueError(msg)
+    prob = _softmax_last_axis(logits)
+    return (
+        logits.argmax(axis=-1).astype(np.int64),
+        prob.max(axis=-1).astype(np.float32),
+    )
+
+
+def validate_checkpoint_for_global_anchor_infer(
+    ckpt: dict[str, Any],
+    *,
+    model_sig: dict[str, Any],
+) -> None:
+    if not isinstance(ckpt, dict):
+        msg = 'ckpt must be dict'
+        raise TypeError(msg)
+    if not isinstance(model_sig, dict):
+        msg = 'model_sig must be dict'
+        raise TypeError(msg)
+
+    pipeline = ckpt.get('pipeline')
+    if pipeline != 'fbpick':
+        msg = f'coarse infer checkpoint pipeline must be "fbpick", got {pipeline!r}'
+        raise ValueError(msg)
+
+    ckpt_model_sig = ckpt.get('model_sig')
+    if not isinstance(ckpt_model_sig, dict):
+        msg = 'checkpoint model_sig must be dict'
+        raise TypeError(msg)
+    for key, value in ckpt_model_sig.items():
+        if key in model_sig and model_sig[key] != value:
+            msg = (
+                f'checkpoint model_sig mismatch for {key}: '
+                f'{value!r} != {model_sig[key]!r}'
+            )
+            raise ValueError(msg)
+
+    output_ids = ckpt.get('output_ids')
+    if output_ids is not None:
+        if not isinstance(output_ids, (list, tuple)):
+            msg = 'checkpoint output_ids must be list[str] or tuple[str, ...]'
+            raise TypeError(msg)
+        if list(output_ids) != ['P']:
+            msg = (
+                'coarse infer checkpoint output_ids must be ["P"], '
+                f'got {output_ids!r}'
+            )
+            raise ValueError(msg)
+
+    softmax_axis = ckpt.get('softmax_axis')
+    if softmax_axis is not None and softmax_axis != 'time':
+        msg = (
+            'coarse infer checkpoint softmax_axis must be "time", '
+            f'got {softmax_axis!r}'
+        )
+        raise ValueError(msg)
+
+    expected_meta = {
+        'coarse_input_mode': COARSE_INPUT_MODE_GLOBAL_ANCHOR_RESIZE,
+        'coarse_trace_len': COARSE_TRACE_LEN,
+        'coarse_time_len': COARSE_TIME_LEN,
+        'coarse_in_chans': COARSE_IN_CHANS,
+    }
+    for key, expected in expected_meta.items():
+        actual = ckpt.get(key)
+        if actual != expected:
+            legacy_hint = ''
+            if key == 'coarse_input_mode' and actual is None:
+                legacy_hint = (
+                    ' This checkpoint appears to be from the legacy tiled coarse '
+                    'pipeline.'
+                )
+            msg = (
+                f'Invalid fbpick-coarse checkpoint: expected {key}={expected!r}, '
+                f'got {actual!r}.{legacy_hint}'
+            )
+            raise ValueError(msg)
+
+
+def restore_anchor_predictions_to_full_traces(
+    *,
+    raw_trace_indices: np.ndarray,
+    anchor_source_pos: np.ndarray,
+    trace_valid: np.ndarray,
+    segment_id: np.ndarray,
+    anchor_bin_start_pos: np.ndarray,
+    anchor_bin_stop_pos: np.ndarray,
+    anchor_pick_i_raw: np.ndarray,
+    anchor_pmax: np.ndarray,
+    n_samples_orig: int,
+) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    raw_indices = np.asarray(raw_trace_indices, dtype=np.int64)
+    valid = np.asarray(trace_valid, dtype=np.bool_)
+    anchor_pos = np.asarray(anchor_source_pos, dtype=np.int64)
+    seg_id = np.asarray(segment_id, dtype=np.int64)
+    bin_start = np.asarray(anchor_bin_start_pos, dtype=np.int64)
+    bin_stop = np.asarray(anchor_bin_stop_pos, dtype=np.int64)
+    pick_raw = np.asarray(anchor_pick_i_raw, dtype=np.float32)
+    pmax = np.asarray(anchor_pmax, dtype=np.float32)
+
+    h = int(valid.shape[0])
+    for name, arr in (
+        ('anchor_source_pos', anchor_pos),
+        ('segment_id', seg_id),
+        ('anchor_bin_start_pos', bin_start),
+        ('anchor_bin_stop_pos', bin_stop),
+        ('anchor_pick_i_raw', pick_raw),
+        ('anchor_pmax', pmax),
+    ):
+        if arr.shape != (h,):
+            msg = f'{name} must have shape ({h},), got {arr.shape}'
+            raise ValueError(msg)
+
+    n_samples = int(n_samples_orig)
+    if raw_indices.ndim != 1 or raw_indices.size == 0:
+        msg = 'raw_trace_indices must be a non-empty 1D array'
+        raise ValueError(msg)
+    if n_samples <= 0:
+        msg = 'n_samples_orig must be positive'
+        raise ValueError(msg)
+
+    out_raw_indices: list[np.ndarray] = []
+    out_pick_parts: list[np.ndarray] = []
+    out_pmax_parts: list[np.ndarray] = []
+
+    valid_segment_ids = sorted(int(value) for value in np.unique(seg_id[valid]))
+    for sid in valid_segment_ids:
+        mask = valid & (seg_id == sid)
+        if not np.any(mask):
+            continue
+        start = int(np.min(bin_start[mask]))
+        stop = int(np.max(bin_stop[mask]))
+        if start < 0 or stop <= start or stop > int(raw_indices.size):
+            msg = f'invalid anchor bin span for segment {sid}: [{start}, {stop})'
+            raise ValueError(msg)
+
+        raw_positions = np.arange(start, stop, dtype=np.int64)
+        anchor_positions = anchor_pos[mask].astype(np.float64, copy=False)
+        order = np.argsort(anchor_positions, kind='mergesort')
+        anchor_positions = anchor_positions[order]
+        pick_values = pick_raw[mask][order].astype(np.float64, copy=False)
+        pmax_values = pmax[mask][order].astype(np.float64, copy=False)
+
+        if anchor_positions.size == 1:
+            pick_interp = np.full(
+                raw_positions.shape,
+                float(pick_values[0]),
+                dtype=np.float64,
+            )
+            pmax_interp = np.full(
+                raw_positions.shape,
+                float(pmax_values[0]),
+                dtype=np.float64,
+            )
+        else:
+            pick_interp = np.interp(
+                raw_positions.astype(np.float64),
+                anchor_positions,
+                pick_values,
+            )
+            pmax_interp = np.interp(
+                raw_positions.astype(np.float64),
+                anchor_positions,
+                pmax_values,
+            )
+
+        out_raw_indices.append(raw_indices[raw_positions])
+        out_pick_parts.append(pick_interp.astype(np.float32, copy=False))
+        out_pmax_parts.append(pmax_interp.astype(np.float32, copy=False))
+
+    if not out_raw_indices:
+        msg = 'no valid anchor predictions to restore'
+        raise RuntimeError(msg)
+
+    restored_raw_indices = np.concatenate(out_raw_indices).astype(np.int64, copy=False)
+    restored_pick_i = np.rint(np.concatenate(out_pick_parts))
+    restored_pick_i = np.clip(restored_pick_i, 0, n_samples - 1).astype(np.int32)
+    restored_pmax = np.concatenate(out_pmax_parts).astype(np.float32, copy=False)
+    restored_pmax = np.clip(restored_pmax, 0.0, 1.0).astype(np.float32, copy=False)
+    return restored_raw_indices, restored_pick_i, restored_pmax
+
+
 def run_coarse_infer(
     *,
     model: torch.nn.Module,
     cfg: dict[str, Any],
     device: torch.device,
+    ckpt: dict[str, Any] | None = None,
     source_model_id: str | None = None,
     iter_id: int | None = None,
     repo_root: Path | None = None,
 ) -> Path:
     typed = load_coarse_infer_config(cfg)
+    if ckpt is None:
+        msg = (
+            'global-anchor coarse inference requires checkpoint metadata validation; '
+            "pass ckpt with coarse_input_mode='global_anchor_resize'"
+        )
+        raise ValueError(msg)
+    validate_checkpoint_for_global_anchor_infer(ckpt, model_sig=typed.model_sig)
     if typed.paths.fb_files is not None:
         msg = 'coarse infer expects raw-only input; omit paths.fb_files'
         raise ValueError(msg)
@@ -57,10 +261,12 @@ def run_coarse_infer(
     dataset = build_raw_infer_dataset(
         segy_files=list(typed.paths.segy_files),
         plan=input_plan,
-        subset_traces=typed.infer.subset_traces,
-        overlap_h=typed.infer.overlap_h,
+        trace_len=typed.transform.trace_len,
         time_len=typed.transform.time_len,
         standardize_eps=typed.transform.standardize_eps,
+        gap_ratio=typed.trace_anchor.gap_ratio,
+        min_gap_m=typed.trace_anchor.min_gap_m,
+        primary_keys=typed.dataset.primary_keys,
         waveform_mode=typed.dataset.waveform_mode,
         segy_endian=typed.dataset.infer_endian,
         use_header_cache=typed.dataset.use_header_cache,
@@ -72,63 +278,136 @@ def run_coarse_infer(
         shuffle=False,
         num_workers=typed.infer.num_workers,
         pin_memory=(device.type == 'cuda'),
-        collate_fn=collate_pad_w_right,
+        collate_fn=collate_input_meta_list,
     )
 
     try:
         info = dataset.file_infos[0]
         n_traces = int(info['n_traces'])
         n_samples_orig = int(info['n_samples'])
-        logits_sum = np.zeros((n_traces, n_samples_orig), dtype=np.float32)
+        coarse_pick_i = np.full((n_traces,), -1, dtype=np.int32)
+        coarse_pmax = np.full((n_traces,), np.nan, dtype=np.float32)
         counts = np.zeros((n_traces,), dtype=np.int32)
 
-        tiled_cfg = TiledWConfig(
-            tile_w=typed.infer.tile_w,
-            overlap_w=typed.infer.overlap_w,
-            tiles_per_batch=typed.infer.tiles_per_batch,
-            amp=typed.infer.amp,
-            use_tqdm=typed.infer.use_tqdm,
-        )
+        non_blocking = bool(device.type == 'cuda')
+        amp_enabled = bool(typed.infer.amp and device.type == 'cuda')
+        model.eval()
 
-        for logits_b1hw, metas in iter_infer_loader_tiled_w(
-            model,
-            loader,
-            device=device,
-            cfg=tiled_cfg,
-            output_to_cpu=True,
-        ):
-            logits_bhw = logits_b1hw[:, 0, :, :].detach().cpu().numpy()
-            for batch_idx, meta in enumerate(metas):
-                raw_idx_global = np.asarray(meta['raw_idx_global'], dtype=np.int64)
-                trace_valid = np.asarray(meta['trace_valid'], dtype=np.bool_)
-                if raw_idx_global.shape != trace_valid.shape:
-                    msg = 'raw_idx_global and trace_valid must have the same shape'
+        with torch.inference_mode():
+            for x_bchw, metas in loader:
+                expected_input_shape = (
+                    int(x_bchw.shape[0]),
+                    3,
+                    typed.transform.trace_len,
+                    typed.transform.time_len,
+                )
+                if tuple(x_bchw.shape) != expected_input_shape:
+                    msg = (
+                        'global-anchor coarse infer input must have shape '
+                        f'{expected_input_shape}, got {tuple(x_bchw.shape)}'
+                    )
+                    raise ValueError(msg)
+                x_bchw = x_bchw.to(device=device, non_blocking=non_blocking)
+                with torch.autocast(device_type=device.type, enabled=amp_enabled):
+                    logits = model(x_bchw)
+                if not isinstance(logits, torch.Tensor):
+                    msg = 'model must return torch.Tensor'
+                    raise TypeError(msg)
+                expected_logits_shape = (
+                    int(x_bchw.shape[0]),
+                    1,
+                    typed.transform.trace_len,
+                    typed.transform.time_len,
+                )
+                if tuple(logits.shape) != expected_logits_shape:
+                    msg = (
+                        'global-anchor coarse infer logits must have shape '
+                        f'{expected_logits_shape}, got {tuple(logits.shape)}'
+                    )
                     raise ValueError(msg)
 
-                for row_idx, (raw_idx, is_valid) in enumerate(
-                    zip(raw_idx_global, trace_valid, strict=True)
-                ):
-                    if not bool(is_valid):
-                        continue
-                    raw_trace_idx = int(raw_idx)
-                    if raw_trace_idx < 0 or raw_trace_idx >= n_traces:
-                        msg = f'raw trace index out of range: {raw_trace_idx}'
+                logits_bhw = (
+                    logits[:, 0, :, :]
+                    .detach()
+                    .cpu()
+                    .numpy()
+                    .astype(np.float32, copy=False)
+                )
+                for batch_idx, meta in enumerate(metas):
+                    anchor_pick_j, anchor_pmax = _extract_anchor_predictions(
+                        logits_bhw[batch_idx]
+                    )
+                    trace_valid = np.asarray(meta['trace_valid'], dtype=np.bool_)
+                    if trace_valid.shape != anchor_pick_j.shape:
+                        msg = (
+                            'trace_valid and anchor predictions must have the same '
+                            f'shape, got {trace_valid.shape} and {anchor_pick_j.shape}'
+                        )
                         raise ValueError(msg)
-                    row_logits = np.asarray(logits_bhw[batch_idx, row_idx], dtype=np.float32)
-                    if int(row_logits.shape[0]) < n_samples_orig:
-                        msg = 'inference logits width is shorter than n_samples_orig'
-                        raise ValueError(msg)
-                    logits_sum[raw_trace_idx] += row_logits[:n_samples_orig]
-                    counts[raw_trace_idx] += 1
+                    anchor_pick_j_validated = np.full(
+                        anchor_pick_j.shape,
+                        -1,
+                        dtype=np.int64,
+                    )
+                    anchor_pick_j_validated[trace_valid] = anchor_pick_j[trace_valid]
+                    anchor_pick_i_raw = project_coarse_indices_to_raw_time(
+                        anchor_pick_j_validated,
+                        raw_time_len=int(meta['raw_time_len']),
+                        coarse_time_len=int(meta['coarse_time_len']),
+                        ignore_index=-1,
+                    )
+                    restored_raw_idx, restored_pick_i, restored_pmax = (
+                        restore_anchor_predictions_to_full_traces(
+                            raw_trace_indices=np.asarray(
+                                meta['raw_trace_indices'],
+                                dtype=np.int64,
+                            ),
+                            anchor_source_pos=np.asarray(
+                                meta['anchor_source_pos'],
+                                dtype=np.int64,
+                            ),
+                            trace_valid=trace_valid,
+                            segment_id=np.asarray(meta['segment_id'], dtype=np.int64),
+                            anchor_bin_start_pos=np.asarray(
+                                meta['anchor_bin_start_pos'],
+                                dtype=np.int64,
+                            ),
+                            anchor_bin_stop_pos=np.asarray(
+                                meta['anchor_bin_stop_pos'],
+                                dtype=np.int64,
+                            ),
+                            anchor_pick_i_raw=anchor_pick_i_raw,
+                            anchor_pmax=anchor_pmax,
+                            n_samples_orig=n_samples_orig,
+                        )
+                    )
+                    for raw_idx, pick_i, pmax in zip(
+                        restored_raw_idx,
+                        restored_pick_i,
+                        restored_pmax,
+                        strict=True,
+                    ):
+                        raw_trace_idx = int(raw_idx)
+                        if raw_trace_idx < 0 or raw_trace_idx >= n_traces:
+                            msg = f'raw trace index out of range: {raw_trace_idx}'
+                            raise ValueError(msg)
+                        if counts[raw_trace_idx] > 0:
+                            msg = (
+                                'duplicate coarse prediction for raw trace '
+                                f'{raw_trace_idx}'
+                            )
+                            raise ValueError(msg)
+                        coarse_pick_i[raw_trace_idx] = int(pick_i)
+                        coarse_pmax[raw_trace_idx] = np.float32(pmax)
+                        counts[raw_trace_idx] += 1
 
         if np.any(counts <= 0):
-            msg = 'some raw traces were not covered by inference windows'
+            msg = 'some raw traces were not covered by global-anchor coarse inference'
             raise RuntimeError(msg)
 
-        avg_logits = logits_sum / counts[:, None].astype(np.float32)
-        prob = _softmax_last_axis(avg_logits)
-        coarse_pick_i = avg_logits.argmax(axis=-1).astype(np.int32)
-        coarse_pmax = prob.max(axis=-1).astype(np.float32)
+        coarse_pick_i = (
+            np.rint(coarse_pick_i).clip(0, n_samples_orig - 1).astype(np.int32)
+        )
         dt_sec = float(info['dt_sec'])
         coarse_pick_t_sec = coarse_pick_i.astype(np.float32) * np.float32(dt_sec)
 

--- a/packages/seisai-engine/tests/test_fbpick_cli.py
+++ b/packages/seisai-engine/tests/test_fbpick_cli.py
@@ -124,7 +124,7 @@ def test_run_fbpick_coarse_infer_cli_is_thin_wrapper(
     expected_out_path = tmp_path / 'coarse_out' / 'site54__synthetic.coarse.npz'
     out_path.parent.mkdir()
 
-    def _fake_run_coarse_infer(*, model, cfg, device):
+    def _fake_run_coarse_infer(*, model, cfg, device, ckpt):
         out_path.touch()
         return out_path
 
@@ -397,7 +397,7 @@ def test_run_fbpick_coarse_infer_cli_loops_over_multiple_inputs(
     ]
     out_paths[0].parent.mkdir()
 
-    def _fake_run_coarse_infer(*, model, cfg, device):
+    def _fake_run_coarse_infer(*, model, cfg, device, ckpt):
         captured_cfgs.append(cfg)
         out_path = out_paths[len(captured_cfgs) - 1]
         out_path.touch()

--- a/packages/seisai-engine/tests/test_fbpick_coarse.py
+++ b/packages/seisai-engine/tests/test_fbpick_coarse.py
@@ -12,12 +12,18 @@ from seisai_engine.pipelines.fbpick.coarse import (
     build_fbgate,
     build_labeled_infer_dataset,
     build_plan,
+    build_raw_infer_dataset,
     build_train_dataset,
+    collate_input_meta_list,
     load_coarse_infer_config,
     load_coarse_train_config,
     load_train_bundle,
     run_coarse_infer,
     run_train,
+)
+from seisai_engine.pipelines.fbpick.coarse.infer import (
+    restore_anchor_predictions_to_full_traces,
+    validate_checkpoint_for_global_anchor_infer,
 )
 from seisai_engine.pipelines.fbpick.common import COARSE_REQUIRED_KEYS, load_coarse_npz
 from seisai_engine.train_loop import train_one_epoch
@@ -558,6 +564,121 @@ def test_global_anchor_validation_dataset_is_deterministic(tmp_path: Path) -> No
     assert torch.equal(first['anchor_source_pos'], second['anchor_source_pos'])
 
 
+def test_global_anchor_raw_infer_dataset_returns_fixed_shape_without_target(
+    tmp_path: Path,
+) -> None:
+    n_traces = 128
+    n_samples = 2049
+    traces = np.stack(
+        [
+            np.linspace(-1.0, 1.0, n_samples, dtype=np.float32) + i
+            for i in range(n_traces)
+        ],
+        axis=0,
+    )
+    segy_path = str(tmp_path / 'raw_global_infer.sgy')
+    write_unstructured_segy(segy_path, traces, dt_us=2000)
+
+    ds = build_raw_infer_dataset(
+        segy_files=[segy_path],
+        plan=_make_plan(),
+        trace_len=256,
+        time_len=2048,
+        standardize_eps=1.0e-8,
+        gap_ratio=5.0,
+        min_gap_m=None,
+        primary_keys=('ffid',),
+        waveform_mode='eager',
+        segy_endian='big',
+        use_header_cache=False,
+    )
+
+    try:
+        first = ds[0]
+        second = ds[0]
+    finally:
+        ds.close()
+
+    assert tuple(first['input'].shape) == (3, 256, 2048)
+    assert 'target' not in first
+    assert tuple(first['meta']['raw_trace_indices'].shape) == (n_traces,)
+    assert tuple(first['meta']['anchor_raw_indices'].shape) == (256,)
+    assert tuple(first['meta']['anchor_source_pos'].shape) == (256,)
+    np.testing.assert_array_equal(
+        first['meta']['anchor_source_pos'],
+        second['meta']['anchor_source_pos'],
+    )
+    torch.testing.assert_close(first['input'], second['input'])
+    trace_valid = np.asarray(first['meta']['trace_valid'], dtype=np.bool_)
+    assert np.count_nonzero(trace_valid) == n_traces
+    assert not np.any(trace_valid[n_traces:])
+
+
+def test_global_anchor_raw_infer_loader_stacks_fixed_shape(tmp_path: Path) -> None:
+    n_traces = 256
+    n_samples = 2048
+    traces = np.stack(
+        [
+            np.linspace(-1.0, 1.0, n_samples, dtype=np.float32) + i
+            for i in range(n_traces)
+        ],
+        axis=0,
+    )
+    segy_path = str(tmp_path / 'raw_global_loader.sgy')
+    write_unstructured_segy(segy_path, traces, dt_us=2000)
+
+    ds = build_raw_infer_dataset(
+        segy_files=[segy_path],
+        plan=_make_plan(),
+        trace_len=256,
+        time_len=2048,
+        standardize_eps=1.0e-8,
+        gap_ratio=5.0,
+        min_gap_m=None,
+        primary_keys=('ffid',),
+        waveform_mode='eager',
+        segy_endian='big',
+        use_header_cache=False,
+    )
+
+    try:
+        loader = DataLoader(
+            ds,
+            batch_size=1,
+            shuffle=False,
+            num_workers=0,
+            collate_fn=collate_input_meta_list,
+        )
+        x_bchw, metas = next(iter(loader))
+    finally:
+        ds.close()
+
+    assert tuple(x_bchw.shape) == (1, 3, 256, 2048)
+    assert len(metas) == 1
+    assert 'raw_trace_indices' in metas[0]
+
+
+def test_restore_anchor_predictions_to_full_traces_interpolates_within_segments() -> None:
+    raw_idx, pick_i, pmax = restore_anchor_predictions_to_full_traces(
+        raw_trace_indices=np.arange(20, dtype=np.int64),
+        anchor_source_pos=np.array([0, 9, 10, 19], dtype=np.int64),
+        trace_valid=np.array([True, True, True, True], dtype=np.bool_),
+        segment_id=np.array([0, 0, 1, 1], dtype=np.int64),
+        anchor_bin_start_pos=np.array([0, 5, 10, 15], dtype=np.int64),
+        anchor_bin_stop_pos=np.array([5, 10, 15, 20], dtype=np.int64),
+        anchor_pick_i_raw=np.array([100, 190, 300, 390], dtype=np.int64),
+        anchor_pmax=np.array([0.1, 0.9, 0.2, 0.8], dtype=np.float32),
+        n_samples_orig=512,
+    )
+
+    np.testing.assert_array_equal(raw_idx, np.arange(20, dtype=np.int64))
+    assert pick_i[9] == 190
+    assert pick_i[10] == 300
+    assert pick_i[9] != pick_i[10]
+    assert pmax[9] == pytest.approx(0.9)
+    assert pmax[10] == pytest.approx(0.2)
+
+
 def test_coarse_train_smoke_one_epoch(tmp_path: Path) -> None:
     n_traces = 256
     n_samples = 6200
@@ -637,6 +758,111 @@ def test_coarse_run_train_writes_fbpick_ckpt_metadata(tmp_path: Path) -> None:
     assert ckpt['model_sig']['out_chans'] == 1
 
 
+def _make_global_anchor_ckpt() -> dict:
+    return {
+        'pipeline': 'fbpick',
+        'model_sig': {'backbone': 'resnet18', 'in_chans': 3, 'out_chans': 1},
+        'output_ids': ['P'],
+        'softmax_axis': 'time',
+        'coarse_input_mode': 'global_anchor_resize',
+        'coarse_trace_len': 256,
+        'coarse_time_len': 2048,
+        'coarse_in_chans': 3,
+    }
+
+
+def test_validate_checkpoint_for_global_anchor_infer_accepts_contract() -> None:
+    validate_checkpoint_for_global_anchor_infer(
+        _make_global_anchor_ckpt(),
+        model_sig={'backbone': 'resnet18', 'in_chans': 3, 'out_chans': 1},
+    )
+
+
+def test_validate_checkpoint_for_global_anchor_infer_rejects_legacy_metadata() -> None:
+    ckpt = _make_global_anchor_ckpt()
+    for key in (
+        'coarse_input_mode',
+        'coarse_trace_len',
+        'coarse_time_len',
+        'coarse_in_chans',
+    ):
+        ckpt.pop(key)
+
+    with pytest.raises(ValueError) as exc:
+        validate_checkpoint_for_global_anchor_infer(
+            ckpt,
+            model_sig={'backbone': 'resnet18', 'in_chans': 3, 'out_chans': 1},
+        )
+
+    assert "expected coarse_input_mode='global_anchor_resize', got None" in str(
+        exc.value
+    )
+    assert 'legacy tiled coarse pipeline' in str(exc.value)
+
+
+def test_run_coarse_infer_rejects_legacy_ckpt_before_dataset_open(
+    tmp_path: Path,
+) -> None:
+    cfg = _make_training_config(
+        tmp_path,
+        segy_path=str(tmp_path / 'missing.sgy'),
+        fb_path='unused.npy',
+    )
+    cfg['paths'].pop('fb_files')
+    cfg['infer'] = {
+        'batch_size': 1,
+        'num_workers': 0,
+        'amp': False,
+        'use_tqdm': False,
+    }
+    ckpt = _make_global_anchor_ckpt()
+    for key in (
+        'coarse_input_mode',
+        'coarse_trace_len',
+        'coarse_time_len',
+        'coarse_in_chans',
+    ):
+        ckpt.pop(key)
+
+    with pytest.raises(ValueError) as exc:
+        run_coarse_infer(
+            model=torch.nn.Conv2d(3, 1, kernel_size=1),
+            cfg=cfg,
+            device=torch.device('cpu'),
+            ckpt=ckpt,
+        )
+
+    assert "expected coarse_input_mode='global_anchor_resize', got None" in str(
+        exc.value
+    )
+
+
+def test_run_coarse_infer_requires_ckpt_before_dataset_open(
+    tmp_path: Path,
+) -> None:
+    cfg = _make_training_config(
+        tmp_path,
+        segy_path=str(tmp_path / 'missing.sgy'),
+        fb_path='unused.npy',
+    )
+    cfg['paths'].pop('fb_files')
+    cfg['infer'] = {
+        'batch_size': 1,
+        'num_workers': 0,
+        'amp': False,
+        'use_tqdm': False,
+    }
+
+    with pytest.raises(ValueError) as exc:
+        run_coarse_infer(
+            model=torch.nn.Conv2d(3, 1, kernel_size=1),
+            cfg=cfg,
+            device=torch.device('cpu'),
+        )
+
+    assert 'requires checkpoint metadata validation' in str(exc.value)
+
+
 class _TimeChannelModel(torch.nn.Module):
     out_chans = 1
 
@@ -689,13 +915,8 @@ def test_coarse_raw_only_infer_writes_npz(tmp_path: Path) -> None:
             'offset_ref_m': 2000.0,
         },
         'infer': {
-            'subset_traces': 256,
-            'batch_size': 2,
+            'batch_size': 1,
             'num_workers': 0,
-            'overlap_h': 192,
-            'tile_w': 2048,
-            'overlap_w': 1024,
-            'tiles_per_batch': 4,
             'amp': False,
             'use_tqdm': False,
         },
@@ -711,6 +932,7 @@ def test_coarse_raw_only_infer_writes_npz(tmp_path: Path) -> None:
         model=_TimeChannelModel(),
         cfg=cfg,
         device=torch.device('cpu'),
+        ckpt=_make_global_anchor_ckpt(),
         source_model_id='coarse-smoke',
         iter_id=7,
         repo_root=tmp_path,
@@ -740,3 +962,53 @@ def test_coarse_raw_only_infer_writes_npz(tmp_path: Path) -> None:
     assert lineage['source_model_id'] == 'coarse-smoke'
     assert lineage['cfg_hash']
     assert lineage['git_sha'] is None
+
+
+class _BadShapeModel(torch.nn.Module):
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return torch.zeros(
+            (int(x.shape[0]), 1, 128, int(x.shape[3])),
+            dtype=x.dtype,
+            device=x.device,
+        )
+
+
+def test_coarse_raw_only_infer_rejects_invalid_logits_shape(tmp_path: Path) -> None:
+    n_traces = 256
+    n_samples = 2048
+    traces = np.zeros((n_traces, n_samples), dtype=np.float32)
+    segy_path = str(tmp_path / 'coarse_bad_logits.sgy')
+    write_unstructured_segy(segy_path, traces, dt_us=2000)
+
+    cfg = _make_training_config(tmp_path, segy_path=segy_path, fb_path='unused.npy')
+    cfg['paths'].pop('fb_files')
+    cfg['paths']['out_dir'] = str(tmp_path / 'infer_bad_logits_out')
+    cfg['infer'] = {
+        'batch_size': 1,
+        'num_workers': 0,
+        'amp': False,
+        'use_tqdm': False,
+    }
+
+    with pytest.raises(ValueError) as exc:
+        run_coarse_infer(
+            model=_BadShapeModel(),
+            cfg=cfg,
+            device=torch.device('cpu'),
+            ckpt=_make_global_anchor_ckpt(),
+        )
+
+    assert 'global-anchor coarse infer logits must have shape' in str(exc.value)
+
+
+def test_coarse_infer_config_rejects_batch_size_greater_than_one(
+    tmp_path: Path,
+) -> None:
+    cfg = _make_training_config(tmp_path, segy_path='dummy.sgy', fb_path='dummy.npy')
+    cfg['paths'].pop('fb_files')
+    cfg['infer']['batch_size'] = 2
+
+    with pytest.raises(ValueError) as exc:
+        load_coarse_infer_config(cfg)
+
+    assert 'requires infer.batch_size == 1' in str(exc.value)


### PR DESCRIPTION
Closes #30

## Summary
- [fbpick-coarse] Replace tiled coarse inference with global-anchor inference  Issue body

## Changed files
- `cli/run_fbpick_coarse_infer.py`
- `examples/config_infer_fbpick_coarse.yaml`
- `packages/seisai-engine/src/seisai_engine/pipelines/fbpick/coarse/__init__.py`
- `packages/seisai-engine/src/seisai_engine/pipelines/fbpick/coarse/build_dataset.py`
- `packages/seisai-engine/src/seisai_engine/pipelines/fbpick/coarse/config.py`
- `packages/seisai-engine/src/seisai_engine/pipelines/fbpick/coarse/infer.py`
- `packages/seisai-engine/tests/test_fbpick_cli.py`
- `packages/seisai-engine/tests/test_fbpick_coarse.py`

## Checks
- `.work/codex/checks.log`: 761 passed, 5 warnings in 58.61s

## Review
- `.work/codex/review.txt`: accept: yes
- findings: blocker 0, major 0, minor 0
