### PR TITLE
[fbpick-fine] Allow explicit coarse_npz_files for fine inference merge

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,6 +317,7 @@ pytest -q -m integration
 
 - FBPick coarse global-anchor resize 設計: `docs/fbpick_coarse_global_anchor.md`
 - FBPick coarse coverage 評価: `docs/fbpick_coarse_eval.md`
+- FBPick fine inference 入力契約: `docs/fbpick_fine_infer.md`
 - SegyGatherPipelineDataset 出力契約: `docs/spec/segy_gather_pipeline_dataset_output_contract.md`
 - SegyGatherPipelineDataset 入力前提 (SEG-Y): `docs/spec/segy_gather_pipeline_dataset_input_assumptions.md`
 - Phase pick ファイル仕様: `docs/spec/phase_pick_files_spec.md`

--- a/docs/fbpick_fine_infer.md
+++ b/docs/fbpick_fine_infer.md
@@ -1,0 +1,51 @@
+# FBPick Fine Inference
+
+Fine inference refines first-break picks from one SEG-Y gather using two upstream
+artifacts:
+
+- physics / robust output: `*.robust.npz`
+- coarse output: `*.coarse.npz`
+
+The current fine inference CLI is a single-gather entrypoint. It requires exactly
+one `paths.segy_files` entry and exactly one `paths.robust_npz_files` entry.
+
+## Coarse NPZ Input
+
+Set `paths.coarse_npz_files` when the coarse and physics outputs live in
+different directories:
+
+```yaml
+paths:
+  segy_files:
+    - /path/to/sample.sgy
+  robust_npz_files:
+    - /workspace/proc/fbpick/site54/fbpick_physics_valid_out/sample.robust.npz
+  coarse_npz_files:
+    - /workspace/proc/fbpick/site54/fbpick_coarse_infer_valid_out/sample.coarse.npz
+  out_dir: /workspace/proc/fbpick/site54/fbpick_fine_infer_valid_out
+```
+
+`paths.coarse_npz_files` accepts the same forms as `paths.segy_files` and
+`paths.robust_npz_files`: either a list of paths or a listfile path. When it is
+provided, its length must match `paths.segy_files` and `paths.robust_npz_files`.
+For the current single-gather CLI, all three lists must contain one path.
+
+If `paths.coarse_npz_files` is omitted, fine inference keeps the legacy behavior
+and infers the coarse path from the robust path:
+
+```text
+/path/to/sample.robust.npz -> /path/to/sample.coarse.npz
+```
+
+Use explicit `paths.coarse_npz_files` for workflows where:
+
+```text
+coarse inference output:
+  fbpick_coarse_infer_valid_out/*.coarse.npz
+
+physics output:
+  fbpick_physics_valid_out/*.robust.npz
+```
+
+In that layout, the inferred same-directory coarse path is wrong, so fine
+inference should point to both upstream outputs explicitly.

--- a/examples/config_infer_fbpick_fine.yaml
+++ b/examples/config_infer_fbpick_fine.yaml
@@ -3,6 +3,8 @@ paths:
     - REPLACE_ME_infer_fine.sgy
   robust_npz_files:
     - REPLACE_ME_infer_fine.robust.npz
+  coarse_npz_files:
+    - REPLACE_ME_infer_fine.coarse.npz
   out_dir: ./_fbpick_fine_infer_out
 
 dataset:

--- a/packages/seisai-engine/src/seisai_engine/pipelines/fbpick/fine/config.py
+++ b/packages/seisai-engine/src/seisai_engine/pipelines/fbpick/fine/config.py
@@ -69,6 +69,7 @@ class FinePaths:
     segy_files: tuple[str, ...]
     fb_files: tuple[str, ...] | None
     robust_npz_files: tuple[str, ...] | None
+    coarse_npz_files: tuple[str, ...] | None
     infer_segy_files: tuple[str, ...] | None
     infer_fb_files: tuple[str, ...] | None
     infer_robust_npz_files: tuple[str, ...] | None
@@ -187,6 +188,7 @@ def _load_paths_cfg(
     segy_files = tuple(require_list_str(paths, 'segy_files'))
     fb_files = _load_optional_str_list(paths, 'fb_files')
     robust_npz_files = _load_optional_str_list(paths, 'robust_npz_files')
+    coarse_npz_files = _load_optional_str_list(paths, 'coarse_npz_files')
 
     if require_fb_files and fb_files is None:
         msg = 'paths.fb_files is required for fbpick fine training'
@@ -198,8 +200,23 @@ def _load_paths_cfg(
     if fb_files is not None and len(fb_files) != len(segy_files):
         msg = 'paths.segy_files and paths.fb_files must have the same length'
         raise ValueError(msg)
-    if robust_npz_files is not None and len(robust_npz_files) != len(segy_files):
+    if robust_npz_files is not None and coarse_npz_files is not None:
+        if (
+            len(segy_files) != len(robust_npz_files)
+            or len(segy_files) != len(coarse_npz_files)
+        ):
+            msg = (
+                'paths.segy_files, paths.robust_npz_files, and '
+                'paths.coarse_npz_files must have the same length'
+            )
+            raise ValueError(msg)
+    elif robust_npz_files is not None and len(robust_npz_files) != len(segy_files):
         msg = 'paths.segy_files and paths.robust_npz_files must have the same length'
+        raise ValueError(msg)
+    elif coarse_npz_files is not None and len(coarse_npz_files) != len(segy_files):
+        msg = (
+            'paths.segy_files and paths.coarse_npz_files must have the same length'
+        )
         raise ValueError(msg)
 
     infer_segy_files = _load_optional_str_list(paths, 'infer_segy_files')
@@ -248,6 +265,7 @@ def _load_paths_cfg(
         segy_files=segy_files,
         fb_files=fb_files,
         robust_npz_files=robust_npz_files,
+        coarse_npz_files=coarse_npz_files,
         infer_segy_files=infer_segy_files,
         infer_fb_files=infer_fb_files,
         infer_robust_npz_files=infer_robust_npz_files,

--- a/packages/seisai-engine/src/seisai_engine/pipelines/fbpick/fine/infer.py
+++ b/packages/seisai-engine/src/seisai_engine/pipelines/fbpick/fine/infer.py
@@ -39,7 +39,10 @@ from .build_plan import build_plan
 from .config import FineInferConfig, load_fine_infer_config
 
 __all__ = [
+    'infer_coarse_npz_path_from_robust_npz_path',
     'main',
+    'require_existing_coarse_npz_path',
+    'resolve_fine_coarse_npz_path',
     'run_fine_infer',
     'run_fine_local_infer',
     'run_infer_and_write',
@@ -51,6 +54,7 @@ _SAFE_OVERRIDE_PATHS = frozenset(
     {
         'paths.segy_files',
         'paths.robust_npz_files',
+        'paths.coarse_npz_files',
         'paths.out_dir',
         'dataset.use_header_cache',
         'dataset.verbose',
@@ -82,6 +86,7 @@ def _default_cfg() -> dict[str, Any]:
         'paths': {
             'segy_files': [],
             'robust_npz_files': [],
+            'coarse_npz_files': None,
             'out_dir': './_fbpick_fine_infer_out',
         },
         'dataset': {
@@ -166,6 +171,12 @@ def _validate_fine_infer_inputs(typed: FineInferConfig) -> None:
         raise ValueError(msg)
     if len(typed.paths.robust_npz_files) != 1:
         msg = 'fine infer expects exactly one paths.robust_npz_files entry'
+        raise ValueError(msg)
+    if (
+        typed.paths.coarse_npz_files is not None
+        and len(typed.paths.coarse_npz_files) != 1
+    ):
+        msg = 'fine infer expects exactly one paths.coarse_npz_files entry'
         raise ValueError(msg)
     if typed.dataset.waveform_mode == 'mmap' and typed.infer.num_workers != 0:
         msg = 'dataset.waveform_mode="mmap" requires infer.num_workers=0'
@@ -374,13 +385,50 @@ def run_fine_local_infer(
     return _run_fine_local_infer_impl(model=model, typed=typed, device=device)
 
 
-def _derive_coarse_npz_path_from_robust(robust_npz_path: str | Path) -> Path:
+def infer_coarse_npz_path_from_robust_npz_path(robust_npz_path: str | Path) -> Path:
+    """Infer the legacy same-directory coarse path for a robust NPZ path."""
     path = Path(robust_npz_path).expanduser().resolve()
     if not path.name.endswith('.robust.npz'):
         msg = f'expected *.robust.npz input, got {path.name}'
         raise ValueError(msg)
     stem = path.name[: -len('.robust.npz')]
     return path.with_name(f'{stem}.coarse.npz')
+
+
+def resolve_fine_coarse_npz_path(
+    *,
+    robust_npz_path: str | Path,
+    explicit_coarse_npz_path: str | Path | None,
+) -> Path:
+    """Resolve the coarse path, preferring an explicit fine-infer config path."""
+    if explicit_coarse_npz_path is not None:
+        return Path(explicit_coarse_npz_path).expanduser().resolve()
+    return infer_coarse_npz_path_from_robust_npz_path(robust_npz_path)
+
+
+def require_existing_coarse_npz_path(
+    *,
+    coarse_npz_path: str | Path,
+    robust_npz_path: str | Path,
+    was_explicit: bool,
+) -> Path:
+    """Return an existing coarse path or raise a fine-infer specific error."""
+    path = Path(coarse_npz_path).expanduser().resolve()
+    if path.is_file():
+        return path
+
+    if was_explicit:
+        msg = f'coarse npz file not found: {path}'
+        raise FileNotFoundError(msg)
+
+    robust_path = Path(robust_npz_path).expanduser().resolve()
+    msg = (
+        f'coarse npz file not found: {path}\n'
+        f'inferred from robust npz: {robust_path}\n'
+        'Set paths.coarse_npz_files explicitly if coarse and robust outputs are '
+        'in different directories.'
+    )
+    raise FileNotFoundError(msg)
 
 
 def _derive_final_npz_path(*, segy_path: str | Path, out_dir: str | Path) -> Path:
@@ -408,15 +456,17 @@ def _load_fine_ckpt_cfg_for_merge(
 
 def _prepare_fine_infer_cfg(cfg: dict[str, Any], *, base_dir: Path) -> dict[str, Any]:
     prepared = deepcopy(cfg)
-    expand_cfg_listfiles(prepared, keys=['paths.segy_files', 'paths.robust_npz_files'])
-    path_keys: list[str] = ['paths.segy_files', 'paths.robust_npz_files']
     paths = prepared.get('paths')
     if not isinstance(paths, dict):
         msg = 'paths must be dict'
         raise TypeError(msg)
+    list_path_keys: list[str] = ['paths.segy_files', 'paths.robust_npz_files']
+    if paths.get('coarse_npz_files') is not None:
+        list_path_keys.append('paths.coarse_npz_files')
+    resolve_cfg_paths(prepared, base_dir, keys=list_path_keys)
+    expand_cfg_listfiles(prepared, keys=list_path_keys)
     if paths.get('out_dir') is not None:
-        path_keys.append('paths.out_dir')
-    resolve_cfg_paths(prepared, base_dir, keys=path_keys)
+        resolve_cfg_paths(prepared, base_dir, keys=['paths.out_dir'])
     return prepared
 
 
@@ -571,9 +621,21 @@ def run_fine_infer(
     if robust_payload is None:
         robust_payload = load_robust_npz(typed.paths.robust_npz_files[0])
     if coarse_payload is None:
-        coarse_payload = load_coarse_npz(
-            _derive_coarse_npz_path_from_robust(typed.paths.robust_npz_files[0])
+        explicit_coarse_npz_path = (
+            None
+            if typed.paths.coarse_npz_files is None
+            else typed.paths.coarse_npz_files[0]
         )
+        coarse_npz_path = resolve_fine_coarse_npz_path(
+            robust_npz_path=typed.paths.robust_npz_files[0],
+            explicit_coarse_npz_path=explicit_coarse_npz_path,
+        )
+        coarse_npz_path = require_existing_coarse_npz_path(
+            coarse_npz_path=coarse_npz_path,
+            robust_npz_path=typed.paths.robust_npz_files[0],
+            was_explicit=explicit_coarse_npz_path is not None,
+        )
+        coarse_payload = load_coarse_npz(coarse_npz_path)
 
     final_payload = build_fbpick_final_payload(
         coarse_payload=coarse_payload,

--- a/packages/seisai-engine/tests/test_fbpick_fine.py
+++ b/packages/seisai-engine/tests/test_fbpick_fine.py
@@ -37,7 +37,12 @@ from seisai_engine.pipelines.fbpick.fine import (
     run_train,
     restore_local_pick_to_raw,
 )
-from seisai_engine.pipelines.fbpick.fine.infer import main as run_fine_infer_main
+from seisai_engine.pipelines.fbpick.fine.infer import (
+    _prepare_fine_infer_cfg,
+    main as run_fine_infer_main,
+    require_existing_coarse_npz_path,
+    resolve_fine_coarse_npz_path,
+)
 from seisai_engine.pipelines.fbpick.fine.init_from_coarse import (
     build_fine_init_state_dict,
     load_fine_init_from_coarse_checkpoint,
@@ -303,13 +308,18 @@ def _make_fine_infer_config(
     *,
     segy_path: str,
     robust_path: str,
+    coarse_path: str | None = None,
 ) -> dict:
+    paths = {
+        'segy_files': [segy_path],
+        'robust_npz_files': [robust_path],
+        'out_dir': str(tmp_path / 'fine_infer_out'),
+    }
+    if coarse_path is not None:
+        paths['coarse_npz_files'] = [coarse_path]
+
     return {
-        'paths': {
-            'segy_files': [segy_path],
-            'robust_npz_files': [robust_path],
-            'out_dir': str(tmp_path / 'fine_infer_out'),
-        },
+        'paths': paths,
         'dataset': {
             'use_header_cache': False,
             'verbose': False,
@@ -488,6 +498,81 @@ def test_load_fine_infer_config_returns_default_high_conf_threshold(
     assert typed.infer.high_conf_threshold == pytest.approx(0.5)
 
 
+def test_load_fine_infer_config_parses_explicit_coarse_npz_files(
+    tmp_path: Path,
+) -> None:
+    cfg = _make_fine_infer_config(
+        tmp_path,
+        segy_path='dummy.sgy',
+        robust_path='dummy.robust.npz',
+        coarse_path='other_dir/dummy.coarse.npz',
+    )
+
+    typed = load_fine_infer_config(cfg)
+
+    assert typed.paths.coarse_npz_files == ('other_dir/dummy.coarse.npz',)
+
+
+def test_prepare_fine_infer_cfg_expands_coarse_npz_listfile(tmp_path: Path) -> None:
+    data_dir = tmp_path / 'data'
+    physics_dir = tmp_path / 'physics'
+    coarse_dir = tmp_path / 'coarse'
+    list_dir = tmp_path / 'lists'
+    for directory in (data_dir, physics_dir, coarse_dir, list_dir):
+        directory.mkdir()
+
+    segy_path = data_dir / 'sample.sgy'
+    robust_path = physics_dir / 'sample.robust.npz'
+    coarse_path = coarse_dir / 'sample.coarse.npz'
+    for path in (segy_path, robust_path, coarse_path):
+        path.touch()
+
+    segy_list = list_dir / 'segy.txt'
+    robust_list = list_dir / 'robust.txt'
+    coarse_list = list_dir / 'coarse.txt'
+    segy_list.write_text('../data/sample.sgy\n', encoding='utf-8')
+    robust_list.write_text('../physics/sample.robust.npz\n', encoding='utf-8')
+    coarse_list.write_text('../coarse/sample.coarse.npz\n', encoding='utf-8')
+
+    cfg = _make_fine_infer_config(
+        tmp_path,
+        segy_path='unused.sgy',
+        robust_path='unused.robust.npz',
+    )
+    cfg['paths'] = {
+        'segy_files': 'lists/segy.txt',
+        'robust_npz_files': 'lists/robust.txt',
+        'coarse_npz_files': 'lists/coarse.txt',
+        'out_dir': 'out',
+    }
+
+    prepared = _prepare_fine_infer_cfg(cfg, base_dir=tmp_path)
+    typed = load_fine_infer_config(prepared)
+
+    assert typed.paths.segy_files == (str(segy_path.resolve()),)
+    assert typed.paths.robust_npz_files == (str(robust_path.resolve()),)
+    assert typed.paths.coarse_npz_files == (str(coarse_path.resolve()),)
+
+
+def test_load_fine_infer_config_rejects_explicit_coarse_length_mismatch(
+    tmp_path: Path,
+) -> None:
+    cfg = _make_fine_infer_config(
+        tmp_path,
+        segy_path='dummy.sgy',
+        robust_path='dummy.robust.npz',
+    )
+    cfg['paths']['coarse_npz_files'] = [
+        'one.coarse.npz',
+        'two.coarse.npz',
+    ]
+
+    with pytest.raises(ValueError) as exc:
+        load_fine_infer_config(cfg)
+
+    assert 'must have the same length' in str(exc.value)
+
+
 def test_load_fine_infer_config_rejects_invalid_overlap(tmp_path: Path) -> None:
     cfg = _make_fine_infer_config(
         tmp_path,
@@ -518,6 +603,66 @@ def test_load_fine_infer_config_rejects_invalid_high_conf_threshold(
         load_fine_infer_config(cfg)
 
     assert 'infer.high_conf_threshold must lie in [0, 1]' in str(exc.value)
+
+
+def test_resolve_fine_coarse_npz_path_prefers_explicit_path(tmp_path: Path) -> None:
+    robust_path = tmp_path / 'physics' / 'sample.robust.npz'
+    explicit_path = tmp_path / 'coarse' / 'sample.coarse.npz'
+
+    resolved = resolve_fine_coarse_npz_path(
+        robust_npz_path=robust_path,
+        explicit_coarse_npz_path=explicit_path,
+    )
+
+    assert resolved == explicit_path.resolve()
+
+
+def test_resolve_fine_coarse_npz_path_infers_from_robust_path(tmp_path: Path) -> None:
+    robust_path = tmp_path / 'same_dir' / 'sample.robust.npz'
+
+    resolved = resolve_fine_coarse_npz_path(
+        robust_npz_path=robust_path,
+        explicit_coarse_npz_path=None,
+    )
+
+    assert resolved == (tmp_path / 'same_dir' / 'sample.coarse.npz').resolve()
+
+
+def test_require_existing_coarse_npz_path_reports_missing_explicit(
+    tmp_path: Path,
+) -> None:
+    coarse_path = tmp_path / 'missing' / 'sample.coarse.npz'
+
+    with pytest.raises(FileNotFoundError) as exc:
+        require_existing_coarse_npz_path(
+            coarse_npz_path=coarse_path,
+            robust_npz_path=tmp_path / 'sample.robust.npz',
+            was_explicit=True,
+        )
+
+    message = str(exc.value)
+    assert 'coarse npz file not found' in message
+    assert str(coarse_path.resolve()) in message
+    assert 'Set paths.coarse_npz_files explicitly' not in message
+
+
+def test_require_existing_coarse_npz_path_suggests_explicit_for_missing_inferred(
+    tmp_path: Path,
+) -> None:
+    robust_path = tmp_path / 'physics' / 'sample.robust.npz'
+    coarse_path = tmp_path / 'physics' / 'sample.coarse.npz'
+
+    with pytest.raises(FileNotFoundError) as exc:
+        require_existing_coarse_npz_path(
+            coarse_npz_path=coarse_path,
+            robust_npz_path=robust_path,
+            was_explicit=False,
+        )
+
+    message = str(exc.value)
+    assert 'coarse npz file not found' in message
+    assert f'inferred from robust npz: {robust_path.resolve()}' in message
+    assert 'Set paths.coarse_npz_files explicitly' in message
 
 
 def test_extract_local_windowed_view_zero_pads_and_restores_indices() -> None:
@@ -1006,6 +1151,55 @@ def test_run_fine_infer_builds_and_saves_final_payload(
 
     saved = load_fbpick_final_npz(tmp_path / 'fine_infer_out' / 'fine_public.fbpick_final.npz')
     np.testing.assert_array_equal(saved['final_pick_i'], final_pick.astype(np.int32))
+
+
+def test_run_fine_infer_uses_explicit_coarse_npz_path(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    n_traces = 160
+    n_samples = 512
+    dt_sec = 0.002
+    trace_axis = np.arange(n_traces, dtype=np.int32)
+    robust = 220 + ((trace_axis % 7) - 3) * 4
+    final_pick = robust + ((trace_axis % 5) - 2) * 7
+
+    traces = np.zeros((n_traces, n_samples), dtype=np.float32)
+    for trace_idx, pick_idx in enumerate(final_pick.tolist()):
+        traces[trace_idx, int(pick_idx)] = 10.0 + 0.01 * float(trace_idx)
+
+    segy_path = _register_synthetic_segy(tmp_path, 'fine_explicit.sgy', traces)
+    coarse_path = _write_coarse_with_n_samples(
+        tmp_path / 'coarse_out' / 'fine_explicit.coarse.npz',
+        coarse_pick_i=robust.astype(np.int32),
+        n_samples_orig=n_samples,
+        dt_sec=dt_sec,
+    )
+    robust_path = _write_robust_with_n_samples(
+        tmp_path / 'physics_out' / 'fine_explicit.robust.npz',
+        robust_pick_i=robust,
+        n_samples_orig=n_samples,
+        dt_sec=dt_sec,
+    )
+    _patch_synthetic_file_infos(
+        monkeypatch,
+        traces_by_path={segy_path: traces},
+        dt_sec=dt_sec,
+    )
+
+    result = run_fine_infer(
+        model=_IdentityFineModel(),
+        cfg=_make_fine_infer_config(
+            tmp_path,
+            segy_path=segy_path,
+            robust_path=robust_path,
+            coarse_path=coarse_path,
+        ),
+        device=torch.device('cpu'),
+    )
+
+    validate_fbpick_final_payload(result, high_conf_threshold=0.5)
+    np.testing.assert_array_equal(result['final_pick_i'], final_pick.astype(np.int32))
 
 
 def test_fine_infer_main_merges_ckpt_cfg_and_writes_final_payload(

--- a/proc/fbpick/site54/configs/config_infer_fbpick_fine.yaml
+++ b/proc/fbpick/site54/configs/config_infer_fbpick_fine.yaml
@@ -3,6 +3,8 @@ paths:
     - REPLACE_ME_infer_fine.sgy
   robust_npz_files:
     - REPLACE_ME_infer_fine.robust.npz
+  coarse_npz_files:
+    - REPLACE_ME_infer_fine.coarse.npz
   out_dir: ./_fbpick_fine_infer_out
 
 dataset:


### PR DESCRIPTION
Closes #47

## Summary
- [fbpick-fine] Allow explicit coarse_npz_files for fine inference merge

## Changed files
- `README.md`
- `docs/fbpick_fine_infer.md`
- `examples/config_infer_fbpick_fine.yaml`
- `packages/seisai-engine/src/seisai_engine/pipelines/fbpick/fine/config.py`
- `packages/seisai-engine/src/seisai_engine/pipelines/fbpick/fine/infer.py`
- `packages/seisai-engine/tests/test_fbpick_fine.py`
- `proc/fbpick/site54/configs/config_infer_fbpick_fine.yaml`

## Checks
- `.work/codex/checks.log`: 818 passed, 5 warnings in 59.18s

## Review
- `.work/codex/review.txt`: accept: yes
- findings: blocker 0, major 0, minor 0
