### PR TITLE
[tests/docs] Update tests, example configs, and design documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,6 +315,7 @@ pytest -q -m integration
 
 ## ドキュメント
 
+- FBPick coarse global-anchor resize 設計: `docs/fbpick_coarse_global_anchor.md`
 - SegyGatherPipelineDataset 出力契約: `docs/spec/segy_gather_pipeline_dataset_output_contract.md`
 - SegyGatherPipelineDataset 入力前提 (SEG-Y): `docs/spec/segy_gather_pipeline_dataset_input_assumptions.md`
 - Phase pick ファイル仕様: `docs/spec/phase_pick_files_spec.md`

--- a/cli/run_fbpick_coarse_infer.py
+++ b/cli/run_fbpick_coarse_infer.py
@@ -117,6 +117,7 @@ def _validate_checkpoint_for_infer(ckpt: dict[str, Any], *, model_sig: dict[str,
         'coarse_trace_len': 256,
         'coarse_time_len': 2048,
         'coarse_in_chans': 3,
+        'coarse_input_channels': ['waveform', 'offset_ch', 'time_ch'],
     }
     for key, expected in expected_meta.items():
         actual = ckpt.get(key)

--- a/docs/develop/fbpick_codex_implementation_plan.md
+++ b/docs/develop/fbpick_codex_implementation_plan.md
@@ -1,13 +1,19 @@
-# SeisAI `fbpick` 実装計画（Codex 向け・正本）
+# SeisAI `fbpick` 実装計画（初期 v0 / historical）
 
 Version: v0.3
 Date: 2026-04-03
-Status: authoritative
+Status: historical
 
 ## 0. この文書の扱い
 
-このファイルは、`docs/develop/fbpick_codex_implementation_plan.md` の**唯一の正本**である。
-本書は、2026-04-03 時点の **P 波初動自動読み取り v0 仕様**を SeisAI モノレポ上で実装するための、Codex 向け具体指示書である。
+このファイルは初期 `fbpick` v0 実装計画の履歴である。
+`fbpick-coarse` の local-crop / tiled coarse 前提は現在の仕様ではない。
+coarse stage の正本は `docs/fbpick_coarse_global_anchor.md` であり、固定
+`global_anchor_resize` contract (`3 x 256 x 2048`) を使う。
+
+本書の physics / fine に関する背景メモは参照用として残すが、coarse の設計・
+テスト・example config を変更する場合は `docs/fbpick_coarse_global_anchor.md`
+を優先する。
 
 ---
 

--- a/docs/fbpick_coarse_global_anchor.md
+++ b/docs/fbpick_coarse_global_anchor.md
@@ -1,0 +1,184 @@
+# FBPick Coarse Global-Anchor Resize Design
+
+This document is the current contract for `fbpick-coarse`. It supersedes the
+legacy local-crop / tiled-coarse design for the coarse stage.
+
+## Purpose
+
+`fbpick-coarse` gives a global first-break location estimate for each trace. It
+is not the final sample-level picker. The coarse output is the large-scale
+search center used by the downstream physics / robustification and fine stages.
+
+The primary coarse evaluation question is whether the restored coarse pick falls
+inside the later fine-stage search window, not whether it is already the final
+sample-accurate answer.
+
+## Input Contract
+
+Global-anchor coarse uses a fixed model input:
+
+- input mode: `global_anchor_resize`
+- input shape: `(3, 256, 2048)`
+- target shape: `(1, 256, 2048)`
+- logits shape: `(B, 1, 256, 2048)`
+
+Input channels are ordered as:
+
+1. `waveform`
+2. `offset_ch`
+3. `time_ch`
+
+`offset_ch` is built from anchor offsets and normalized by
+`NormalizeOffsetByConst`. `time_ch` is built from the raw seconds grid and
+normalized by `NormalizeTimeByConst`.
+
+## Train / Validation Flow
+
+Training and validation both start from the full gather:
+
+1. `draw_full_gather`
+2. split by offset gaps
+3. choose trace anchors inside each segment
+4. resample the full raw time axis to 2048 samples
+5. build a fixed `3 x 256 x 2048` input and `1 x 256 x 2048` target
+
+Training uses `trace_anchor.train_mode: random`. Validation uses
+`trace_anchor.infer_mode: center`, so validation samples are deterministic.
+
+If a gather has fewer than 256 usable anchor rows, the remaining rows are pad
+rows. Pad rows are marked invalid by `trace_valid`, have ignored first-break
+indices, and must not contribute to target labels or restored predictions.
+
+## Raw Inference Flow
+
+Raw inference does not use the legacy tiled window dataset or W-tiling helpers.
+The flow is:
+
+1. load one full raw gather
+2. split by offset gaps
+3. choose deterministic center anchors
+4. build the fixed `3 x 256 x 2048` input
+5. run the model once per gather item
+6. project anchor predictions from coarse sample coordinates to raw samples
+7. restore segment-wise predictions to original trace coordinates
+8. write `.coarse.npz`
+
+Current raw inference requires `infer.batch_size == 1` because metadata is
+restored per full gather item.
+
+## Offset Gap Handling
+
+Offset gaps split traces into independent segments. Anchor bins are allocated
+inside segments, and an anchor bin must not cross a gap.
+
+For example:
+
+```python
+offsets = [0, 10, 20, 30, 1000, 1010, 1020]
+segments = [(0, 4), (4, 7)]
+```
+
+Prediction restoration interpolates only within each segment. No interpolation
+or confidence propagation is allowed across offset gaps.
+
+## Time Axis And Time Channel
+
+The coarse time grid is endpoint-aligned between original SEG-Y samples and the
+2048-sample coarse axis:
+
+- raw sample `0` maps to coarse sample `0`
+- raw sample `raw_time_len - 1` maps to coarse sample `2047`
+- coarse sample `0` maps to raw sample `0`
+- coarse sample `2047` maps to raw sample `raw_time_len - 1`
+
+For `raw_time_len = 6016`, this means:
+
+- raw `0 -> coarse 0`
+- raw `6015 -> coarse 2047`
+- coarse `0 -> raw 0`
+- coarse `2047 -> raw 6015`
+
+`time_view_sec` is the raw seconds grid after endpoint-aligned resampling.
+`build_time_channel` / `MakeTimeChannel` only broadcasts this raw seconds grid
+over trace rows; it does not normalize time.
+
+Time normalization is performed by `NormalizeTimeByConst` in the BuildPlan:
+
+```text
+time_ch = clip(time_view_sec / time_ref_sec, 0.0, 1.5)
+```
+
+Do not normalize by `time_view_sec[-1]`; each gather's final sample must not be
+forced to `1.0`.
+
+## `.coarse.npz` Contract
+
+Although model predictions are internal `256 x 2048` coarse-grid predictions,
+saved `.coarse.npz` fields are restored to original SEG-Y coordinates.
+
+Required coarse fields include:
+
+- `coarse_pick_i`: original SEG-Y sample index, shape `(n_traces,)`
+- `coarse_pick_t_sec`: `coarse_pick_i * dt_sec`, shape `(n_traces,)`
+- `coarse_pmax`: trace-wise confidence, shape `(n_traces,)`
+
+The payload also carries trace/sample metadata such as `dt_sec`,
+`n_samples_orig`, `n_traces`, `trace_indices`, `ffid_values`, `chno_values`, and
+`offsets_m`.
+
+Physics and fine stages consume the restored original-coordinate schema and do
+not need schema changes for global-anchor coarse.
+
+## Checkpoint Compatibility
+
+Global-anchor coarse checkpoints must carry:
+
+- `coarse_input_mode == "global_anchor_resize"`
+- `coarse_trace_len == 256`
+- `coarse_time_len == 2048`
+- `coarse_in_chans == 3`
+- `coarse_input_channels == ["waveform", "offset_ch", "time_ch"]`
+
+Raw inference validates the global-anchor metadata and rejects missing metadata,
+legacy tiled checkpoints, and shape/channel mismatches.
+
+## Migration From Legacy Tiled Coarse
+
+Before:
+
+- local crop / tiled inference
+- H-window plus W-tile inference
+- arbitrary input width handled by tiling
+- coarse raw inference used fields such as `tile_w`, `overlap_w`, and
+  `tiles_per_batch`
+
+After:
+
+- full gather context
+- gap-aware anchor selection
+- fixed `3 x 256 x 2048` input
+- deterministic center anchors for validation and raw inference
+- segment-wise restoration to original trace/sample coordinates
+
+Old tiled coarse checkpoints are not compatible. Raw global-anchor inference no
+longer uses `InferenceGatherWindowsDataset`, `collate_pad_w_right`,
+`TiledWConfig`, `iter_infer_loader_tiled_w`, `tile_w`, `overlap_w`, or
+`tiles_per_batch`.
+
+## Evaluation Recommendations
+
+Recommended coarse metrics:
+
+- P50 / P90 / P95 absolute error
+- coverage within the fine-window half width
+- gap-neighborhood error
+- trace-wise failure rate
+
+The key coverage check is:
+
+```text
+abs(coarse_pick_i - fb_i) <= fine_window_half
+```
+
+Use this coverage as the primary coarse-stage regression metric when evaluating
+whether the coarse output is good enough for physics / fine refinement.

--- a/examples/config_infer_fbpick_coarse.yaml
+++ b/examples/config_infer_fbpick_coarse.yaml
@@ -23,6 +23,7 @@ transform:
 trace_anchor:
   gap_ratio: 5.0
   min_gap_m: null
+  # Required by the shared coarse schema; raw inference uses infer_mode only.
   train_mode: random
   infer_mode: center
 

--- a/examples/config_train_fbpick_coarse.yaml
+++ b/examples/config_train_fbpick_coarse.yaml
@@ -3,6 +3,10 @@ paths:
     - REPLACE_ME_train_coarse.sgy
   fb_files:
     - REPLACE_ME_train_coarse_fb.npy
+  infer_segy_files:
+    - REPLACE_ME_valid_coarse.sgy
+  infer_fb_files:
+    - REPLACE_ME_valid_coarse_fb.npy
   out_dir: ./_fbpick_coarse_train_out
 
 coarse:
@@ -42,6 +46,8 @@ train:
   use_amp: false
   lr: 1.0e-3
   weight_decay: 0.0
+  # Global-anchor coarse is fixed to transform.trace_len (=256).
+  # This is retained for the shared train schema; it is not a local crop size.
   subset_traces: 256
   fb_sigma_ms: 10.0
 
@@ -50,6 +56,7 @@ infer:
   batch_size: 1
   num_workers: 0
   max_batches: 8
+  # Validation uses deterministic center anchors with the same fixed trace_len.
   subset_traces: 256
 
 vis:

--- a/packages/seisai-engine/src/seisai_engine/pipelines/fbpick/coarse/infer.py
+++ b/packages/seisai-engine/src/seisai_engine/pipelines/fbpick/coarse/infer.py
@@ -17,6 +17,7 @@ from .build_dataset import build_raw_infer_dataset, collate_input_meta_list
 from .build_plan import build_plan
 from .config import (
     COARSE_IN_CHANS,
+    COARSE_INPUT_CHANNELS,
     COARSE_INPUT_MODE_GLOBAL_ANCHOR_RESIZE,
     COARSE_TIME_LEN,
     COARSE_TRACE_LEN,
@@ -105,6 +106,7 @@ def validate_checkpoint_for_global_anchor_infer(
         'coarse_trace_len': COARSE_TRACE_LEN,
         'coarse_time_len': COARSE_TIME_LEN,
         'coarse_in_chans': COARSE_IN_CHANS,
+        'coarse_input_channels': list(COARSE_INPUT_CHANNELS),
     }
     for key, expected in expected_meta.items():
         actual = ckpt.get(key)

--- a/packages/seisai-engine/tests/test_fbpick_cli.py
+++ b/packages/seisai-engine/tests/test_fbpick_cli.py
@@ -204,6 +204,7 @@ def test_run_fbpick_coarse_infer_accepts_global_anchor_ckpt_metadata(
         'coarse_trace_len': 256,
         'coarse_time_len': 2048,
         'coarse_in_chans': 3,
+        'coarse_input_channels': ['waveform', 'offset_ch', 'time_ch'],
     }
 
     module._validate_checkpoint_for_infer(

--- a/packages/seisai-engine/tests/test_fbpick_coarse.py
+++ b/packages/seisai-engine/tests/test_fbpick_coarse.py
@@ -460,6 +460,81 @@ def test_build_train_bundle_uses_train_and_infer_endian_for_dataset_builders(
     assert bundle.ds_train_full is not bundle.ds_infer_full
 
 
+def test_global_anchor_labeled_datasets_draw_full_gather_before_anchor_selection(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    n_traces = 300
+    n_samples = 2048
+    traces = np.stack(
+        [
+            np.linspace(-1.0, 1.0, n_samples, dtype=np.float32) + i
+            for i in range(n_traces)
+        ],
+        axis=0,
+    )
+    segy_path = str(tmp_path / 'global_labeled_full_gather.sgy')
+    write_unstructured_segy(segy_path, traces, dt_us=2000)
+    fb = np.full((n_traces,), 1000, dtype=np.int64)
+    fb_path = str(tmp_path / 'global_labeled_full_gather_fb.npy')
+    np.save(fb_path, fb)
+
+    common = {
+        'segy_files': [segy_path],
+        'fb_files': [fb_path],
+        'sampling_overrides': None,
+        'plan': _make_plan(),
+        'fbgate': build_fbgate(apply_on='off', min_pick_ratio=0.0, verbose=False),
+        'subset_traces': 256,
+        'trace_len': 256,
+        'time_len': 2048,
+        'standardize_eps': 1.0e-8,
+        'gap_ratio': 5.0,
+        'min_gap_m': None,
+        'primary_keys': ('ffid',),
+        'secondary_key_fixed': False,
+        'verbose': False,
+        'progress': False,
+        'max_trials': 8,
+        'use_header_cache': False,
+        'waveform_mode': 'eager',
+        'segy_endian': 'big',
+    }
+    train_ds = build_train_dataset(
+        **common,
+        anchor_mode='random',
+        trace_decimate_prob=0.0,
+        trace_decimate_stride_range=(1, 1),
+    )
+    infer_ds = build_labeled_infer_dataset(**common, anchor_mode='center')
+
+    try:
+        for ds in (train_ds, infer_ds):
+            seen: list[np.ndarray] = []
+            original = ds.sampler.draw_full_gather
+
+            def wrapped_draw_full_gather(info, *args, **kwargs):
+                sample = original(info, *args, **kwargs)
+                seen.append(np.asarray(sample['indices'], dtype=np.int64).copy())
+                return sample
+
+            monkeypatch.setattr(ds.sampler, 'draw_full_gather', wrapped_draw_full_gather)
+            ds._rng = np.random.default_rng(0)
+            sample = ds[0]
+
+            assert tuple(sample['input'].shape) == (3, 256, 2048)
+            assert tuple(sample['target'].shape) == (1, 256, 2048)
+            assert len(seen) == 1
+            np.testing.assert_array_equal(
+                seen[0],
+                np.arange(n_traces, dtype=np.int64),
+            )
+            assert tuple(sample['anchor_raw_indices'].shape) == (256,)
+    finally:
+        train_ds.close()
+        infer_ds.close()
+
+
 def test_global_anchor_train_dataset_uses_random_anchors(tmp_path: Path) -> None:
     n_traces = 512
     n_samples = 2049
@@ -685,6 +760,32 @@ def test_restore_anchor_predictions_to_full_traces_interpolates_within_segments(
     assert pmax[10] == pytest.approx(0.2)
 
 
+def test_restore_anchor_predictions_to_full_traces_does_not_interpolate_across_gap() -> None:
+    pick_i, pmax = restore_anchor_predictions_to_full_traces(
+        anchor_pick_i_raw=np.array([100, 400, 1000, 1600], dtype=np.int64),
+        anchor_pmax=np.array([0.1, 0.4, 0.8, 0.2], dtype=np.float32),
+        trace_valid=np.array([True, True, True, True], dtype=np.bool_),
+        anchor_source_pos=np.array([0, 3, 4, 6], dtype=np.int64),
+        segment_id=np.array([0, 0, 1, 1], dtype=np.int64),
+        segments=(
+            TraceSegment(segment_id=0, start_pos=0, stop_pos=4, n_traces=4),
+            TraceSegment(segment_id=1, start_pos=4, stop_pos=7, n_traces=3),
+        ),
+        n_traces=7,
+        n_samples_orig=2048,
+    )
+
+    np.testing.assert_array_equal(
+        pick_i,
+        np.asarray([100, 200, 300, 400, 1000, 1300, 1600], dtype=np.int32),
+    )
+    np.testing.assert_allclose(
+        pmax,
+        np.asarray([0.1, 0.2, 0.3, 0.4, 0.8, 0.5, 0.2], dtype=np.float32),
+        atol=1.0e-6,
+    )
+
+
 def test_restore_anchor_predictions_to_full_traces_fills_single_anchor_segment() -> None:
     pick_i, pmax = restore_anchor_predictions_to_full_traces(
         anchor_pick_i_raw=np.array([150, -1, -1, -1], dtype=np.int64),
@@ -862,6 +963,7 @@ def _make_global_anchor_ckpt() -> dict:
         'coarse_trace_len': 256,
         'coarse_time_len': 2048,
         'coarse_in_chans': 3,
+        'coarse_input_channels': ['waveform', 'offset_ch', 'time_ch'],
     }
 
 
@@ -869,6 +971,57 @@ def test_validate_checkpoint_for_global_anchor_infer_accepts_contract() -> None:
     validate_checkpoint_for_global_anchor_infer(
         _make_global_anchor_ckpt(),
         model_sig={'backbone': 'resnet18', 'in_chans': 3, 'out_chans': 1},
+    )
+
+
+@pytest.mark.parametrize(
+    ('key', 'value', 'message'),
+    [
+        (
+            'coarse_input_mode',
+            'legacy_tiled',
+            "expected coarse_input_mode='global_anchor_resize'",
+        ),
+        ('coarse_trace_len', 128, 'expected coarse_trace_len=256'),
+        ('coarse_time_len', 6016, 'expected coarse_time_len=2048'),
+        ('coarse_in_chans', 1, 'expected coarse_in_chans=3'),
+        (
+            'coarse_input_channels',
+            ['waveform', 'time_ch', 'offset_ch'],
+            "expected coarse_input_channels=['waveform', 'offset_ch', 'time_ch']",
+        ),
+    ],
+)
+def test_validate_checkpoint_for_global_anchor_infer_rejects_metadata_mismatch(
+    key: str,
+    value: object,
+    message: str,
+) -> None:
+    ckpt = _make_global_anchor_ckpt()
+    ckpt[key] = value
+
+    with pytest.raises(ValueError) as exc:
+        validate_checkpoint_for_global_anchor_infer(
+            ckpt,
+            model_sig={'backbone': 'resnet18', 'in_chans': 3, 'out_chans': 1},
+        )
+
+    assert message in str(exc.value)
+
+
+def test_validate_checkpoint_for_global_anchor_infer_rejects_missing_input_channels() -> None:
+    ckpt = _make_global_anchor_ckpt()
+    ckpt.pop('coarse_input_channels')
+
+    with pytest.raises(ValueError) as exc:
+        validate_checkpoint_for_global_anchor_infer(
+            ckpt,
+            model_sig={'backbone': 'resnet18', 'in_chans': 3, 'out_chans': 1},
+        )
+
+    assert (
+        "expected coarse_input_channels=['waveform', 'offset_ch', 'time_ch'], got None"
+        in str(exc.value)
     )
 
 
@@ -1065,6 +1218,72 @@ class _BadShapeModel(torch.nn.Module):
             dtype=x.dtype,
             device=x.device,
         )
+
+
+class _CaptureInputShapeModel(torch.nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.seen_shapes: list[tuple[int, ...]] = []
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        self.seen_shapes.append(tuple(int(v) for v in x.shape))
+        return torch.zeros(
+            (int(x.shape[0]), 1, int(x.shape[2]), int(x.shape[3])),
+            dtype=x.dtype,
+            device=x.device,
+        )
+
+
+def test_coarse_raw_only_infer_does_not_call_tiled_inference_utilities(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import seisai_dataset.infer_window_dataset as infer_window_dataset
+    import seisai_engine.infer.runner as infer_runner
+
+    def fail_if_called(*args, **kwargs):
+        _ = (args, kwargs)
+        raise AssertionError('legacy tiled coarse inference utility was called')
+
+    for name in (
+        'InferenceGatherWindowsDataset',
+        'collate_pad_w_right',
+    ):
+        monkeypatch.setattr(infer_window_dataset, name, fail_if_called)
+    for name in (
+        'TiledWConfig',
+        'infer_batch_tiled_w',
+        'iter_infer_loader_tiled_w',
+        'run_infer_loader_tiled_w',
+    ):
+        monkeypatch.setattr(infer_runner, name, fail_if_called)
+
+    n_traces = 256
+    n_samples = 2048
+    traces = np.zeros((n_traces, n_samples), dtype=np.float32)
+    segy_path = str(tmp_path / 'coarse_no_tiled.sgy')
+    write_unstructured_segy(segy_path, traces, dt_us=2000)
+
+    cfg = _make_training_config(tmp_path, segy_path=segy_path, fb_path='unused.npy')
+    cfg['paths'].pop('fb_files')
+    cfg['paths']['out_dir'] = str(tmp_path / 'infer_no_tiled_out')
+    cfg['infer'] = {
+        'batch_size': 1,
+        'num_workers': 0,
+        'amp': False,
+        'use_tqdm': False,
+    }
+    model = _CaptureInputShapeModel()
+
+    out_path = run_coarse_infer(
+        model=model,
+        cfg=cfg,
+        device=torch.device('cpu'),
+        ckpt=_make_global_anchor_ckpt(),
+    )
+
+    assert out_path.is_file()
+    assert model.seen_shapes == [(1, 3, 256, 2048)]
 
 
 def test_coarse_raw_only_infer_rejects_invalid_logits_shape(tmp_path: Path) -> None:

--- a/packages/seisai-engine/tests/test_fbpick_coarse_time_axis.py
+++ b/packages/seisai-engine/tests/test_fbpick_coarse_time_axis.py
@@ -47,6 +47,16 @@ def test_project_fb_indices_to_coarse_time_preserves_ignore_and_endpoints() -> N
     )
 
 
+def test_project_fb_indices_to_coarse_time_maps_fbpick_endpoints() -> None:
+    projected = project_fb_indices_to_coarse_time(
+        np.asarray([0, 6015], dtype=np.int64),
+        raw_time_len=6016,
+        coarse_time_len=2048,
+    )
+
+    np.testing.assert_array_equal(projected, np.asarray([0, 2047], dtype=np.int64))
+
+
 def test_project_coarse_indices_to_raw_time_preserves_ignore_and_endpoints() -> None:
     coarse = np.asarray([0, 3, 5, -1], dtype=np.int64)
 

--- a/packages/seisai-engine/tests/test_fbpick_trace_anchor.py
+++ b/packages/seisai-engine/tests/test_fbpick_trace_anchor.py
@@ -26,6 +26,18 @@ def test_split_trace_segments_by_offset_gap_detects_large_jumps() -> None:
     assert [s.n_anchor_rows for s in segments] == [0, 0, 0]
 
 
+def test_split_trace_segments_by_offset_gap_matches_fbpick_gap_example() -> None:
+    offsets = np.asarray([0, 10, 20, 30, 1000, 1010, 1020], dtype=np.float32)
+
+    segments = split_trace_segments_by_offset_gap(
+        offsets,
+        gap_ratio=5.0,
+        min_gap_m=None,
+    )
+
+    assert [(s.start_pos, s.stop_pos) for s in segments] == [(0, 4), (4, 7)]
+
+
 def test_split_trace_segments_by_offset_gap_keeps_flat_offsets_together() -> None:
     segments = split_trace_segments_by_offset_gap(
         np.zeros(4, dtype=np.float32),
@@ -109,6 +121,44 @@ def test_select_trace_anchors_center_mode_never_bins_across_gap() -> None:
             strict=True,
         )
     )
+
+
+def test_select_trace_anchors_random_mode_stays_inside_gap_segments() -> None:
+    raw_indices = np.arange(7, dtype=np.int64)
+    offsets = np.asarray([0, 10, 20, 30, 1000, 1010, 1020], dtype=np.float32)
+
+    selection = select_trace_anchors(
+        raw_indices,
+        offsets,
+        4,
+        'random',
+        gap_ratio=5.0,
+        min_gap_m=None,
+        rng=np.random.default_rng(0),
+    )
+
+    assert [s.n_anchor_rows for s in selection.segments] == [2, 2]
+    np.testing.assert_array_equal(selection.segment_id, np.asarray([0, 0, 1, 1]))
+    assert selection.anchor_bin_start_pos is not None
+    assert selection.anchor_bin_stop_pos is not None
+    assert all(
+        0 <= start < stop <= 4
+        for start, stop in zip(
+            selection.anchor_bin_start_pos[:2],
+            selection.anchor_bin_stop_pos[:2],
+            strict=True,
+        )
+    )
+    assert all(
+        4 <= start < stop <= 7
+        for start, stop in zip(
+            selection.anchor_bin_start_pos[2:],
+            selection.anchor_bin_stop_pos[2:],
+            strict=True,
+        )
+    )
+    assert np.all(selection.anchor_source_pos[:2] < 4)
+    assert np.all(selection.anchor_source_pos[2:] >= 4)
 
 
 def test_select_trace_anchors_prefers_long_segments_when_there_are_too_many() -> None:


### PR DESCRIPTION
Closes #34

## Summary
- [tests/docs] Update tests, example configs, and design documentation

## Changed files
- `README.md`
- `cli/run_fbpick_coarse_infer.py`
- `docs/develop/fbpick_codex_implementation_plan.md`
- `docs/fbpick_coarse_global_anchor.md`
- `examples/config_infer_fbpick_coarse.yaml`
- `examples/config_train_fbpick_coarse.yaml`
- `packages/seisai-engine/src/seisai_engine/pipelines/fbpick/coarse/infer.py`
- `packages/seisai-engine/tests/test_fbpick_cli.py`
- `packages/seisai-engine/tests/test_fbpick_coarse.py`
- `packages/seisai-engine/tests/test_fbpick_coarse_time_axis.py`
- `packages/seisai-engine/tests/test_fbpick_trace_anchor.py`

## Checks
- `.work/codex/checks.log`: 779 passed, 5 warnings in 61.41s (0:01:01)

## Review
- `.work/codex/review.txt`: accept: yes
- findings: blocker 0, major 0, minor 0
