### PR TITLE
[fbpick-coarse] Tighten global-anchor infer config validation and checkpoint validation reuse

### DIFF
--- a/cli/run_fbpick_coarse_infer.py
+++ b/cli/run_fbpick_coarse_infer.py
@@ -23,7 +23,10 @@ def _load_runtime() -> SimpleNamespace:
     )
     from seisai_engine.pipelines.fbpick.coarse.build_model import build_model
     from seisai_engine.pipelines.fbpick.coarse.config import load_coarse_infer_config
-    from seisai_engine.pipelines.fbpick.coarse.infer import run_coarse_infer
+    from seisai_engine.pipelines.fbpick.coarse.infer import (
+        run_coarse_infer,
+        validate_checkpoint_for_global_anchor_infer,
+    )
 
     return SimpleNamespace(
         expand_cfg_listfiles=expand_cfg_listfiles,
@@ -35,6 +38,9 @@ def _load_runtime() -> SimpleNamespace:
         build_model=build_model,
         load_coarse_infer_config=load_coarse_infer_config,
         run_coarse_infer=run_coarse_infer,
+        validate_checkpoint_for_global_anchor_infer=(
+            validate_checkpoint_for_global_anchor_infer
+        ),
     )
 
 
@@ -81,58 +87,6 @@ def _resolve_ckpt_path(cfg: dict[str, Any]) -> Path:
         msg = f'checkpoint not found: {path}'
         raise FileNotFoundError(msg)
     return path
-
-
-def _validate_checkpoint_for_infer(ckpt: dict[str, Any], *, model_sig: dict[str, Any]) -> None:
-    pipeline = ckpt.get('pipeline')
-    if pipeline != 'fbpick':
-        msg = f'coarse infer checkpoint pipeline must be "fbpick", got {pipeline!r}'
-        raise ValueError(msg)
-
-    ckpt_model_sig = ckpt.get('model_sig')
-    if not isinstance(ckpt_model_sig, dict):
-        msg = 'checkpoint model_sig must be dict'
-        raise TypeError(msg)
-    for key, value in ckpt_model_sig.items():
-        if key in model_sig and model_sig[key] != value:
-            msg = f'checkpoint model_sig mismatch for {key}: {value!r} != {model_sig[key]!r}'
-            raise ValueError(msg)
-
-    output_ids = ckpt.get('output_ids')
-    if output_ids is not None:
-        if not isinstance(output_ids, (list, tuple)):
-            msg = 'checkpoint output_ids must be list[str] or tuple[str, ...]'
-            raise TypeError(msg)
-        if list(output_ids) != ['P']:
-            msg = f'coarse infer checkpoint output_ids must be ["P"], got {output_ids!r}'
-            raise ValueError(msg)
-
-    softmax_axis = ckpt.get('softmax_axis')
-    if softmax_axis is not None and softmax_axis != 'time':
-        msg = f'coarse infer checkpoint softmax_axis must be "time", got {softmax_axis!r}'
-        raise ValueError(msg)
-
-    expected_meta = {
-        'coarse_input_mode': 'global_anchor_resize',
-        'coarse_trace_len': 256,
-        'coarse_time_len': 2048,
-        'coarse_in_chans': 3,
-        'coarse_input_channels': ['waveform', 'offset_ch', 'time_ch'],
-    }
-    for key, expected in expected_meta.items():
-        actual = ckpt.get(key)
-        if actual != expected:
-            legacy_hint = ''
-            if key == 'coarse_input_mode' and actual is None:
-                legacy_hint = (
-                    ' This checkpoint appears to be from the legacy tiled coarse '
-                    'pipeline.'
-                )
-            msg = (
-                f'Invalid fbpick-coarse checkpoint: expected {key}={expected!r}, '
-                f'got {actual!r}.{legacy_hint}'
-            )
-            raise ValueError(msg)
 
 
 def _build_out_path(*, segy_path: str | Path, out_dir: str | Path) -> Path:
@@ -184,7 +138,10 @@ def run_pipeline(config_path: str | Path) -> Path:
     device = _resolve_cli_device(prepared, runtime=runtime)
 
     ckpt = runtime.load_checkpoint(ckpt_path)
-    _validate_checkpoint_for_infer(ckpt, model_sig=typed.model_sig)
+    runtime.validate_checkpoint_for_global_anchor_infer(
+        ckpt,
+        model_sig=typed.model_sig,
+    )
 
     model = runtime.build_model(dict(typed.model_sig))
     state_dict, _ = runtime.select_state_dict(ckpt)

--- a/docs/fbpick_coarse_global_anchor.md
+++ b/docs/fbpick_coarse_global_anchor.md
@@ -66,6 +66,10 @@ The flow is:
 Current raw inference requires `infer.batch_size == 1` because metadata is
 restored per full gather item.
 
+Raw global-anchor coarse inference currently requires exactly one
+`dataset.primary_keys` entry. Use `primary_keys: [ffid]` as the recommended
+default unless the input SEG-Y line is keyed by another single trace header.
+
 ## Offset Gap Handling
 
 Offset gaps split traces into independent segments. Anchor bins are allocated

--- a/examples/config_infer_fbpick_coarse.yaml
+++ b/examples/config_infer_fbpick_coarse.yaml
@@ -10,6 +10,7 @@ dataset:
   use_header_cache: true
   verbose: true
   progress: true
+  # Raw global-anchor coarse inference currently supports exactly one key.
   primary_keys: [ffid]
   waveform_mode: eager
   train_endian: big

--- a/packages/seisai-engine/src/seisai_engine/pipelines/fbpick/coarse/config.py
+++ b/packages/seisai-engine/src/seisai_engine/pipelines/fbpick/coarse/config.py
@@ -67,6 +67,13 @@ INFER_PAIR_MESSAGE = (
     'paths.infer_segy_files and paths.infer_fb_files must be provided together, '
     'or omit both to reuse the training segy/fb pairs'
 )
+LEGACY_TILED_INFER_KEYS = (
+    'subset_traces',
+    'overlap_h',
+    'tile_w',
+    'overlap_w',
+    'tiles_per_batch',
+)
 
 
 @dataclass(frozen=True)
@@ -484,15 +491,30 @@ def load_coarse_infer_config(cfg: dict) -> CoarseInferConfig:
         raise TypeError(msg)
 
     infer_cfg = require_dict(cfg, 'infer')
+    legacy_keys = [key for key in LEGACY_TILED_INFER_KEYS if key in infer_cfg]
+    if legacy_keys:
+        msg = (
+            'fbpick-coarse global-anchor inference does not use legacy tiled '
+            f'infer keys: {legacy_keys!r}'
+        )
+        raise ValueError(msg)
+
     batch_size = int(optional_int(infer_cfg, 'batch_size', 1))
     if batch_size != 1:
         msg = 'global-anchor coarse inference currently requires infer.batch_size == 1'
+        raise ValueError(msg)
+    dataset = _load_dataset_cfg(cfg)
+    if len(dataset.primary_keys) != 1:
+        msg = (
+            'global-anchor coarse raw inference requires exactly one '
+            'dataset.primary_keys entry'
+        )
         raise ValueError(msg)
 
     return CoarseInferConfig(
         coarse=_load_coarse_mode_cfg(cfg),
         paths=_load_paths_cfg(cfg, allow_missing_infer_pairs=True),
-        dataset=_load_dataset_cfg(cfg),
+        dataset=dataset,
         transform=_load_transform_cfg(cfg),
         trace_anchor=_load_trace_anchor_cfg(cfg),
         norm_refs=load_norm_refs_cfg(cfg),

--- a/packages/seisai-engine/tests/test_fbpick_cli.py
+++ b/packages/seisai-engine/tests/test_fbpick_cli.py
@@ -123,10 +123,19 @@ def test_run_fbpick_coarse_infer_cli_is_thin_wrapper(
     out_path = tmp_path / 'coarse_out' / 'synthetic.coarse.npz'
     expected_out_path = tmp_path / 'coarse_out' / 'site54__synthetic.coarse.npz'
     out_path.parent.mkdir()
+    ckpt = {
+        'pipeline': 'fbpick',
+        'model_sig': {'backbone': 'resnet18', 'in_chans': 3, 'out_chans': 1},
+    }
+    validated: dict[str, object] = {}
 
     def _fake_run_coarse_infer(*, model, cfg, device, ckpt):
         out_path.touch()
         return out_path
+
+    def _fake_validate_checkpoint(ckpt, *, model_sig) -> None:
+        validated['ckpt'] = ckpt
+        validated['model_sig'] = model_sig
 
     runtime = SimpleNamespace(
         load_cfg_with_base_dir=lambda path: (
@@ -141,76 +150,36 @@ def test_run_fbpick_coarse_infer_cli_is_thin_wrapper(
         load_coarse_infer_config=lambda cfg: SimpleNamespace(
             model_sig={'backbone': 'resnet18', 'in_chans': 3, 'out_chans': 1}
         ),
-        load_checkpoint=lambda path: {
-            'pipeline': 'fbpick',
-            'model_sig': {'backbone': 'resnet18', 'in_chans': 3, 'out_chans': 1},
-        },
+        load_checkpoint=lambda path: ckpt,
         resolve_device=lambda device_raw: 'cpu',
         build_model=lambda model_sig: model,
         select_state_dict=lambda ckpt: ({'weight': 1}, False),
         run_coarse_infer=_fake_run_coarse_infer,
+        validate_checkpoint_for_global_anchor_infer=_fake_validate_checkpoint,
     )
     monkeypatch.setattr(module, '_load_runtime', lambda: runtime)
     monkeypatch.setattr(module, '_resolve_ckpt_path', lambda cfg: tmp_path / 'dummy.pt')
-    monkeypatch.setattr(
-        module,
-        '_validate_checkpoint_for_infer',
-        lambda ckpt, *, model_sig: None,
-    )
 
     result = module.run_pipeline(cfg_path)
 
     assert result == expected_out_path
     assert model.loaded_state_dict == {'weight': 1}
     assert model.device == 'cpu'
+    assert validated == {
+        'ckpt': ckpt,
+        'model_sig': {'backbone': 'resnet18', 'in_chans': 3, 'out_chans': 1},
+    }
     assert not out_path.exists()
     assert expected_out_path.exists()
     assert capsys.readouterr().out.strip() == str(expected_out_path)
 
 
-def test_run_fbpick_coarse_infer_rejects_legacy_ckpt_metadata(
+def test_run_fbpick_coarse_infer_has_no_local_checkpoint_validator(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     module = _load_cli_module('run_fbpick_coarse_infer.py', monkeypatch)
-    ckpt = {
-        'pipeline': 'fbpick',
-        'model_sig': {'backbone': 'resnet18', 'in_chans': 3, 'out_chans': 1},
-        'output_ids': ['P'],
-        'softmax_axis': 'time',
-    }
 
-    with pytest.raises(ValueError) as exc:
-        module._validate_checkpoint_for_infer(
-            ckpt,
-            model_sig={'backbone': 'resnet18', 'in_chans': 3, 'out_chans': 1},
-        )
-
-    assert "expected coarse_input_mode='global_anchor_resize', got None" in str(
-        exc.value
-    )
-    assert 'legacy tiled coarse pipeline' in str(exc.value)
-
-
-def test_run_fbpick_coarse_infer_accepts_global_anchor_ckpt_metadata(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    module = _load_cli_module('run_fbpick_coarse_infer.py', monkeypatch)
-    ckpt = {
-        'pipeline': 'fbpick',
-        'model_sig': {'backbone': 'resnet18', 'in_chans': 3, 'out_chans': 1},
-        'output_ids': ['P'],
-        'softmax_axis': 'time',
-        'coarse_input_mode': 'global_anchor_resize',
-        'coarse_trace_len': 256,
-        'coarse_time_len': 2048,
-        'coarse_in_chans': 3,
-        'coarse_input_channels': ['waveform', 'offset_ch', 'time_ch'],
-    }
-
-    module._validate_checkpoint_for_infer(
-        ckpt,
-        model_sig={'backbone': 'resnet18', 'in_chans': 3, 'out_chans': 1},
-    )
+    assert not hasattr(module, '_validate_checkpoint_for_infer')
 
 
 def test_run_fbpick_physics_cli_is_thin_wrapper(
@@ -428,14 +397,12 @@ def test_run_fbpick_coarse_infer_cli_loops_over_multiple_inputs(
         build_model=lambda model_sig: model,
         select_state_dict=lambda ckpt: ({'weight': 1}, False),
         run_coarse_infer=_fake_run_coarse_infer,
+        validate_checkpoint_for_global_anchor_infer=(
+            lambda ckpt, *, model_sig: None
+        ),
     )
     monkeypatch.setattr(module, '_load_runtime', lambda: runtime)
     monkeypatch.setattr(module, '_resolve_ckpt_path', lambda cfg: tmp_path / 'dummy.pt')
-    monkeypatch.setattr(
-        module,
-        '_validate_checkpoint_for_infer',
-        lambda ckpt, *, model_sig: None,
-    )
 
     result = module.run_pipeline(cfg_path)
 

--- a/packages/seisai-engine/tests/test_fbpick_coarse.py
+++ b/packages/seisai-engine/tests/test_fbpick_coarse.py
@@ -144,6 +144,15 @@ def _make_training_config(tmp_path: Path, *, segy_path: str, fb_path: str) -> di
     }
 
 
+def _use_raw_infer_runtime_cfg(cfg: dict) -> None:
+    cfg['infer'] = {
+        'batch_size': 1,
+        'num_workers': 0,
+        'amp': False,
+        'use_tqdm': False,
+    }
+
+
 def test_load_coarse_train_config_returns_fixed_contract_values(
     tmp_path: Path,
 ) -> None:
@@ -213,11 +222,23 @@ def test_load_coarse_train_config_uses_explicit_infer_pairs(
     assert typed.paths.infer_fb_files == ('valid.npy',)
 
 
+def test_load_coarse_train_config_allows_multiple_primary_keys(
+    tmp_path: Path,
+) -> None:
+    cfg = _make_training_config(tmp_path, segy_path='train.sgy', fb_path='train.npy')
+    cfg['dataset']['primary_keys'] = ['ffid', 'cmp']
+
+    typed = load_coarse_train_config(cfg)
+
+    assert typed.dataset.primary_keys == ('ffid', 'cmp')
+
+
 def test_load_coarse_infer_config_returns_global_anchor_contract(
     tmp_path: Path,
 ) -> None:
     cfg = _make_training_config(tmp_path, segy_path='dummy.sgy', fb_path='dummy.npy')
     cfg['paths'].pop('fb_files')
+    _use_raw_infer_runtime_cfg(cfg)
 
     typed = load_coarse_infer_config(cfg)
 
@@ -226,7 +247,42 @@ def test_load_coarse_infer_config_returns_global_anchor_contract(
     assert typed.transform.time_len == 2048
     assert typed.trace_anchor.gap_ratio == pytest.approx(5.0)
     assert typed.trace_anchor.infer_mode == 'center'
+    assert typed.dataset.primary_keys == ('ffid',)
     assert typed.model_sig['in_chans'] == 3
+
+
+@pytest.mark.parametrize(
+    'legacy_key',
+    ['subset_traces', 'overlap_h', 'tile_w', 'overlap_w', 'tiles_per_batch'],
+)
+def test_load_coarse_infer_config_rejects_legacy_tiled_keys(
+    tmp_path: Path,
+    legacy_key: str,
+) -> None:
+    cfg = _make_training_config(tmp_path, segy_path='dummy.sgy', fb_path='dummy.npy')
+    cfg['paths'].pop('fb_files')
+    _use_raw_infer_runtime_cfg(cfg)
+    cfg['infer'][legacy_key] = 123
+
+    with pytest.raises(ValueError) as exc:
+        load_coarse_infer_config(cfg)
+
+    assert 'legacy tiled infer keys' in str(exc.value)
+    assert legacy_key in str(exc.value)
+
+
+def test_load_coarse_infer_config_rejects_multiple_primary_keys(
+    tmp_path: Path,
+) -> None:
+    cfg = _make_training_config(tmp_path, segy_path='dummy.sgy', fb_path='dummy.npy')
+    cfg['paths'].pop('fb_files')
+    _use_raw_infer_runtime_cfg(cfg)
+    cfg['dataset']['primary_keys'] = ['ffid', 'cmp']
+
+    with pytest.raises(ValueError) as exc:
+        load_coarse_infer_config(cfg)
+
+    assert 'requires exactly one dataset.primary_keys' in str(exc.value)
 
 
 @pytest.mark.parametrize(
@@ -1319,6 +1375,7 @@ def test_coarse_infer_config_rejects_batch_size_greater_than_one(
 ) -> None:
     cfg = _make_training_config(tmp_path, segy_path='dummy.sgy', fb_path='dummy.npy')
     cfg['paths'].pop('fb_files')
+    _use_raw_infer_runtime_cfg(cfg)
     cfg['infer']['batch_size'] = 2
 
     with pytest.raises(ValueError) as exc:


### PR DESCRIPTION
Closes #36

## Summary
- [fbpick-coarse] Tighten global-anchor infer config validation and checkpoint validation reuse

## Changed files
- `cli/run_fbpick_coarse_infer.py`
- `docs/fbpick_coarse_global_anchor.md`
- `examples/config_infer_fbpick_coarse.yaml`
- `packages/seisai-engine/src/seisai_engine/pipelines/fbpick/coarse/config.py`
- `packages/seisai-engine/tests/test_fbpick_cli.py`
- `packages/seisai-engine/tests/test_fbpick_coarse.py`

## Checks
- `.work/codex/checks.log`: 785 passed, 5 warnings in 62.08s (0:01:02)

## Review
- `.work/codex/review.txt`: accept: yes
- findings: blocker 0, major 0, minor 0
