### PR TITLE
[fbpick-physics/fine] Export smoothed fine centers from physics and use them for fine windows

### DIFF
--- a/examples/config_infer_fbpick_fine.yaml
+++ b/examples/config_infer_fbpick_fine.yaml
@@ -22,6 +22,10 @@ transform:
   center_index: 128
   standardize_eps: 1.0e-8
 
+window_center:
+  npz_key: fine_center_i
+  fallback_npz_key: robust_pick_i
+
 infer:
   ckpt_path: REPLACE_ME_fine_best.pt
   device: auto

--- a/examples/config_train_fbpick_fine.yaml
+++ b/examples/config_train_fbpick_fine.yaml
@@ -22,6 +22,10 @@ transform:
   center_index: 128
   standardize_eps: 1.0e-8
 
+window_center:
+  npz_key: fine_center_i
+  fallback_npz_key: robust_pick_i
+
 train:
   seed: 0
   epochs: 10

--- a/packages/seisai-engine/src/seisai_engine/pipelines/fbpick/common/io.py
+++ b/packages/seisai-engine/src/seisai_engine/pipelines/fbpick/common/io.py
@@ -81,6 +81,27 @@ def _validate_unit_interval(name: str, arr: np.ndarray) -> None:
         raise ValueError(msg)
 
 
+def _validate_pick_time_pair(
+    *,
+    pick_key: str,
+    time_key: str,
+    pick_i: np.ndarray,
+    pick_t_sec: np.ndarray,
+    dt_sec: float,
+    n_samples_orig: int,
+) -> None:
+    if np.any(pick_i < 0) or np.any(pick_i >= int(n_samples_orig)):
+        msg = f'{pick_key} must lie in [0, n_samples_orig)'
+        raise ValueError(msg)
+    if not np.all(np.isfinite(pick_t_sec)):
+        msg = f'{time_key} must be finite'
+        raise ValueError(msg)
+    expected_t_sec = pick_i.astype(np.float32) * np.float32(dt_sec)
+    if not np.array_equal(pick_t_sec, expected_t_sec):
+        msg = f'{time_key} must equal {pick_key} * dt_sec'
+        raise ValueError(msg)
+
+
 def _require_exact_dtype(name: str, arr: np.ndarray, *, dtype) -> None:
     if arr.dtype != np.dtype(dtype):
         msg = f'{name} dtype must be {np.dtype(dtype)}, got {arr.dtype}'
@@ -283,6 +304,10 @@ def save_robust_npz(
     conf_trend1,
     conf_rs1,
     lineage,
+    trend_center_i=None,
+    trend_center_t_sec=None,
+    fine_center_i=None,
+    fine_center_t_sec=None,
 ) -> Path:
     out_path = Path(path).expanduser().resolve()
     out_path.parent.mkdir(parents=True, exist_ok=True)
@@ -384,6 +409,44 @@ def save_robust_npz(
         'lineage': _coerce_lineage(lineage),
     }
 
+    optional_center_values = {
+        'trend_center_i': trend_center_i,
+        'trend_center_t_sec': trend_center_t_sec,
+        'fine_center_i': fine_center_i,
+        'fine_center_t_sec': fine_center_t_sec,
+    }
+    for pick_key, time_key in (
+        ('trend_center_i', 'trend_center_t_sec'),
+        ('fine_center_i', 'fine_center_t_sec'),
+    ):
+        pick_value = optional_center_values[pick_key]
+        time_value = optional_center_values[time_key]
+        if pick_value is None and time_value is None:
+            continue
+        if pick_value is None or time_value is None:
+            msg = f'{pick_key} and {time_key} must be provided together'
+            raise ValueError(msg)
+        arrays[pick_key] = _coerce_vector(
+            pick_key,
+            pick_value,
+            dtype=np.int32,
+            length=n_traces_int,
+        )
+        arrays[time_key] = _coerce_vector(
+            time_key,
+            time_value,
+            dtype=np.float32,
+            length=n_traces_int,
+        )
+        _validate_pick_time_pair(
+            pick_key=pick_key,
+            time_key=time_key,
+            pick_i=arrays[pick_key],
+            pick_t_sec=arrays[time_key],
+            dt_sec=float(arrays['dt_sec'].item()),
+            n_samples_orig=n_samples_orig_int,
+        )
+
     robust_pick_i_arr = arrays['robust_pick_i']
     if np.any(robust_pick_i_arr < 0) or np.any(robust_pick_i_arr >= n_samples_orig_int):
         msg = 'robust_pick_i must lie in [0, n_samples_orig)'
@@ -466,6 +529,34 @@ def load_robust_npz(path: str | Path) -> dict[str, np.ndarray]:
             msg = f'{key} must be 1D with length n_traces'
             raise ValueError(msg)
         _require_exact_dtype(key, arr, dtype=dtype)
+
+    for pick_key, time_key in (
+        ('trend_center_i', 'trend_center_t_sec'),
+        ('fine_center_i', 'fine_center_t_sec'),
+    ):
+        if pick_key not in out and time_key not in out:
+            continue
+        if pick_key not in out or time_key not in out:
+            msg = f'robust npz must contain both {pick_key} and {time_key}'
+            raise KeyError(msg)
+        pick_i = np.asarray(out[pick_key])
+        pick_t_sec = np.asarray(out[time_key])
+        if pick_i.ndim != 1 or int(pick_i.shape[0]) != n_traces:
+            msg = f'{pick_key} must be 1D with length n_traces'
+            raise ValueError(msg)
+        if pick_t_sec.ndim != 1 or int(pick_t_sec.shape[0]) != n_traces:
+            msg = f'{time_key} must be 1D with length n_traces'
+            raise ValueError(msg)
+        _require_exact_dtype(pick_key, pick_i, dtype=np.int32)
+        _require_exact_dtype(time_key, pick_t_sec, dtype=np.float32)
+        _validate_pick_time_pair(
+            pick_key=pick_key,
+            time_key=time_key,
+            pick_i=pick_i,
+            pick_t_sec=pick_t_sec,
+            dt_sec=float(np.asarray(out['dt_sec']).item()),
+            n_samples_orig=n_samples_orig,
+        )
 
     if np.any(np.asarray(out['robust_pick_i']) < 0) or np.any(
         np.asarray(out['robust_pick_i']) >= n_samples_orig

--- a/packages/seisai-engine/src/seisai_engine/pipelines/fbpick/fine/__init__.py
+++ b/packages/seisai-engine/src/seisai_engine/pipelines/fbpick/fine/__init__.py
@@ -25,6 +25,7 @@ from .config import (
     FineInferConfig,
     FineTrainConfig,
     FineViewerCfg,
+    FineWindowCenterCfg,
     load_fine_infer_config,
     load_fine_train_config,
 )
@@ -60,6 +61,7 @@ __all__ = [
     'FineTrainBundle',
     'FineTrainConfig',
     'FineViewerCfg',
+    'FineWindowCenterCfg',
     'build_criterion',
     'build_fine_init_state_dict',
     'build_infer_transform',

--- a/packages/seisai-engine/src/seisai_engine/pipelines/fbpick/fine/build_dataset.py
+++ b/packages/seisai-engine/src/seisai_engine/pipelines/fbpick/fine/build_dataset.py
@@ -93,7 +93,29 @@ def _validate_local_transform_meta(meta: dict) -> None:
     meta['start'] = 0
 
 
-def _load_robust_centers_for_info(robust_npz_path: str, info) -> np.ndarray:
+def _select_center_vector(
+    robust: dict[str, np.ndarray],
+    *,
+    npz_key: str,
+    fallback_npz_key: str | None,
+) -> tuple[str, np.ndarray]:
+    center_key = str(npz_key)
+    fallback_key = None if fallback_npz_key is None else str(fallback_npz_key)
+    if center_key in robust:
+        return center_key, np.asarray(robust[center_key])
+    if fallback_key is not None and fallback_key in robust:
+        return fallback_key, np.asarray(robust[fallback_key])
+    msg = f'robust npz missing requested fine window center key: {center_key}'
+    raise KeyError(msg)
+
+
+def _load_robust_centers_for_info(
+    robust_npz_path: str,
+    info,
+    *,
+    npz_key: str = 'robust_pick_i',
+    fallback_npz_key: str | None = None,
+) -> np.ndarray:
     robust = load_robust_npz(robust_npz_path)
     n_traces = int(np.asarray(robust['n_traces']).item())
     n_samples_orig = int(np.asarray(robust['n_samples_orig']).item())
@@ -118,9 +140,21 @@ def _load_robust_centers_for_info(robust_npz_path: str, info) -> np.ndarray:
         msg = f'robust dt_sec {dt_sec} != info.dt_sec {float(info["dt_sec"])}'
         raise ValueError(msg)
 
-    centers = np.asarray(robust['robust_pick_i'], dtype=np.int64)
+    selected_key, selected = _select_center_vector(
+        robust,
+        npz_key=npz_key,
+        fallback_npz_key=fallback_npz_key,
+    )
+    if selected.ndim != 1 or int(selected.shape[0]) != n_traces:
+        msg = f'{selected_key} must be 1D with length n_traces'
+        raise ValueError(msg)
+    if not np.issubdtype(selected.dtype, np.integer):
+        msg = f'{selected_key} must be an integer center vector'
+        raise ValueError(msg)
+
+    centers = selected.astype(np.int64, copy=False)
     if np.any(centers < 0) or np.any(centers >= n_samples_orig):
-        msg = 'robust_pick_i must lie in [0, n_samples_orig)'
+        msg = f'{selected_key} must lie in [0, n_samples_orig)'
         raise ValueError(msg)
     return centers
 
@@ -330,16 +364,25 @@ class _FineLocalWindowTrainDataset(SegyGatherPipelineDataset):
         self,
         *,
         robust_npz_files: list[str],
+        window_center_npz_key: str = 'robust_pick_i',
+        window_center_fallback_npz_key: str | None = None,
         **kwargs,
     ) -> None:
         self._robust_npz_files = list(robust_npz_files)
+        self._window_center_npz_key = str(window_center_npz_key)
+        self._window_center_fallback_npz_key = window_center_fallback_npz_key
         super().__init__(**kwargs)
         if len(self._robust_npz_files) != len(self.file_infos):
             msg = 'robust_npz_files length must match indexed training files'
             raise ValueError(msg)
         self._center_pick_by_path: dict[str, np.ndarray] = {}
         for info, robust_npz_path in zip(self.file_infos, self._robust_npz_files, strict=True):
-            centers = _load_robust_centers_for_info(robust_npz_path, info)
+            centers = _load_robust_centers_for_info(
+                robust_npz_path,
+                info,
+                npz_key=self._window_center_npz_key,
+                fallback_npz_key=self._window_center_fallback_npz_key,
+            )
             self._center_pick_by_path[str(info.path)] = centers
 
     def _init_rejection_counters(self) -> dict[str, int]:
@@ -463,17 +506,26 @@ class FineInferenceGatherWindowsDataset(InferenceGatherWindowsDataset):
         *,
         robust_npz_files: Sequence[str],
         center_index: int,
+        window_center_npz_key: str = 'robust_pick_i',
+        window_center_fallback_npz_key: str | None = None,
         **kwargs,
     ) -> None:
         self._robust_npz_files = list(robust_npz_files)
         self._center_index = int(center_index)
+        self._window_center_npz_key = str(window_center_npz_key)
+        self._window_center_fallback_npz_key = window_center_fallback_npz_key
         super().__init__(**kwargs)
         if len(self._robust_npz_files) != len(self.file_infos):
             msg = 'robust_npz_files length must match indexed inference files'
             raise ValueError(msg)
         self._center_pick_by_path: dict[str, np.ndarray] = {}
         for info, robust_npz_path in zip(self.file_infos, self._robust_npz_files, strict=True):
-            centers = _load_robust_centers_for_info(robust_npz_path, info)
+            centers = _load_robust_centers_for_info(
+                robust_npz_path,
+                info,
+                npz_key=self._window_center_npz_key,
+                fallback_npz_key=self._window_center_fallback_npz_key,
+            )
             self._center_pick_by_path[str(info['path'])] = centers
 
     def __getitem__(self, i: int) -> dict:
@@ -625,6 +677,8 @@ def _build_labeled_dataset(
     use_header_cache: bool,
     waveform_mode: str,
     segy_endian: str,
+    window_center_npz_key: str = 'robust_pick_i',
+    window_center_fallback_npz_key: str | None = None,
 ) -> SegyGatherPipelineDataset:
     if sampling_overrides is not None and len(sampling_overrides) != len(segy_files):
         msg = 'sampling_overrides length must match segy_files length'
@@ -649,6 +703,8 @@ def _build_labeled_dataset(
         segy_files=list(segy_files),
         fb_files=list(fb_files),
         robust_npz_files=list(robust_npz_files),
+        window_center_npz_key=str(window_center_npz_key),
+        window_center_fallback_npz_key=window_center_fallback_npz_key,
         sampling_overrides=sampling_overrides,
         transform=transform,
         sample_transformer=sample_transformer,
@@ -690,6 +746,8 @@ def build_train_dataset(
     use_header_cache: bool,
     waveform_mode: str,
     segy_endian: str,
+    window_center_npz_key: str = 'robust_pick_i',
+    window_center_fallback_npz_key: str | None = None,
 ) -> SegyGatherPipelineDataset:
     return _build_labeled_dataset(
         segy_files=segy_files,
@@ -701,6 +759,8 @@ def build_train_dataset(
         trace_len=trace_len,
         time_len=time_len,
         center_index=center_index,
+        window_center_npz_key=window_center_npz_key,
+        window_center_fallback_npz_key=window_center_fallback_npz_key,
         standardize_eps=standardize_eps,
         trace_decimate_prob=trace_decimate_prob,
         trace_decimate_stride_range=trace_decimate_stride_range,
@@ -735,6 +795,8 @@ def build_labeled_infer_dataset(
     use_header_cache: bool,
     waveform_mode: str,
     segy_endian: str,
+    window_center_npz_key: str = 'robust_pick_i',
+    window_center_fallback_npz_key: str | None = None,
 ) -> SegyGatherPipelineDataset:
     return _build_labeled_dataset(
         segy_files=segy_files,
@@ -746,6 +808,8 @@ def build_labeled_infer_dataset(
         trace_len=trace_len,
         time_len=time_len,
         center_index=center_index,
+        window_center_npz_key=window_center_npz_key,
+        window_center_fallback_npz_key=window_center_fallback_npz_key,
         standardize_eps=standardize_eps,
         trace_decimate_prob=0.0,
         trace_decimate_stride_range=(1, 1),
@@ -773,6 +837,8 @@ def build_raw_infer_dataset(
     waveform_mode: str,
     segy_endian: str,
     use_header_cache: bool,
+    window_center_npz_key: str = 'robust_pick_i',
+    window_center_fallback_npz_key: str | None = None,
 ) -> FineInferenceGatherWindowsDataset:
     stride_traces = int(trace_len) - int(overlap_h)
     if stride_traces <= 0:
@@ -796,6 +862,8 @@ def build_raw_infer_dataset(
         fb_files=None,
         robust_npz_files=list(robust_npz_files),
         center_index=int(center_index),
+        window_center_npz_key=str(window_center_npz_key),
+        window_center_fallback_npz_key=window_center_fallback_npz_key,
         plan=plan,
         cfg=cfg,
         transform=build_infer_transform(standardize_eps=float(standardize_eps)),

--- a/packages/seisai-engine/src/seisai_engine/pipelines/fbpick/fine/config.py
+++ b/packages/seisai-engine/src/seisai_engine/pipelines/fbpick/fine/config.py
@@ -49,6 +49,7 @@ __all__ = [
     'FineTrainCfg',
     'FineTrainConfig',
     'FineTransformCfg',
+    'FineWindowCenterCfg',
     'load_fine_infer_config',
     'load_fine_train_config',
 ]
@@ -95,6 +96,12 @@ class FineTransformCfg:
     time_len: int
     center_index: int
     standardize_eps: float
+
+
+@dataclass(frozen=True)
+class FineWindowCenterCfg:
+    npz_key: str
+    fallback_npz_key: str | None
 
 
 @dataclass(frozen=True)
@@ -150,6 +157,7 @@ class FineTrainConfig:
     paths: FinePaths
     dataset: FineDatasetCfg
     transform: FineTransformCfg
+    window_center: FineWindowCenterCfg
     train: FineTrainCfg
     init: FineInitCfg
     model_sig: dict[str, Any]
@@ -161,6 +169,7 @@ class FineInferConfig:
     paths: FinePaths
     dataset: FineDatasetCfg
     transform: FineTransformCfg
+    window_center: FineWindowCenterCfg
     infer: FineInferRuntimeCfg
     viewer: FineViewerCfg
     model_sig: dict[str, Any]
@@ -329,6 +338,37 @@ def _load_transform_cfg(cfg: dict) -> FineTransformCfg:
     )
 
 
+def _load_window_center_cfg(cfg: dict) -> FineWindowCenterCfg:
+    window_cfg = cfg.get('window_center')
+    if window_cfg is None:
+        window_cfg = {}
+    if not isinstance(window_cfg, dict):
+        msg = 'window_center must be dict'
+        raise TypeError(msg)
+
+    npz_key = optional_str(window_cfg, 'npz_key', 'robust_pick_i').strip()
+    if not npz_key:
+        msg = 'window_center.npz_key must be non-empty'
+        raise ValueError(msg)
+
+    fallback_raw = window_cfg.get('fallback_npz_key')
+    if fallback_raw is None:
+        fallback_npz_key = None
+    else:
+        if not isinstance(fallback_raw, str):
+            msg = 'window_center.fallback_npz_key must be str or null'
+            raise TypeError(msg)
+        fallback_npz_key = fallback_raw.strip()
+        if not fallback_npz_key:
+            msg = 'window_center.fallback_npz_key must be non-empty when provided'
+            raise ValueError(msg)
+
+    return FineWindowCenterCfg(
+        npz_key=npz_key,
+        fallback_npz_key=fallback_npz_key,
+    )
+
+
 def _load_viewer_cfg(cfg: dict) -> FineViewerCfg:
     viewer_cfg = cfg.get('viewer')
     if viewer_cfg is None:
@@ -452,6 +492,7 @@ def load_fine_train_config(
         ),
         dataset=_load_dataset_cfg(cfg),
         transform=_load_transform_cfg(cfg),
+        window_center=_load_window_center_cfg(cfg),
         train=FineTrainCfg(
             lr=float(require_float(train_cfg, 'lr')),
             weight_decay=float(optional_float(train_cfg, 'weight_decay', 0.0)),
@@ -509,6 +550,7 @@ def load_fine_infer_config(cfg: dict) -> FineInferConfig:
         ),
         dataset=_load_dataset_cfg(cfg),
         transform=transform,
+        window_center=_load_window_center_cfg(cfg),
         infer=FineInferRuntimeCfg(
             batch_size=int(optional_int(infer_cfg, 'batch_size', 1)),
             num_workers=int(optional_int(infer_cfg, 'num_workers', 0)),

--- a/packages/seisai-engine/src/seisai_engine/pipelines/fbpick/fine/infer.py
+++ b/packages/seisai-engine/src/seisai_engine/pipelines/fbpick/fine/infer.py
@@ -73,6 +73,8 @@ _SAFE_OVERRIDE_PATHS = frozenset(
         'infer.source_model_id',
         'infer.iter_id',
         'infer.allow_unsafe_override',
+        'window_center.npz_key',
+        'window_center.fallback_npz_key',
         'viewer.enabled',
         'viewer.save_overview_png',
         'viewer.dpi',
@@ -103,6 +105,10 @@ def _default_cfg() -> dict[str, Any]:
             'time_len': 256,
             'center_index': 128,
             'standardize_eps': 1.0e-8,
+        },
+        'window_center': {
+            'npz_key': 'robust_pick_i',
+            'fallback_npz_key': None,
         },
         'infer': {
             'ckpt_path': '',
@@ -219,6 +225,8 @@ def _run_fine_local_infer_impl(
         waveform_mode=typed.dataset.waveform_mode,
         segy_endian=typed.dataset.infer_endian,
         use_header_cache=typed.dataset.use_header_cache,
+        window_center_npz_key=typed.window_center.npz_key,
+        window_center_fallback_npz_key=typed.window_center.fallback_npz_key,
     )
 
     loader = DataLoader(

--- a/packages/seisai-engine/src/seisai_engine/pipelines/fbpick/fine/train.py
+++ b/packages/seisai-engine/src/seisai_engine/pipelines/fbpick/fine/train.py
@@ -209,6 +209,8 @@ def build_train_bundle(
         use_header_cache=typed.dataset.use_header_cache,
         waveform_mode=typed.dataset.waveform_mode,
         segy_endian=typed.dataset.train_endian,
+        window_center_npz_key=typed.window_center.npz_key,
+        window_center_fallback_npz_key=typed.window_center.fallback_npz_key,
     )
     ds_infer_full = build_labeled_infer_dataset(
         segy_files=list(typed.paths.infer_segy_files),
@@ -229,6 +231,8 @@ def build_train_bundle(
         use_header_cache=typed.dataset.use_header_cache,
         waveform_mode=typed.dataset.waveform_mode,
         segy_endian=typed.dataset.train_endian,
+        window_center_npz_key=typed.window_center.npz_key,
+        window_center_fallback_npz_key=typed.window_center.fallback_npz_key,
     )
 
     model_sig = dict(typed.model_sig)

--- a/packages/seisai-engine/src/seisai_engine/pipelines/fbpick/physics/run.py
+++ b/packages/seisai-engine/src/seisai_engine/pipelines/fbpick/physics/run.py
@@ -67,6 +67,10 @@ def build_robust_payload_from_coarse(
         'conf_prob1': np.asarray(confidence.conf_prob1, dtype=np.float32),
         'conf_trend1': np.asarray(confidence.conf_trend1, dtype=np.float32),
         'conf_rs1': np.asarray(confidence.conf_rs1, dtype=np.float32),
+        'trend_center_i': np.asarray(trend.trend_center_i, dtype=np.int32),
+        'trend_center_t_sec': np.asarray(trend.trend_center_sec, dtype=np.float32),
+        'fine_center_i': np.asarray(trend.trend_center_i, dtype=np.int32),
+        'fine_center_t_sec': np.asarray(trend.trend_center_sec, dtype=np.float32),
         'lineage': build_lineage_payload(
             canonical_cfg,
             repo_root=repo_root,

--- a/packages/seisai-engine/tests/test_fbpick_fine.py
+++ b/packages/seisai-engine/tests/test_fbpick_fine.py
@@ -176,33 +176,40 @@ def _write_robust_with_n_samples(
     robust_pick_i: np.ndarray,
     n_samples_orig: int,
     dt_sec: float,
+    fine_center_i: np.ndarray | None = None,
 ) -> str:
     robust_pick_i_arr = np.asarray(robust_pick_i, dtype=np.int32)
     n_traces = int(robust_pick_i_arr.shape[0])
-    save_robust_npz(
-        path,
-        dt_sec=float(dt_sec),
-        n_samples_orig=int(n_samples_orig),
-        n_traces=n_traces,
-        ffid_values=np.ones(n_traces, dtype=np.int32),
-        chno_values=np.arange(1, n_traces + 1, dtype=np.int32),
-        offsets_m=np.arange(n_traces, dtype=np.float32) * 10.0,
-        trace_indices=np.arange(n_traces, dtype=np.int64),
-        robust_pick_i=robust_pick_i_arr,
-        robust_pick_t_sec=robust_pick_i_arr.astype(np.float32) * np.float32(dt_sec),
-        robust_conf=np.ones(n_traces, dtype=np.float32),
-        robust_source=np.full(
+    payload = {
+        'dt_sec': float(dt_sec),
+        'n_samples_orig': int(n_samples_orig),
+        'n_traces': n_traces,
+        'ffid_values': np.ones(n_traces, dtype=np.int32),
+        'chno_values': np.arange(1, n_traces + 1, dtype=np.int32),
+        'offsets_m': np.arange(n_traces, dtype=np.float32) * 10.0,
+        'trace_indices': np.arange(n_traces, dtype=np.int64),
+        'robust_pick_i': robust_pick_i_arr,
+        'robust_pick_t_sec': robust_pick_i_arr.astype(np.float32) * np.float32(dt_sec),
+        'robust_conf': np.ones(n_traces, dtype=np.float32),
+        'robust_source': np.full(
             n_traces,
             ROBUST_SOURCE_COARSE_OBSERVED,
             dtype=np.uint8,
         ),
-        used_theoretical_mask=np.zeros(n_traces, dtype=np.bool_),
-        reason_mask=np.zeros(n_traces, dtype=np.uint8),
-        conf_prob1=np.ones(n_traces, dtype=np.float32),
-        conf_trend1=np.ones(n_traces, dtype=np.float32),
-        conf_rs1=np.ones(n_traces, dtype=np.float32),
-        lineage=np.asarray('synthetic-lineage'),
-    )
+        'used_theoretical_mask': np.zeros(n_traces, dtype=np.bool_),
+        'reason_mask': np.zeros(n_traces, dtype=np.uint8),
+        'conf_prob1': np.ones(n_traces, dtype=np.float32),
+        'conf_trend1': np.ones(n_traces, dtype=np.float32),
+        'conf_rs1': np.ones(n_traces, dtype=np.float32),
+        'lineage': np.asarray('synthetic-lineage'),
+    }
+    if fine_center_i is not None:
+        fine_center_i_arr = np.asarray(fine_center_i, dtype=np.int32)
+        payload['fine_center_i'] = fine_center_i_arr
+        payload['fine_center_t_sec'] = (
+            fine_center_i_arr.astype(np.float32) * np.float32(dt_sec)
+        )
+    save_robust_npz(path, **payload)
     return str(path.resolve())
 
 
@@ -430,6 +437,8 @@ def test_load_fine_train_config_returns_fixed_contract_values(tmp_path: Path) ->
     assert typed.train.fb_sigma_ms == pytest.approx(3.0)
     assert typed.model_sig['in_chans'] == 1
     assert typed.model_sig['out_chans'] == 1
+    assert typed.window_center.npz_key == 'robust_pick_i'
+    assert typed.window_center.fallback_npz_key is None
     assert typed.ckpt.pipeline == 'fbpick'
     assert typed.ckpt.stage == 'fine'
     assert typed.ckpt.output_ids == ('P',)
@@ -496,6 +505,25 @@ def test_load_fine_infer_config_returns_default_high_conf_threshold(
     )
 
     assert typed.infer.high_conf_threshold == pytest.approx(0.5)
+    assert typed.window_center.npz_key == 'robust_pick_i'
+    assert typed.window_center.fallback_npz_key is None
+
+
+def test_load_fine_infer_config_parses_window_center(tmp_path: Path) -> None:
+    cfg = _make_fine_infer_config(
+        tmp_path,
+        segy_path='dummy.sgy',
+        robust_path='dummy.robust.npz',
+    )
+    cfg['window_center'] = {
+        'npz_key': 'fine_center_i',
+        'fallback_npz_key': 'robust_pick_i',
+    }
+
+    typed = load_fine_infer_config(cfg)
+
+    assert typed.window_center.npz_key == 'fine_center_i'
+    assert typed.window_center.fallback_npz_key == 'robust_pick_i'
 
 
 def test_load_fine_infer_config_parses_explicit_coarse_npz_files(
@@ -817,6 +845,57 @@ def test_fine_infer_dataset_meta_includes_raw_restore_fields(
     assert int(meta['center_raw_i'][0]) == int(robust[0])
 
 
+def test_fine_infer_dataset_uses_configured_fine_center(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    n_traces = 160
+    n_samples = 512
+    dt_sec = 0.002
+    traces = np.zeros((n_traces, n_samples), dtype=np.float32)
+    robust = np.full((n_traces,), 80, dtype=np.int32)
+    fine_center = np.linspace(180, 220, n_traces, dtype=np.int32)
+
+    segy_path = _register_synthetic_segy(tmp_path, 'infer_fine_center.sgy', traces)
+    robust_path = _write_robust_with_n_samples(
+        tmp_path / 'infer_fine_center.robust.npz',
+        robust_pick_i=robust,
+        fine_center_i=fine_center,
+        n_samples_orig=n_samples,
+        dt_sec=dt_sec,
+    )
+    _patch_synthetic_file_infos(
+        monkeypatch,
+        traces_by_path={segy_path: traces},
+        dt_sec=dt_sec,
+    )
+
+    ds = build_raw_infer_dataset(
+        segy_files=[segy_path],
+        robust_npz_files=[robust_path],
+        plan=build_plan(sigma_ms=3.0, sigma_samples_min=1.5, sigma_samples_max=12.0),
+        trace_len=128,
+        overlap_h=96,
+        time_len=256,
+        center_index=128,
+        standardize_eps=1.0e-8,
+        waveform_mode='eager',
+        segy_endian='big',
+        use_header_cache=False,
+        window_center_npz_key='fine_center_i',
+        window_center_fallback_npz_key='robust_pick_i',
+    )
+
+    try:
+        sample = ds[0]
+    finally:
+        ds.close()
+
+    meta = sample['meta']
+    np.testing.assert_array_equal(meta['center_raw_i'][:5], fine_center[:5])
+    np.testing.assert_array_equal(meta['window_start_i'][:5], fine_center[:5] - 128)
+
+
 def test_build_fine_init_state_dict_slices_first_conv_waveform_channel() -> None:
     coarse_model = build_coarse_model(_coarse_model_sig())
     fine_model = build_fine_model(_fine_model_sig())
@@ -1092,6 +1171,58 @@ def test_run_fine_local_infer_restores_raw_indices_and_covers_all_traces(
         final_pick.astype(np.float32) * np.float32(dt_sec),
         atol=1.0e-6,
     )
+
+
+def test_run_fine_local_infer_uses_configured_fine_center(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    n_traces = 160
+    n_samples = 512
+    dt_sec = 0.002
+    trace_axis = np.arange(n_traces, dtype=np.int32)
+    robust = np.full((n_traces,), 80, dtype=np.int32)
+    fine_center = 220 + ((trace_axis % 7) - 3) * 4
+    final_pick = fine_center + ((trace_axis % 5) - 2) * 7
+
+    traces = np.zeros((n_traces, n_samples), dtype=np.float32)
+    for trace_idx, pick_idx in enumerate(final_pick.tolist()):
+        traces[trace_idx, int(pick_idx)] = 10.0 + 0.01 * float(trace_idx)
+
+    segy_path = _register_synthetic_segy(tmp_path, 'fine_center_infer.sgy', traces)
+    robust_path = _write_robust_with_n_samples(
+        tmp_path / 'fine_center_infer.robust.npz',
+        robust_pick_i=robust,
+        fine_center_i=fine_center,
+        n_samples_orig=n_samples,
+        dt_sec=dt_sec,
+    )
+    _patch_synthetic_file_infos(
+        monkeypatch,
+        traces_by_path={segy_path: traces},
+        dt_sec=dt_sec,
+    )
+
+    cfg = _make_fine_infer_config(
+        tmp_path,
+        segy_path=segy_path,
+        robust_path=robust_path,
+    )
+    cfg['window_center'] = {
+        'npz_key': 'fine_center_i',
+        'fallback_npz_key': 'robust_pick_i',
+    }
+    result = run_fine_local_infer(
+        model=_IdentityFineModel(),
+        cfg=cfg,
+        device=torch.device('cpu'),
+    )
+
+    np.testing.assert_array_equal(
+        result['window_start_i'],
+        (fine_center - 128).astype(np.int32),
+    )
+    np.testing.assert_array_equal(result['final_pick_i'], final_pick.astype(np.int32))
 
 
 def test_run_fine_infer_builds_and_saves_final_payload(

--- a/packages/seisai-engine/tests/test_fbpick_physics.py
+++ b/packages/seisai-engine/tests/test_fbpick_physics.py
@@ -220,6 +220,42 @@ def test_save_and_load_robust_npz_preserve_contract(tmp_path: Path) -> None:
             np.testing.assert_array_equal(loaded[key], value)
 
 
+def test_save_and_load_robust_npz_preserve_optional_center_fields(tmp_path: Path) -> None:
+    center_i = np.array([100, 105, 110], dtype=np.int32)
+    center_t_sec = center_i.astype(np.float32) * np.float32(0.004)
+    payload = {
+        'dt_sec': np.asarray(0.004, dtype=np.float32),
+        'n_samples_orig': np.asarray(512, dtype=np.int32),
+        'n_traces': np.asarray(3, dtype=np.int32),
+        'ffid_values': np.array([1, 1, 1], dtype=np.int32),
+        'chno_values': np.array([1, 2, 3], dtype=np.int32),
+        'offsets_m': np.array([100.0, 200.0, 300.0], dtype=np.float32),
+        'trace_indices': np.array([0, 1, 2], dtype=np.int64),
+        'robust_pick_i': np.array([101, 106, 111], dtype=np.int32),
+        'robust_pick_t_sec': np.array([0.404, 0.424, 0.444], dtype=np.float32),
+        'robust_conf': np.array([0.9, 0.8, 0.7], dtype=np.float32),
+        'robust_source': np.array([0, 2, 0], dtype=np.uint8),
+        'used_theoretical_mask': np.array([False, False, False], dtype=np.bool_),
+        'reason_mask': np.zeros((3,), dtype=np.uint8),
+        'conf_prob1': np.array([0.9, 0.2, 0.8], dtype=np.float32),
+        'conf_trend1': np.array([0.9, 0.6, 0.8], dtype=np.float32),
+        'conf_rs1': np.array([1.0, 1.0, 1.0], dtype=np.float32),
+        'lineage': np.asarray('{"iter_id":"","source_model_id":"x","cfg_hash":"y","git_sha":"z"}'),
+        'trend_center_i': center_i,
+        'trend_center_t_sec': center_t_sec,
+        'fine_center_i': center_i,
+        'fine_center_t_sec': center_t_sec,
+    }
+
+    out_path = save_robust_npz(tmp_path / 'centers.robust.npz', **payload)
+    loaded = load_robust_npz(out_path)
+
+    np.testing.assert_array_equal(loaded['trend_center_i'], center_i)
+    np.testing.assert_array_equal(loaded['trend_center_t_sec'], center_t_sec)
+    np.testing.assert_array_equal(loaded['fine_center_i'], center_i)
+    np.testing.assert_array_equal(loaded['fine_center_t_sec'], center_t_sec)
+
+
 def test_run_physics_lite_end_to_end_outputs_full_covering_robust_picks(
     tmp_path: Path,
 ) -> None:
@@ -254,6 +290,24 @@ def test_run_physics_lite_end_to_end_outputs_full_covering_robust_picks(
     assert out_path.name == 'synthetic.robust.npz'
     assert robust['robust_pick_i'].shape == (n_traces,)
     assert robust['robust_pick_t_sec'].shape == (n_traces,)
+    assert robust['trend_center_i'].shape == (n_traces,)
+    assert robust['trend_center_t_sec'].shape == (n_traces,)
+    assert robust['fine_center_i'].shape == (n_traces,)
+    assert robust['fine_center_t_sec'].shape == (n_traces,)
+    assert robust['trend_center_i'].dtype == np.int32
+    assert robust['trend_center_t_sec'].dtype == np.float32
+    assert robust['fine_center_i'].dtype == np.int32
+    assert robust['fine_center_t_sec'].dtype == np.float32
+    np.testing.assert_array_equal(robust['fine_center_i'], robust['trend_center_i'])
+    np.testing.assert_array_equal(
+        robust['fine_center_t_sec'],
+        robust['trend_center_t_sec'],
+    )
+    np.testing.assert_array_equal(
+        robust['fine_center_t_sec'],
+        robust['fine_center_i'].astype(np.float32)
+        * np.asarray(robust['dt_sec'], dtype=np.float32),
+    )
     assert np.all(robust['robust_pick_i'] >= 0)
     assert np.all(robust['robust_pick_i'] < int(np.asarray(robust['n_samples_orig']).item()))
     assert not bool(np.any(robust['used_theoretical_mask']))
@@ -281,6 +335,15 @@ def test_build_robust_payload_from_coarse_returns_required_keys(tmp_path: Path) 
     assert payload['robust_pick_i'].dtype == np.int32
     assert payload['robust_pick_t_sec'].dtype == np.float32
     assert payload['robust_source'].dtype == np.uint8
+    assert payload['trend_center_i'].dtype == np.int32
+    assert payload['trend_center_t_sec'].dtype == np.float32
+    assert payload['fine_center_i'].dtype == np.int32
+    assert payload['fine_center_t_sec'].dtype == np.float32
+    np.testing.assert_array_equal(payload['fine_center_i'], payload['trend_center_i'])
+    np.testing.assert_array_equal(
+        payload['fine_center_t_sec'],
+        payload['trend_center_t_sec'],
+    )
     assert lineage['source_model_id'] == 'coarse-model'
     assert lineage['git_sha'] is None
 

--- a/proc/fbpick/site54/configs/config_infer_fbpick_fine.yaml
+++ b/proc/fbpick/site54/configs/config_infer_fbpick_fine.yaml
@@ -22,6 +22,10 @@ transform:
   center_index: 128
   standardize_eps: 1.0e-8
 
+window_center:
+  npz_key: fine_center_i
+  fallback_npz_key: robust_pick_i
+
 infer:
   ckpt_path: /workspace/proc/fbpick/site54/fbpick_coarse_train_out/ckpt/best.pt
   device: auto

--- a/proc/fbpick/site54/configs/config_train_fbpick_fine.yaml
+++ b/proc/fbpick/site54/configs/config_train_fbpick_fine.yaml
@@ -22,6 +22,10 @@ transform:
   center_index: 128
   standardize_eps: 1.0e-8
 
+window_center:
+  npz_key: fine_center_i
+  fallback_npz_key: robust_pick_i
+
 train:
   seed: 0
   epochs: 10


### PR DESCRIPTION
Closes #49

## Summary
- [fbpick-physics/fine] Export smoothed fine centers from physics and use them for fine windows

## Changed files
- `examples/config_infer_fbpick_fine.yaml`
- `examples/config_train_fbpick_fine.yaml`
- `packages/seisai-engine/src/seisai_engine/pipelines/fbpick/common/io.py`
- `packages/seisai-engine/src/seisai_engine/pipelines/fbpick/fine/__init__.py`
- `packages/seisai-engine/src/seisai_engine/pipelines/fbpick/fine/build_dataset.py`
- `packages/seisai-engine/src/seisai_engine/pipelines/fbpick/fine/config.py`
- `packages/seisai-engine/src/seisai_engine/pipelines/fbpick/fine/infer.py`
- `packages/seisai-engine/src/seisai_engine/pipelines/fbpick/fine/train.py`
- `packages/seisai-engine/src/seisai_engine/pipelines/fbpick/physics/run.py`
- `packages/seisai-engine/tests/test_fbpick_fine.py`
- `packages/seisai-engine/tests/test_fbpick_physics.py`
- `proc/fbpick/site54/configs/config_infer_fbpick_fine.yaml`
- `proc/fbpick/site54/configs/config_train_fbpick_fine.yaml`

## Checks
- `.work/codex/checks.log`: 822 passed, 5 warnings in 59.11s

## Review
- `.work/codex/review.txt`: accept: yes
- findings: blocker 0, major 0, minor 1
