### PR TITLE
[fbpick-coarse] Add QC visualization for global-anchor coarse predictions

### DIFF
--- a/examples/config_infer_fbpick_coarse.yaml
+++ b/examples/config_infer_fbpick_coarse.yaml
@@ -40,6 +40,19 @@ infer:
   amp: false
   use_tqdm: false
 
+qc:
+  enabled: false
+  max_gathers: 16
+  out_subdir: vis/coarse_global_anchor
+  plot_anchor_grid: true
+  plot_original_gather: true
+  plot_confidence: true
+  plot_error_if_labels_available: true
+  fine_window_half_samples: 128
+  max_display_traces: 512
+  max_display_samples: 4096
+  low_confidence_threshold: null
+
 model:
   backbone: resnet18
   pretrained: false

--- a/packages/seisai-engine/src/seisai_engine/pipelines/fbpick/coarse/__init__.py
+++ b/packages/seisai-engine/src/seisai_engine/pipelines/fbpick/coarse/__init__.py
@@ -17,6 +17,7 @@ from .config import (
     COARSE_TRACE_LEN,
     CoarseInferConfig,
     CoarseModeCfg,
+    CoarseQCCfg,
     CoarseTraceAnchorCfg,
     CoarseTrainConfig,
     load_coarse_infer_config,
@@ -29,6 +30,13 @@ from .infer import (
     validate_checkpoint_for_global_anchor_infer,
 )
 from .loss import build_criterion
+from .qc import (
+    plot_anchor_grid_qc,
+    plot_confidence_qc,
+    plot_error_qc,
+    plot_original_gather_qc,
+    write_global_anchor_coarse_qc,
+)
 from .time_axis import (
     CoarseTimeGrid,
     build_coarse_fb_labels_for_anchors,
@@ -61,6 +69,7 @@ __all__ = [
     'COARSE_TRACE_LEN',
     'CoarseInferConfig',
     'CoarseModeCfg',
+    'CoarseQCCfg',
     'CoarseTimeGrid',
     'CoarseTraceAnchorCfg',
     'CoarseTrainBundle',
@@ -86,6 +95,10 @@ __all__ = [
     'load_coarse_train_config',
     'load_train_bundle',
     'load_train_spec',
+    'plot_anchor_grid_qc',
+    'plot_confidence_qc',
+    'plot_error_qc',
+    'plot_original_gather_qc',
     'project_coarse_indices_to_raw_time',
     'project_fb_indices_to_coarse_time',
     'resample_waveform_time_axis',
@@ -96,4 +109,5 @@ __all__ = [
     'split_trace_segments_by_offset_gap',
     'validate_coarse_npz_payload',
     'validate_checkpoint_for_global_anchor_infer',
+    'write_global_anchor_coarse_qc',
 ]

--- a/packages/seisai-engine/src/seisai_engine/pipelines/fbpick/coarse/config.py
+++ b/packages/seisai-engine/src/seisai_engine/pipelines/fbpick/coarse/config.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import math
 from dataclasses import dataclass
+from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from seisai_utils.config import (
@@ -45,6 +46,7 @@ __all__ = [
     'CoarseInferRuntimeCfg',
     'CoarseModeCfg',
     'CoarsePaths',
+    'CoarseQCCfg',
     'CoarseTraceAnchorCfg',
     'CoarseTrainCfg',
     'CoarseTrainConfig',
@@ -135,6 +137,23 @@ class CoarseInferRuntimeCfg:
 
 
 @dataclass(frozen=True)
+class CoarseQCCfg:
+    enabled: bool
+    max_gathers: int
+    out_subdir: str
+    plot_anchor_grid: bool
+    plot_original_gather: bool
+    plot_confidence: bool
+    plot_error_if_labels_available: bool
+    fine_window_half_samples: int
+    max_display_traces: int
+    max_display_samples: int
+    low_confidence_threshold: float | None
+    dpi: int
+    clip_percentile: float
+
+
+@dataclass(frozen=True)
 class CoarseCkptCfg:
     save_best_only: bool
     metric: str
@@ -167,6 +186,7 @@ class CoarseInferConfig:
     trace_anchor: CoarseTraceAnchorCfg
     norm_refs: FBPickNormRefs
     infer: CoarseInferRuntimeCfg
+    qc: CoarseQCCfg
     model_sig: dict[str, Any]
 
 
@@ -417,6 +437,102 @@ def _load_model_sig(cfg: dict) -> dict[str, Any]:
     return build_encdec2d_kwargs(model_cfg, in_chans=in_chans, out_chans=out_chans)
 
 
+def _load_qc_cfg(cfg: dict) -> CoarseQCCfg:
+    raw = cfg.get('qc')
+    if raw is None:
+        qc_cfg: dict = {}
+    else:
+        if not isinstance(raw, dict):
+            msg = 'config.qc must be dict'
+            raise TypeError(msg)
+        qc_cfg = raw
+
+    max_gathers = int(optional_int(qc_cfg, 'max_gathers', 16))
+    if max_gathers < 0:
+        msg = 'qc.max_gathers must be >= 0'
+        raise ValueError(msg)
+
+    fine_window_half_samples = int(
+        optional_int(qc_cfg, 'fine_window_half_samples', 128)
+    )
+    if fine_window_half_samples < 0:
+        msg = 'qc.fine_window_half_samples must be >= 0'
+        raise ValueError(msg)
+
+    max_display_traces = int(optional_int(qc_cfg, 'max_display_traces', 512))
+    if max_display_traces <= 0:
+        msg = 'qc.max_display_traces must be > 0'
+        raise ValueError(msg)
+
+    max_display_samples = int(optional_int(qc_cfg, 'max_display_samples', 4096))
+    if max_display_samples <= 0:
+        msg = 'qc.max_display_samples must be > 0'
+        raise ValueError(msg)
+
+    low_confidence_threshold_raw = qc_cfg.get('low_confidence_threshold')
+    if low_confidence_threshold_raw is None:
+        low_confidence_threshold = None
+    else:
+        if isinstance(low_confidence_threshold_raw, bool) or not isinstance(
+            low_confidence_threshold_raw,
+            (int, float),
+        ):
+            msg = 'config.qc.low_confidence_threshold must be float or null'
+            raise TypeError(msg)
+        low_confidence_threshold = float(low_confidence_threshold_raw)
+        if (
+            not math.isfinite(low_confidence_threshold)
+            or low_confidence_threshold < 0.0
+            or low_confidence_threshold > 1.0
+        ):
+            msg = 'qc.low_confidence_threshold must lie in [0, 1]'
+            raise ValueError(msg)
+
+    dpi = int(optional_int(qc_cfg, 'dpi', 150))
+    if dpi <= 0:
+        msg = 'qc.dpi must be > 0'
+        raise ValueError(msg)
+
+    clip_percentile = float(optional_float(qc_cfg, 'clip_percentile', 99.0))
+    if (
+        not math.isfinite(clip_percentile)
+        or clip_percentile <= 0.0
+        or clip_percentile > 100.0
+    ):
+        msg = 'qc.clip_percentile must lie in (0, 100]'
+        raise ValueError(msg)
+
+    out_subdir = str(optional_str(qc_cfg, 'out_subdir', 'vis/coarse_global_anchor'))
+    if not out_subdir.strip():
+        msg = 'qc.out_subdir must be non-empty'
+        raise ValueError(msg)
+    if Path(out_subdir).is_absolute():
+        msg = 'qc.out_subdir must be relative to paths.out_dir'
+        raise ValueError(msg)
+
+    return CoarseQCCfg(
+        enabled=bool(optional_bool(qc_cfg, 'enabled', default=False)),
+        max_gathers=max_gathers,
+        out_subdir=out_subdir,
+        plot_anchor_grid=bool(
+            optional_bool(qc_cfg, 'plot_anchor_grid', default=True)
+        ),
+        plot_original_gather=bool(
+            optional_bool(qc_cfg, 'plot_original_gather', default=True)
+        ),
+        plot_confidence=bool(optional_bool(qc_cfg, 'plot_confidence', default=True)),
+        plot_error_if_labels_available=bool(
+            optional_bool(qc_cfg, 'plot_error_if_labels_available', default=True)
+        ),
+        fine_window_half_samples=fine_window_half_samples,
+        max_display_traces=max_display_traces,
+        max_display_samples=max_display_samples,
+        low_confidence_threshold=low_confidence_threshold,
+        dpi=dpi,
+        clip_percentile=clip_percentile,
+    )
+
+
 def load_coarse_train_config(cfg: dict) -> CoarseTrainConfig:
     if not isinstance(cfg, dict):
         msg = 'cfg must be dict'
@@ -525,5 +641,6 @@ def load_coarse_infer_config(cfg: dict) -> CoarseInferConfig:
             amp=bool(optional_bool(infer_cfg, 'amp', default=False)),
             use_tqdm=bool(optional_bool(infer_cfg, 'use_tqdm', default=False)),
         ),
+        qc=_load_qc_cfg(cfg),
         model_sig=_load_model_sig(cfg),
     )

--- a/packages/seisai-engine/src/seisai_engine/pipelines/fbpick/coarse/infer.py
+++ b/packages/seisai-engine/src/seisai_engine/pipelines/fbpick/coarse/infer.py
@@ -5,6 +5,8 @@ from typing import Any
 
 import numpy as np
 import torch
+from seisai_dataset.config import LoaderConfig
+from seisai_dataset.trace_subset_preproc import TraceSubsetLoader
 from torch.utils.data import DataLoader
 
 from seisai_dataset import InputOnlyPlan
@@ -19,10 +21,13 @@ from .config import (
     COARSE_IN_CHANS,
     COARSE_INPUT_CHANNELS,
     COARSE_INPUT_MODE_GLOBAL_ANCHOR_RESIZE,
+    CoarseInferConfig,
+    CoarseQCCfg,
     COARSE_TIME_LEN,
     COARSE_TRACE_LEN,
     load_coarse_infer_config,
 )
+from .qc import select_display_indices, write_global_anchor_coarse_qc
 from .time_axis import project_coarse_indices_to_raw_time
 
 __all__ = [
@@ -335,6 +340,63 @@ def validate_coarse_npz_payload(
         raise ValueError(msg)
 
 
+def _make_qc_gather_id(meta: dict[str, Any]) -> str:
+    source = Path(str(meta.get('source_file') or meta.get('file_path') or 'gather'))
+    parent = source.parent.name
+    prefix = f'{parent}__{source.stem}' if parent else source.stem
+    key_name = str(meta.get('key_name', 'key'))
+    primary_value = meta.get('primary_value', meta.get('primary_unique', '0'))
+    return f'{prefix}__{key_name}-{primary_value}'
+
+
+def _load_qc_label_picks(
+    typed: CoarseInferConfig,
+    *,
+    n_traces: int,
+) -> np.ndarray | None:
+    if not typed.qc.enabled or not typed.qc.plot_error_if_labels_available:
+        return None
+    if typed.paths.infer_fb_files is None:
+        return None
+    if len(typed.paths.infer_fb_files) != 1:
+        msg = 'qc labels require exactly one paths.infer_fb_files entry'
+        raise ValueError(msg)
+    labels = np.asarray(np.load(typed.paths.infer_fb_files[0]), dtype=np.int64)
+    if labels.ndim != 1 or int(labels.shape[0]) != int(n_traces):
+        msg = (
+            'qc labels must be a 1D first-break array with length n_traces, '
+            f'got shape={labels.shape}, n_traces={int(n_traces)}'
+        )
+        raise ValueError(msg)
+    return labels
+
+
+def _load_qc_raw_wave_display(
+    *,
+    info: dict[str, Any],
+    raw_trace_indices: np.ndarray,
+    qc: CoarseQCCfg,
+) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    trace_positions = select_display_indices(
+        int(raw_trace_indices.size),
+        int(qc.max_display_traces),
+    )
+    raw_indices_display = np.asarray(raw_trace_indices, dtype=np.int64)[
+        trace_positions
+    ]
+    loader = TraceSubsetLoader(LoaderConfig(pad_traces_to=1))
+    wave = loader.load_traces(info['mmap'], raw_indices_display)
+    sample_indices = select_display_indices(
+        int(wave.shape[1]),
+        int(qc.max_display_samples),
+    )
+    return (
+        np.ascontiguousarray(wave[:, sample_indices], dtype=np.float32),
+        trace_positions.astype(np.int64, copy=False),
+        sample_indices.astype(np.int64, copy=False),
+    )
+
+
 def run_coarse_infer(
     *,
     model: torch.nn.Module,
@@ -392,6 +454,10 @@ def run_coarse_infer(
         collate_fn=collate_input_meta_list,
     )
 
+    out_dir = Path(typed.paths.out_dir).expanduser().resolve()
+    qc_out_dir = out_dir / typed.qc.out_subdir
+    qc_count = 0
+
     try:
         info = dataset.file_infos[0]
         n_traces = int(info['n_traces'])
@@ -399,6 +465,7 @@ def run_coarse_infer(
         coarse_pick_i = np.full((n_traces,), -1, dtype=np.int32)
         coarse_pmax = np.full((n_traces,), np.nan, dtype=np.float32)
         counts = np.zeros((n_traces,), dtype=np.int32)
+        qc_label_pick_i = _load_qc_label_picks(typed, n_traces=n_traces)
 
         non_blocking = bool(device.type == 'cuda')
         amp_enabled = bool(typed.infer.amp and device.type == 'cuda')
@@ -418,6 +485,9 @@ def run_coarse_infer(
                         f'{expected_input_shape}, got {tuple(x_bchw.shape)}'
                     )
                     raise ValueError(msg)
+                qc_input_bchw = None
+                if typed.qc.enabled and qc_count < int(typed.qc.max_gathers):
+                    qc_input_bchw = x_bchw.detach().cpu()
                 x_bchw = x_bchw.to(device=device, non_blocking=non_blocking)
                 with torch.autocast(device_type=device.type, enabled=amp_enabled):
                     logits = model(x_bchw)
@@ -489,6 +559,47 @@ def run_coarse_infer(
                             n_samples_orig=n_samples_orig,
                         )
                     )
+                    if typed.qc.enabled and qc_count < int(typed.qc.max_gathers):
+                        if qc_input_bchw is None:
+                            msg = 'qc input tensor was not captured'
+                            raise RuntimeError(msg)
+                        raw_wave_hw = None
+                        raw_trace_positions = None
+                        raw_sample_indices = None
+                        if typed.qc.plot_original_gather:
+                            file_idx = int(meta.get('file_idx', 0))
+                            raw_wave_hw, raw_trace_positions, raw_sample_indices = (
+                                _load_qc_raw_wave_display(
+                                    info=dataset.file_infos[file_idx],
+                                    raw_trace_indices=raw_trace_indices,
+                                    qc=typed.qc,
+                                )
+                            )
+                        fb_pick_i = None
+                        if qc_label_pick_i is not None:
+                            fb_pick_i = qc_label_pick_i[raw_trace_indices]
+                        write_global_anchor_coarse_qc(
+                            out_dir=qc_out_dir,
+                            gather_id=_make_qc_gather_id(meta),
+                            input_waveform_hw=qc_input_bchw[batch_idx, 0]
+                            .numpy()
+                            .astype(np.float32, copy=False),
+                            anchor_pick_j=anchor_pick_j_validated,
+                            anchor_pmax=anchor_pmax,
+                            trace_valid=trace_valid,
+                            segment_id=np.asarray(meta['segment_id'], dtype=np.int64),
+                            segments=meta.get('segments'),
+                            coarse_pick_i=restored_pick_i,
+                            coarse_pmax=restored_pmax,
+                            raw_wave_hw=raw_wave_hw,
+                            raw_trace_positions=raw_trace_positions,
+                            raw_sample_indices=raw_sample_indices,
+                            fb_pick_i=fb_pick_i,
+                            n_samples_orig=int(meta['n_samples_orig']),
+                            dt_sec=float(meta['dt_sec']),
+                            cfg=typed.qc,
+                        )
+                        qc_count += 1
                     for raw_idx, pick_i, pmax in zip(
                         raw_trace_indices,
                         restored_pick_i,
@@ -527,7 +638,6 @@ def run_coarse_infer(
             n_samples_orig=n_samples_orig,
         )
 
-        out_dir = Path(typed.paths.out_dir).expanduser().resolve()
         stem = Path(typed.paths.segy_files[0]).stem
         out_path = out_dir / f'{stem}.coarse.npz'
         return save_coarse_npz(

--- a/packages/seisai-engine/src/seisai_engine/pipelines/fbpick/coarse/qc.py
+++ b/packages/seisai-engine/src/seisai_engine/pipelines/fbpick/coarse/qc.py
@@ -1,0 +1,547 @@
+from __future__ import annotations
+
+import re
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+
+import numpy as np
+
+from .config import CoarseQCCfg
+
+__all__ = [
+    'plot_anchor_grid_qc',
+    'plot_confidence_qc',
+    'plot_error_qc',
+    'plot_original_gather_qc',
+    'select_display_indices',
+    'write_global_anchor_coarse_qc',
+]
+
+_SAFE_ID_PATTERN = re.compile(r'[^A-Za-z0-9_.-]+')
+
+
+def _sanitize_id(value: str) -> str:
+    token = _SAFE_ID_PATTERN.sub('-', str(value).strip()).strip('-')
+    return token or 'gather'
+
+
+def select_display_indices(length: int, max_count: int) -> np.ndarray:
+    n = int(length)
+    limit = int(max_count)
+    if n <= 0:
+        msg = 'length must be positive'
+        raise ValueError(msg)
+    if limit <= 0:
+        msg = 'max_count must be positive'
+        raise ValueError(msg)
+    if n <= limit:
+        return np.arange(n, dtype=np.int64)
+    return np.unique(
+        np.linspace(0, n - 1, limit, dtype=np.float64).round().astype(np.int64)
+    )
+
+
+def _as_2d_float(name: str, value: np.ndarray) -> np.ndarray:
+    arr = np.ascontiguousarray(np.asarray(value, dtype=np.float32))
+    if arr.ndim != 2:
+        msg = f'{name} must be 2D, got shape={arr.shape}'
+        raise ValueError(msg)
+    if arr.shape[0] <= 0 or arr.shape[1] <= 0:
+        msg = f'{name} must be non-empty'
+        raise ValueError(msg)
+    return arr
+
+
+def _as_vector(name: str, value: np.ndarray, *, length: int | None = None) -> np.ndarray:
+    arr = np.asarray(value)
+    if arr.ndim != 1:
+        msg = f'{name} must be 1D, got shape={arr.shape}'
+        raise ValueError(msg)
+    if length is not None and int(arr.shape[0]) != int(length):
+        msg = f'{name} length {int(arr.shape[0])} != {int(length)}'
+        raise ValueError(msg)
+    return arr
+
+
+def _resolve_clip(wave_hw: np.ndarray, *, clip_percentile: float) -> float:
+    percentile = float(clip_percentile)
+    if percentile <= 0.0 or percentile > 100.0:
+        msg = 'clip_percentile must lie in (0, 100]'
+        raise ValueError(msg)
+    finite_abs = np.abs(np.asarray(wave_hw, dtype=np.float32))
+    finite_abs = finite_abs[np.isfinite(finite_abs)]
+    if finite_abs.size == 0:
+        return 1.0
+    clip_value = float(np.percentile(finite_abs, percentile))
+    if np.isfinite(clip_value) and clip_value > 0.0:
+        return clip_value
+    max_value = float(np.max(finite_abs))
+    if np.isfinite(max_value) and max_value > 0.0:
+        return max_value
+    return 1.0
+
+
+def _coerce_segment_spans(segments: Sequence[object] | None) -> list[tuple[int, int]]:
+    if segments is None:
+        return []
+    spans: list[tuple[int, int]] = []
+    for segment in segments:
+        if isinstance(segment, Mapping):
+            start = int(segment['start_pos'])
+            stop = int(segment['stop_pos'])
+        else:
+            start = int(getattr(segment, 'start_pos'))
+            stop = int(getattr(segment, 'stop_pos'))
+        if stop <= start:
+            msg = f'invalid segment span: [{start}, {stop})'
+            raise ValueError(msg)
+        spans.append((start, stop))
+    return spans
+
+
+def _draw_segment_boundaries(ax, segments: Sequence[object] | None) -> None:
+    spans = _coerce_segment_spans(segments)
+    for start, _stop in spans[1:]:
+        ax.axvline(float(start) - 0.5, color='orange', lw=0.9, ls='--', alpha=0.8)
+
+
+def _mask_runs(mask: np.ndarray) -> list[tuple[int, int]]:
+    values = np.asarray(mask, dtype=np.bool_)
+    runs: list[tuple[int, int]] = []
+    start: int | None = None
+    for idx, flag in enumerate(values.tolist()):
+        if flag and start is None:
+            start = int(idx)
+        elif not flag and start is not None:
+            runs.append((start, int(idx)))
+            start = None
+    if start is not None:
+        runs.append((start, int(values.size)))
+    return runs
+
+
+def _save_and_close(fig, out_png: str | Path, *, dpi: int) -> Path:
+    import matplotlib.pyplot as plt
+
+    out_path = Path(out_png).expanduser().resolve()
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    fig.tight_layout()
+    fig.savefig(out_path, dpi=int(dpi))
+    plt.close(fig)
+    return out_path
+
+
+def plot_anchor_grid_qc(
+    out_png: str | Path,
+    *,
+    input_waveform_hw: np.ndarray,
+    anchor_pick_j: np.ndarray,
+    anchor_pmax: np.ndarray,
+    trace_valid: np.ndarray,
+    segment_id: np.ndarray | None = None,
+    title: str | None = None,
+    dpi: int = 150,
+    clip_percentile: float = 99.0,
+) -> Path:
+    import matplotlib.pyplot as plt
+
+    wave = _as_2d_float('input_waveform_hw', input_waveform_hw)
+    h, w = wave.shape
+    pick = _as_vector('anchor_pick_j', anchor_pick_j, length=h).astype(np.float32)
+    pmax = _as_vector('anchor_pmax', anchor_pmax, length=h).astype(np.float32)
+    valid = _as_vector('trace_valid', trace_valid, length=h).astype(np.bool_)
+    if segment_id is not None:
+        seg_id = _as_vector('segment_id', segment_id, length=h).astype(np.int64)
+    else:
+        seg_id = None
+
+    finite_pick = np.isfinite(pick)
+    plot_mask = valid & finite_pick & (pick >= 0.0) & (pick < float(w))
+    rows = np.arange(h, dtype=np.float32)
+    clip_value = _resolve_clip(wave, clip_percentile=clip_percentile)
+
+    fig, ax = plt.subplots(figsize=(12.0, 6.0))
+    ax.imshow(
+        wave,
+        cmap='gray',
+        aspect='auto',
+        interpolation='nearest',
+        origin='upper',
+        vmin=-clip_value,
+        vmax=clip_value,
+    )
+    for start, stop in _mask_runs(~valid):
+        ax.axhspan(
+            float(start) - 0.5,
+            float(stop) - 0.5,
+            color='red',
+            alpha=0.12,
+            lw=0.0,
+        )
+
+    if np.any(plot_mask):
+        ax.plot(
+            pick[plot_mask],
+            rows[plot_mask],
+            color='#00d7ff',
+            lw=1.0,
+            alpha=0.85,
+            label='anchor_pick_j',
+        )
+        scatter = ax.scatter(
+            pick[plot_mask],
+            rows[plot_mask],
+            c=np.clip(pmax[plot_mask], 0.0, 1.0),
+            cmap='viridis',
+            s=14.0,
+            vmin=0.0,
+            vmax=1.0,
+            alpha=0.95,
+            label='anchor_pmax',
+            zorder=4,
+        )
+        fig.colorbar(scatter, ax=ax, fraction=0.025, pad=0.01, label='pmax')
+
+    if seg_id is not None and np.any(valid):
+        valid_rows = np.flatnonzero(valid)
+        valid_seg = seg_id[valid_rows]
+        change_at = np.flatnonzero(valid_seg[1:] != valid_seg[:-1]) + 1
+        for change in change_at.tolist():
+            row = int(valid_rows[int(change)])
+            ax.axhline(float(row) - 0.5, color='orange', lw=0.9, ls='--', alpha=0.8)
+
+    ax.set_xlim(-0.5, float(w) - 0.5)
+    ax.set_ylim(float(h) - 0.5, -0.5)
+    ax.set_xlabel('Coarse Time Index')
+    ax.set_ylabel('Anchor Row')
+    ax.set_title('anchor grid QC' if title is None else str(title))
+    if np.any(plot_mask):
+        ax.legend(loc='upper right', fontsize=8)
+    return _save_and_close(fig, out_png, dpi=dpi)
+
+
+def plot_original_gather_qc(
+    out_png: str | Path,
+    *,
+    raw_wave_hw: np.ndarray,
+    coarse_pick_i: np.ndarray,
+    coarse_pmax: np.ndarray | None = None,
+    fb_pick_i: np.ndarray | None = None,
+    trace_positions: np.ndarray | None = None,
+    sample_indices: np.ndarray | None = None,
+    segments: Sequence[object] | None = None,
+    title: str | None = None,
+    dpi: int = 150,
+    clip_percentile: float = 99.0,
+) -> Path:
+    import matplotlib.pyplot as plt
+
+    wave = _as_2d_float('raw_wave_hw', raw_wave_hw)
+    h_disp, w_disp = wave.shape
+    pick = _as_vector('coarse_pick_i', coarse_pick_i).astype(np.float32)
+    n_traces = int(pick.shape[0])
+    if coarse_pmax is not None:
+        pmax = _as_vector('coarse_pmax', coarse_pmax, length=n_traces).astype(
+            np.float32
+        )
+    else:
+        pmax = None
+    if fb_pick_i is not None:
+        fb = _as_vector('fb_pick_i', fb_pick_i, length=n_traces).astype(np.float32)
+    else:
+        fb = None
+
+    if trace_positions is None:
+        trace_pos = np.arange(h_disp, dtype=np.float32)
+    else:
+        trace_pos = _as_vector(
+            'trace_positions',
+            trace_positions,
+            length=h_disp,
+        ).astype(np.float32)
+    if sample_indices is None:
+        sample_pos = np.arange(w_disp, dtype=np.float32)
+    else:
+        sample_pos = _as_vector(
+            'sample_indices',
+            sample_indices,
+            length=w_disp,
+        ).astype(np.float32)
+    if not np.all(np.diff(trace_pos) >= 0.0):
+        msg = 'trace_positions must be sorted'
+        raise ValueError(msg)
+    if not np.all(np.diff(sample_pos) >= 0.0):
+        msg = 'sample_indices must be sorted'
+        raise ValueError(msg)
+
+    clip_value = _resolve_clip(wave, clip_percentile=clip_percentile)
+    fig_width = max(10.0, min(18.0, float(n_traces) / 32.0))
+    fig, ax = plt.subplots(figsize=(fig_width, 7.0))
+    ax.imshow(
+        wave.T,
+        cmap='gray',
+        aspect='auto',
+        interpolation='nearest',
+        origin='upper',
+        extent=(
+            float(trace_pos[0]) - 0.5,
+            float(trace_pos[-1]) + 0.5,
+            float(sample_pos[-1]) + 0.5,
+            float(sample_pos[0]) - 0.5,
+        ),
+        vmin=-clip_value,
+        vmax=clip_value,
+    )
+
+    x = np.arange(n_traces, dtype=np.float32)
+    finite_pick = np.isfinite(pick)
+    ax.plot(
+        x[finite_pick],
+        pick[finite_pick],
+        color='#00d7ff',
+        lw=1.0,
+        alpha=0.9,
+        label='coarse_pick_i',
+    )
+    if pmax is not None and np.any(finite_pick):
+        scatter = ax.scatter(
+            x[finite_pick],
+            pick[finite_pick],
+            c=np.clip(pmax[finite_pick], 0.0, 1.0),
+            cmap='viridis',
+            s=12.0,
+            vmin=0.0,
+            vmax=1.0,
+            alpha=0.9,
+            label='coarse_pmax',
+            zorder=4,
+        )
+        fig.colorbar(scatter, ax=ax, fraction=0.025, pad=0.01, label='pmax')
+    if fb is not None:
+        valid_fb = np.isfinite(fb) & (fb >= 0.0)
+        ax.plot(
+            x[valid_fb],
+            fb[valid_fb],
+            color='yellow',
+            lw=1.0,
+            alpha=0.9,
+            label='ground truth',
+        )
+
+    _draw_segment_boundaries(ax, segments)
+    ax.set_xlim(-0.5, float(max(n_traces - 1, 0)) + 0.5)
+    ax.set_ylim(float(sample_pos[-1]) + 0.5, float(sample_pos[0]) - 0.5)
+    ax.set_xlabel('Trace Position')
+    ax.set_ylabel('Sample Index')
+    ax.set_title('original gather QC' if title is None else str(title))
+    ax.legend(loc='upper right', fontsize=8)
+    return _save_and_close(fig, out_png, dpi=dpi)
+
+
+def plot_confidence_qc(
+    out_png: str | Path,
+    *,
+    coarse_pmax: np.ndarray,
+    segments: Sequence[object] | None = None,
+    low_confidence_threshold: float | None = None,
+    title: str | None = None,
+    dpi: int = 150,
+) -> Path:
+    import matplotlib.pyplot as plt
+
+    pmax = _as_vector('coarse_pmax', coarse_pmax).astype(np.float32)
+    n_traces = int(pmax.shape[0])
+    x = np.arange(n_traces, dtype=np.float32)
+
+    fig_width = max(8.0, min(18.0, float(n_traces) / 40.0))
+    fig, ax = plt.subplots(figsize=(fig_width, 4.5))
+    ax.plot(x, pmax, color='#00d7ff', lw=1.1, label='coarse_pmax')
+    if low_confidence_threshold is not None:
+        threshold = float(low_confidence_threshold)
+        if threshold < 0.0 or threshold > 1.0:
+            msg = 'low_confidence_threshold must lie in [0, 1]'
+            raise ValueError(msg)
+        ax.axhline(
+            threshold,
+            color='red',
+            lw=0.9,
+            ls='--',
+            alpha=0.75,
+            label='low confidence threshold',
+        )
+    _draw_segment_boundaries(ax, segments)
+    ax.set_xlim(-0.5, float(max(n_traces - 1, 0)) + 0.5)
+    ax.set_ylim(0.0, 1.0)
+    ax.set_xlabel('Trace Position')
+    ax.set_ylabel('Confidence')
+    ax.set_title('coarse confidence QC' if title is None else str(title))
+    ax.grid(True, alpha=0.25)
+    ax.legend(loc='lower right', fontsize=8)
+    return _save_and_close(fig, out_png, dpi=dpi)
+
+
+def _error_summary(
+    err_samples: np.ndarray,
+    *,
+    dt_sec: float | None,
+    fine_window_half_samples: int,
+) -> str:
+    abs_err = np.abs(err_samples.astype(np.float64, copy=False))
+    mae = float(np.mean(abs_err))
+    p50, p90, p95 = np.percentile(abs_err, [50.0, 90.0, 95.0]).tolist()
+    coverage = float(np.mean(abs_err <= float(fine_window_half_samples)) * 100.0)
+    parts = [
+        f'MAE={mae:.2f} samples',
+        f'P50={p50:.2f}',
+        f'P90={p90:.2f}',
+        f'P95={p95:.2f}',
+        f'within +/-{int(fine_window_half_samples)}={coverage:.1f}%',
+    ]
+    if dt_sec is not None:
+        mae_ms = mae * float(dt_sec) * 1000.0
+        parts.insert(1, f'MAE={mae_ms:.2f} ms')
+    return ' | '.join(parts)
+
+
+def plot_error_qc(
+    out_png: str | Path,
+    *,
+    coarse_pick_i: np.ndarray,
+    fb_pick_i: np.ndarray,
+    n_samples_orig: int | None = None,
+    dt_sec: float | None = None,
+    fine_window_half_samples: int = 128,
+    segments: Sequence[object] | None = None,
+    title: str | None = None,
+    dpi: int = 150,
+) -> Path:
+    import matplotlib.pyplot as plt
+
+    coarse = _as_vector('coarse_pick_i', coarse_pick_i).astype(np.float32)
+    fb = _as_vector('fb_pick_i', fb_pick_i, length=int(coarse.shape[0])).astype(
+        np.float32
+    )
+    n_traces = int(coarse.shape[0])
+    valid = np.isfinite(coarse) & np.isfinite(fb) & (fb >= 0.0)
+    if n_samples_orig is not None:
+        valid &= fb < float(n_samples_orig)
+    err = coarse - fb
+    err[~valid] = np.nan
+
+    x = np.arange(n_traces, dtype=np.float32)
+    fig_width = max(8.0, min(18.0, float(n_traces) / 40.0))
+    fig, ax = plt.subplots(figsize=(fig_width, 4.8))
+    ax.plot(x, err, color='#00d7ff', lw=1.0, label='coarse - ground truth')
+    ax.axhline(0.0, color='black', lw=0.9, alpha=0.75)
+    half = int(fine_window_half_samples)
+    if half > 0:
+        ax.axhline(float(half), color='red', lw=0.8, ls='--', alpha=0.65)
+        ax.axhline(float(-half), color='red', lw=0.8, ls='--', alpha=0.65)
+    _draw_segment_boundaries(ax, segments)
+    if np.any(valid):
+        summary = _error_summary(
+            err[valid],
+            dt_sec=dt_sec,
+            fine_window_half_samples=half,
+        )
+        title_text = summary if title is None else f'{title}\n{summary}'
+    else:
+        ax.text(
+            0.5,
+            0.5,
+            'no valid ground-truth picks',
+            ha='center',
+            va='center',
+            transform=ax.transAxes,
+        )
+        title_text = 'coarse error QC' if title is None else str(title)
+
+    ax.set_xlim(-0.5, float(max(n_traces - 1, 0)) + 0.5)
+    ax.set_xlabel('Trace Position')
+    ax.set_ylabel('Sample Error')
+    ax.set_title(title_text)
+    ax.grid(True, alpha=0.25)
+    ax.legend(loc='upper right', fontsize=8)
+    return _save_and_close(fig, out_png, dpi=dpi)
+
+
+def write_global_anchor_coarse_qc(
+    *,
+    out_dir: str | Path,
+    gather_id: str,
+    input_waveform_hw: np.ndarray,
+    anchor_pick_j: np.ndarray,
+    anchor_pmax: np.ndarray,
+    trace_valid: np.ndarray,
+    segment_id: np.ndarray,
+    segments: Sequence[object] | None,
+    coarse_pick_i: np.ndarray,
+    coarse_pmax: np.ndarray,
+    raw_wave_hw: np.ndarray | None = None,
+    raw_trace_positions: np.ndarray | None = None,
+    raw_sample_indices: np.ndarray | None = None,
+    fb_pick_i: np.ndarray | None = None,
+    n_samples_orig: int | None = None,
+    dt_sec: float | None = None,
+    cfg: CoarseQCCfg,
+) -> dict[str, Path]:
+    if not cfg.enabled:
+        return {}
+
+    root = Path(out_dir).expanduser().resolve()
+    safe_id = _sanitize_id(gather_id)
+    title = safe_id.replace('-', ' ')
+    paths: dict[str, Path] = {}
+
+    if cfg.plot_anchor_grid:
+        paths['anchor_grid'] = plot_anchor_grid_qc(
+            root / f'{safe_id}_anchor_grid.png',
+            input_waveform_hw=input_waveform_hw,
+            anchor_pick_j=anchor_pick_j,
+            anchor_pmax=anchor_pmax,
+            trace_valid=trace_valid,
+            segment_id=segment_id,
+            title=title,
+            dpi=cfg.dpi,
+            clip_percentile=cfg.clip_percentile,
+        )
+
+    if cfg.plot_original_gather and raw_wave_hw is not None:
+        paths['original_gather'] = plot_original_gather_qc(
+            root / f'{safe_id}_original_gather.png',
+            raw_wave_hw=raw_wave_hw,
+            coarse_pick_i=coarse_pick_i,
+            coarse_pmax=coarse_pmax,
+            fb_pick_i=fb_pick_i,
+            trace_positions=raw_trace_positions,
+            sample_indices=raw_sample_indices,
+            segments=segments,
+            title=title,
+            dpi=cfg.dpi,
+            clip_percentile=cfg.clip_percentile,
+        )
+
+    if cfg.plot_confidence:
+        paths['confidence'] = plot_confidence_qc(
+            root / f'{safe_id}_confidence.png',
+            coarse_pmax=coarse_pmax,
+            segments=segments,
+            low_confidence_threshold=cfg.low_confidence_threshold,
+            title=title,
+            dpi=cfg.dpi,
+        )
+
+    if cfg.plot_error_if_labels_available and fb_pick_i is not None:
+        paths['error'] = plot_error_qc(
+            root / f'{safe_id}_error.png',
+            coarse_pick_i=coarse_pick_i,
+            fb_pick_i=fb_pick_i,
+            n_samples_orig=n_samples_orig,
+            dt_sec=dt_sec,
+            fine_window_half_samples=cfg.fine_window_half_samples,
+            segments=segments,
+            title=title,
+            dpi=cfg.dpi,
+        )
+
+    return paths

--- a/packages/seisai-engine/tests/test_fbpick_coarse.py
+++ b/packages/seisai-engine/tests/test_fbpick_coarse.py
@@ -32,13 +32,26 @@ from seisai_engine.train_loop import train_one_epoch
 from torch.utils.data import DataLoader, Subset
 
 
-def write_unstructured_segy(path: str, traces: np.ndarray, dt_us: int) -> None:
+def write_unstructured_segy(
+    path: str,
+    traces: np.ndarray,
+    dt_us: int,
+    *,
+    ffid_values: np.ndarray | None = None,
+) -> None:
     arr = np.asarray(traces, dtype=np.float32)
     if arr.ndim != 2:
         msg = 'traces must be 2D (n_traces, n_samples)'
         raise ValueError(msg)
 
     n_traces, n_samples = arr.shape
+    if ffid_values is None:
+        ffids = np.ones((n_traces,), dtype=np.int32)
+    else:
+        ffids = np.asarray(ffid_values, dtype=np.int32)
+        if ffids.ndim != 1 or int(ffids.shape[0]) != n_traces:
+            msg = 'ffid_values must be 1D with length n_traces'
+            raise ValueError(msg)
     spec = segyio.spec()
     spec.iline = 189
     spec.xline = 193
@@ -51,7 +64,7 @@ def write_unstructured_segy(path: str, traces: np.ndarray, dt_us: int) -> None:
         f.bin[segyio.BinField.Interval] = int(dt_us)
         for i in range(n_traces):
             f.header[i] = {
-                segyio.TraceField.FieldRecord: 1,
+                segyio.TraceField.FieldRecord: int(ffids[i]),
                 segyio.TraceField.TraceNumber: int(i + 1),
                 segyio.TraceField.CDP: 1,
                 segyio.TraceField.offset: int((i + 1) * 10),
@@ -279,6 +292,46 @@ def test_load_coarse_infer_config_returns_global_anchor_contract(
     assert typed.trace_anchor.infer_mode == 'center'
     assert typed.dataset.primary_keys == ('ffid',)
     assert typed.model_sig['in_chans'] == 3
+    assert typed.qc.enabled is False
+    assert typed.qc.max_gathers == 16
+    assert typed.qc.out_subdir == 'vis/coarse_global_anchor'
+
+
+def test_load_coarse_infer_config_accepts_qc_block(tmp_path: Path) -> None:
+    cfg = _make_training_config(tmp_path, segy_path='dummy.sgy', fb_path='dummy.npy')
+    cfg['paths'].pop('fb_files')
+    _use_raw_infer_runtime_cfg(cfg)
+    cfg['qc'] = {
+        'enabled': True,
+        'max_gathers': 2,
+        'out_subdir': 'vis/custom_coarse_qc',
+        'plot_anchor_grid': False,
+        'plot_original_gather': True,
+        'plot_confidence': False,
+        'plot_error_if_labels_available': True,
+        'fine_window_half_samples': 64,
+        'max_display_traces': 128,
+        'max_display_samples': 512,
+        'low_confidence_threshold': 0.25,
+        'dpi': 90,
+        'clip_percentile': 98.0,
+    }
+
+    typed = load_coarse_infer_config(cfg)
+
+    assert typed.qc.enabled is True
+    assert typed.qc.max_gathers == 2
+    assert typed.qc.out_subdir == 'vis/custom_coarse_qc'
+    assert typed.qc.plot_anchor_grid is False
+    assert typed.qc.plot_original_gather is True
+    assert typed.qc.plot_confidence is False
+    assert typed.qc.plot_error_if_labels_available is True
+    assert typed.qc.fine_window_half_samples == 64
+    assert typed.qc.max_display_traces == 128
+    assert typed.qc.max_display_samples == 512
+    assert typed.qc.low_confidence_threshold == pytest.approx(0.25)
+    assert typed.qc.dpi == 90
+    assert typed.qc.clip_percentile == pytest.approx(98.0)
 
 
 @pytest.mark.parametrize(
@@ -1328,6 +1381,54 @@ def test_coarse_raw_only_infer_writes_npz(tmp_path: Path) -> None:
     assert lineage['source_model_id'] == 'coarse-smoke'
     assert lineage['cfg_hash']
     assert lineage['git_sha'] is None
+    assert not (tmp_path / 'infer_out' / 'vis' / 'coarse_global_anchor').exists()
+
+
+def test_coarse_raw_only_infer_qc_respects_max_gathers(tmp_path: Path) -> None:
+    n_traces = 512
+    n_samples = 512
+    t = np.linspace(-1.0, 1.0, n_samples, dtype=np.float32)
+    traces = np.stack([t + float(i) for i in range(n_traces)], axis=0)
+    ffids = np.concatenate(
+        [
+            np.ones((256,), dtype=np.int32),
+            np.full((256,), 2, dtype=np.int32),
+        ]
+    )
+    segy_path = str(tmp_path / 'coarse_infer_multi_ffid.sgy')
+    write_unstructured_segy(segy_path, traces, dt_us=2000, ffid_values=ffids)
+
+    cfg = _make_training_config(tmp_path, segy_path=segy_path, fb_path='unused.npy')
+    cfg['paths'].pop('fb_files')
+    cfg['paths']['out_dir'] = str(tmp_path / 'infer_qc_out')
+    cfg['infer'] = {
+        'batch_size': 1,
+        'num_workers': 0,
+        'amp': False,
+        'use_tqdm': False,
+    }
+    cfg['qc'] = {
+        'enabled': True,
+        'max_gathers': 1,
+        'plot_anchor_grid': True,
+        'plot_original_gather': False,
+        'plot_confidence': True,
+        'plot_error_if_labels_available': False,
+        'dpi': 80,
+    }
+
+    out_path = run_coarse_infer(
+        model=_TimeChannelModel(),
+        cfg=cfg,
+        device=torch.device('cpu'),
+        ckpt=_make_global_anchor_ckpt(),
+    )
+
+    assert out_path.is_file()
+    qc_dir = tmp_path / 'infer_qc_out' / 'vis' / 'coarse_global_anchor'
+    assert len(list(qc_dir.glob('*_anchor_grid.png'))) == 1
+    assert len(list(qc_dir.glob('*_confidence.png'))) == 1
+    assert not list(qc_dir.glob('*_original_gather.png'))
 
 
 class _BadShapeModel(torch.nn.Module):

--- a/packages/seisai-engine/tests/test_fbpick_coarse_qc.py
+++ b/packages/seisai-engine/tests/test_fbpick_coarse_qc.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import matplotlib
+
+matplotlib.use('Agg')
+
+import numpy as np
+
+from seisai_engine.pipelines.fbpick.coarse import CoarseQCCfg, TraceSegment
+from seisai_engine.pipelines.fbpick.coarse.qc import (
+    plot_original_gather_qc,
+    select_display_indices,
+    write_global_anchor_coarse_qc,
+)
+
+
+def _qc_cfg(**overrides) -> CoarseQCCfg:
+    values = {
+        'enabled': True,
+        'max_gathers': 16,
+        'out_subdir': 'vis/coarse_global_anchor',
+        'plot_anchor_grid': True,
+        'plot_original_gather': True,
+        'plot_confidence': True,
+        'plot_error_if_labels_available': True,
+        'fine_window_half_samples': 4,
+        'max_display_traces': 64,
+        'max_display_samples': 128,
+        'low_confidence_threshold': 0.35,
+        'dpi': 80,
+        'clip_percentile': 99.0,
+    }
+    values.update(overrides)
+    return CoarseQCCfg(**values)
+
+
+def _assert_png(path: Path) -> None:
+    assert path.is_file()
+    assert path.stat().st_size > 0
+
+
+def test_write_global_anchor_coarse_qc_writes_pngs_and_skips_missing_error(
+    tmp_path: Path,
+) -> None:
+    input_waveform = np.linspace(-1.0, 1.0, 4 * 16, dtype=np.float32).reshape(4, 16)
+    raw_wave = np.linspace(-1.0, 1.0, 8 * 32, dtype=np.float32).reshape(8, 32)
+    segments = (
+        TraceSegment(segment_id=0, start_pos=0, stop_pos=4, n_traces=4),
+        TraceSegment(segment_id=1, start_pos=4, stop_pos=8, n_traces=4),
+    )
+
+    paths = write_global_anchor_coarse_qc(
+        out_dir=tmp_path,
+        gather_id='line A ffid=1',
+        input_waveform_hw=input_waveform,
+        anchor_pick_j=np.array([2, 4, 6, 999], dtype=np.int64),
+        anchor_pmax=np.array([0.9, 0.8, 0.6, 1.0], dtype=np.float32),
+        trace_valid=np.array([True, True, True, False], dtype=np.bool_),
+        segment_id=np.array([0, 0, 1, -1], dtype=np.int64),
+        segments=segments,
+        coarse_pick_i=np.array([5, 6, 7, 8, 15, 16, 17, 18], dtype=np.int32),
+        coarse_pmax=np.linspace(0.2, 0.9, 8, dtype=np.float32),
+        raw_wave_hw=raw_wave,
+        n_samples_orig=32,
+        dt_sec=0.002,
+        cfg=_qc_cfg(),
+    )
+
+    assert set(paths) == {'anchor_grid', 'original_gather', 'confidence'}
+    for path in paths.values():
+        _assert_png(path)
+    assert not list(tmp_path.glob('*_error.png'))
+
+
+def test_write_global_anchor_coarse_qc_writes_error_when_labels_exist(
+    tmp_path: Path,
+) -> None:
+    paths = write_global_anchor_coarse_qc(
+        out_dir=tmp_path,
+        gather_id='ffid-2',
+        input_waveform_hw=np.zeros((4, 16), dtype=np.float32),
+        anchor_pick_j=np.array([2, 4, 6, 8], dtype=np.int64),
+        anchor_pmax=np.array([0.9, 0.8, 0.7, 0.6], dtype=np.float32),
+        trace_valid=np.ones((4,), dtype=np.bool_),
+        segment_id=np.zeros((4,), dtype=np.int64),
+        segments=(TraceSegment(segment_id=0, start_pos=0, stop_pos=8, n_traces=8),),
+        coarse_pick_i=np.array([5, 6, 7, 8, 9, 10, 11, 12], dtype=np.int32),
+        coarse_pmax=np.linspace(0.5, 0.9, 8, dtype=np.float32),
+        fb_pick_i=np.array([4, 6, 8, 8, 10, 10, 12, 12], dtype=np.int32),
+        n_samples_orig=32,
+        dt_sec=0.002,
+        cfg=_qc_cfg(plot_original_gather=False),
+    )
+
+    assert 'error' in paths
+    _assert_png(paths['error'])
+
+
+def test_original_gather_qc_accepts_decimated_display_image(tmp_path: Path) -> None:
+    n_traces = 1000
+    n_samples = 5000
+    trace_positions = select_display_indices(n_traces, 64)
+    sample_indices = select_display_indices(n_samples, 128)
+    raw_wave = np.zeros((trace_positions.size, sample_indices.size), dtype=np.float32)
+    coarse_pick_i = np.linspace(100, 2000, n_traces, dtype=np.float32).astype(np.int32)
+
+    out_path = plot_original_gather_qc(
+        tmp_path / 'decimated_original_gather.png',
+        raw_wave_hw=raw_wave,
+        coarse_pick_i=coarse_pick_i,
+        coarse_pmax=np.linspace(0.2, 0.9, n_traces, dtype=np.float32),
+        trace_positions=trace_positions,
+        sample_indices=sample_indices,
+        segments=(
+            TraceSegment(segment_id=0, start_pos=0, stop_pos=500, n_traces=500),
+            TraceSegment(segment_id=1, start_pos=500, stop_pos=1000, n_traces=500),
+        ),
+        dpi=80,
+    )
+
+    _assert_png(out_path)


### PR DESCRIPTION
Closes #41

## Summary
- [fbpick-coarse] Add QC visualization for global-anchor coarse predictions

## Changed files
- `examples/config_infer_fbpick_coarse.yaml`
- `packages/seisai-engine/src/seisai_engine/pipelines/fbpick/coarse/__init__.py`
- `packages/seisai-engine/src/seisai_engine/pipelines/fbpick/coarse/config.py`
- `packages/seisai-engine/src/seisai_engine/pipelines/fbpick/coarse/infer.py`
- `packages/seisai-engine/src/seisai_engine/pipelines/fbpick/coarse/qc.py`
- `packages/seisai-engine/tests/test_fbpick_coarse.py`
- `packages/seisai-engine/tests/test_fbpick_coarse_qc.py`

## Checks
- `.work/codex/checks.log`: 797 passed, 5 warnings in 64.68s (0:01:04)

## Review
- `.work/codex/review.txt`: accept: yes
- findings: blocker 0, major 0, minor 0
