### PR TITLE
[fbpick-physics-qc] Skip invalid or oversized gathers in physics QC visualization

### DIFF
--- a/cli/run_fbpick_physics_qc.py
+++ b/cli/run_fbpick_physics_qc.py
@@ -227,10 +227,41 @@ def _load_vis_cfg(cfg: dict[str, Any]) -> dict[str, Any]:
 		msg = 'vis.save_summary_csv must be bool'
 		raise TypeError(msg)
 
+	skip_gather_keys_raw = vis.get('skip_gather_keys', {})
+	if not isinstance(skip_gather_keys_raw, dict) or not all(
+		isinstance(key, str) for key in skip_gather_keys_raw
+	):
+		msg = 'vis.skip_gather_keys must be dict[str, list[int]]'
+		raise TypeError(msg)
+	skip_gather_keys: dict[str, set[int]] = {}
+	for primary_key, values in skip_gather_keys_raw.items():
+		if not isinstance(values, list) or not all(
+			isinstance(item, int) and not isinstance(item, bool) for item in values
+		):
+			msg = 'vis.skip_gather_keys must be dict[str, list[int]]'
+			raise TypeError(msg)
+		skip_gather_keys[primary_key] = {int(item) for item in values}
+
+	max_traces_per_gather_raw = vis.get('max_traces_per_gather', 10000)
+	if max_traces_per_gather_raw is None:
+		max_traces_per_gather = None
+	elif isinstance(max_traces_per_gather_raw, bool) or not isinstance(
+		max_traces_per_gather_raw, int
+	):
+		msg = 'vis.max_traces_per_gather must be int > 0 or null'
+		raise TypeError(msg)
+	elif int(max_traces_per_gather_raw) <= 0:
+		msg = 'vis.max_traces_per_gather must be int > 0 or null'
+		raise ValueError(msg)
+	else:
+		max_traces_per_gather = int(max_traces_per_gather_raw)
+
 	return {
 		'max_gathers_per_file': int(max_gathers_per_file),
 		'save_cdf': bool(save_cdf),
 		'save_summary_csv': bool(save_summary_csv),
+		'skip_gather_keys': skip_gather_keys,
+		'max_traces_per_gather': max_traces_per_gather,
 	}
 
 
@@ -261,6 +292,9 @@ def _iter_vis_gathers(
 	*,
 	primary_keys: list[str],
 	max_gathers: int,
+	skip_gather_keys: dict[str, set[int]],
+	max_traces_per_gather: int | None,
+	segy_path: str | Path | None = None,
 ):
 	yielded = 0
 	for primary_key in primary_keys:
@@ -270,17 +304,38 @@ def _iter_vis_gathers(
 		key_to_indices = info.get(f'{primary_key}_key_to_indices')
 		if key_to_indices is None:
 			continue
+		skip_for_primary = skip_gather_keys.get(primary_key, set())
 		for gather_key in sorted(key_to_indices):
 			if yielded >= int(max_gathers):
 				return
+			gather_key_i = int(gather_key)
+			raw_indices = key_to_indices[gather_key]
+			n_traces = int(len(raw_indices))
+			if gather_key_i in skip_for_primary:
+				print(
+					f'skip gather by key: file={segy_path} '
+					f'primary={primary_key} key={gather_key_i} traces={n_traces}'
+				)
+				continue
+			if (
+				max_traces_per_gather is not None
+				and n_traces > int(max_traces_per_gather)
+			):
+				print(
+					f'skip oversized gather: file={segy_path} '
+					f'primary={primary_key} key={gather_key_i} '
+					f'traces={n_traces} limit={int(max_traces_per_gather)}'
+				)
+				continue
+			indices = np.asarray(raw_indices, dtype=np.int64)
 			trace_indices = _sort_gather_indices(
 				info,
 				primary_key=primary_key,
-				indices=np.asarray(key_to_indices[gather_key], dtype=np.int64),
+				indices=indices,
 			)
 			if int(trace_indices.size) <= 0:
 				continue
-			yield primary_key, int(gather_key), trace_indices
+			yield primary_key, gather_key_i, trace_indices
 			yielded += 1
 
 
@@ -331,6 +386,9 @@ def _save_vis_pngs(
 			info,
 			primary_keys=list(dataset_cfg['primary_keys']),
 			max_gathers=max_gathers,
+			skip_gather_keys=dict(vis_cfg['skip_gather_keys']),
+			max_traces_per_gather=vis_cfg['max_traces_per_gather'],
+			segy_path=segy_path,
 		)
 	):
 		x_hw = np.stack(
@@ -349,6 +407,8 @@ def _save_vis_pngs(
 				title=title,
 			)
 		)
+	if not out_paths:
+		print(f'No gather PNGs written for {segy_path}: all candidates were skipped')
 	return out_paths
 
 

--- a/cli/run_fbpick_physics_qc.py
+++ b/cli/run_fbpick_physics_qc.py
@@ -227,6 +227,29 @@ def _load_vis_cfg(cfg: dict[str, Any]) -> dict[str, Any]:
 		msg = 'vis.save_summary_csv must be bool'
 		raise TypeError(msg)
 
+	waveform_norm = vis.get('waveform_norm', 'global')
+	if not isinstance(waveform_norm, str):
+		msg = 'vis.waveform_norm must be str'
+		raise TypeError(msg)
+	if waveform_norm not in ('global', 'per_trace'):
+		msg = 'vis.waveform_norm must be one of: global, per_trace'
+		raise ValueError(msg)
+
+	clip_percentile_raw = vis.get('clip_percentile', 99.0)
+	if isinstance(clip_percentile_raw, bool) or not isinstance(
+		clip_percentile_raw, (int, float)
+	):
+		msg = 'vis.clip_percentile must be float'
+		raise TypeError(msg)
+	clip_percentile = float(clip_percentile_raw)
+	if (
+		not np.isfinite(clip_percentile)
+		or clip_percentile <= 0.0
+		or clip_percentile > 100.0
+	):
+		msg = 'vis.clip_percentile must lie in (0, 100]'
+		raise ValueError(msg)
+
 	skip_gather_keys_raw = vis.get('skip_gather_keys', {})
 	if not isinstance(skip_gather_keys_raw, dict) or not all(
 		isinstance(key, str) for key in skip_gather_keys_raw
@@ -260,6 +283,8 @@ def _load_vis_cfg(cfg: dict[str, Any]) -> dict[str, Any]:
 		'max_gathers_per_file': int(max_gathers_per_file),
 		'save_cdf': bool(save_cdf),
 		'save_summary_csv': bool(save_summary_csv),
+		'waveform_norm': waveform_norm,
+		'clip_percentile': clip_percentile,
 		'skip_gather_keys': skip_gather_keys,
 		'max_traces_per_gather': max_traces_per_gather,
 	}
@@ -405,6 +430,8 @@ def _save_vis_pngs(
 				coarse_pick_i=coarse_pick_i[trace_indices],
 				robust_pick_i=robust_pick_i[trace_indices],
 				title=title,
+				waveform_norm=str(vis_cfg['waveform_norm']),
+				clip_percentile=float(vis_cfg['clip_percentile']),
 			)
 		)
 	if not out_paths:

--- a/packages/seisai-engine/src/seisai_engine/viewer/fbpick.py
+++ b/packages/seisai-engine/src/seisai_engine/viewer/fbpick.py
@@ -461,6 +461,46 @@ def _resolve_overview_clip(raw_wave_hw: np.ndarray, *, clip_percentile: float) -
 	return 1.0
 
 
+def _normalize_waveform_for_qc_display(
+	wave: np.ndarray,
+	*,
+	mode: str,
+	clip_percentile: float,
+	eps: float = 1.0e-6,
+) -> np.ndarray:
+	wave_f32 = np.ascontiguousarray(np.asarray(wave, dtype=np.float32))
+	if wave_f32.ndim != 2:
+		msg = f'wave must be 2D, got {wave_f32.shape}'
+		raise ValueError(msg)
+
+	if mode == 'global':
+		_resolve_overview_clip(wave_f32, clip_percentile=clip_percentile)
+		return wave_f32
+	if mode == 'per_trace':
+		percentile = float(clip_percentile)
+		if percentile <= 0.0 or percentile > 100.0:
+			msg = 'clip_percentile must lie in (0, 100]'
+			raise ValueError(msg)
+		eps_f = float(eps)
+		if not np.isfinite(eps_f) or eps_f <= 0.0:
+			msg = 'eps must be finite and > 0'
+			raise ValueError(msg)
+
+		scale = np.nanpercentile(np.abs(wave_f32), percentile, axis=1).astype(
+			np.float32,
+			copy=False,
+		)
+		scale = np.where(np.isfinite(scale) & (scale >= eps_f), scale, 1.0).astype(
+			np.float32,
+			copy=False,
+		)
+		display = wave_f32 / scale[:, None]
+		return np.clip(display, -1.0, 1.0).astype(np.float32, copy=False)
+
+	msg = f'unsupported waveform normalization mode: {mode!r}'
+	raise ValueError(msg)
+
+
 def _extract_batch_scalar(value: object, *, b: int) -> object:
 	if torch.is_tensor(value):
 		if value.ndim == 0:
@@ -817,6 +857,7 @@ def save_fbpick_physics_qc_gather_png(
 	title: str | None = None,
 	dpi: int = 150,
 	clip_percentile: float = 99.0,
+	waveform_norm: str = 'global',
 ) -> Path:
 	import matplotlib.pyplot as plt
 
@@ -859,7 +900,18 @@ def save_fbpick_physics_qc_gather_png(
 	robust_err[~valid_gt] = np.nan
 
 	x = np.arange(n_traces, dtype=np.float32)
-	clip_value = _resolve_overview_clip(wave, clip_percentile=clip_percentile)
+	norm_mode = str(waveform_norm)
+	wave_display = _normalize_waveform_for_qc_display(
+		wave,
+		mode=norm_mode,
+		clip_percentile=clip_percentile,
+	)
+	if norm_mode == 'global':
+		display_vmin = -_resolve_overview_clip(wave, clip_percentile=clip_percentile)
+		display_vmax = -display_vmin
+	else:
+		display_vmin = -1.0
+		display_vmax = 1.0
 	fig_width = max(14.0, float(n_traces) / 12.0)
 	fig, axes = plt.subplots(
 		1,
@@ -869,13 +921,13 @@ def save_fbpick_physics_qc_gather_png(
 	)
 
 	axes[0].imshow(
-		wave.T,
+		wave_display.T,
 		cmap='gray',
 		aspect='auto',
 		interpolation='nearest',
 		origin='upper',
-		vmin=-clip_value,
-		vmax=clip_value,
+		vmin=display_vmin,
+		vmax=display_vmax,
 	)
 	axes[0].plot(
 		x[valid_gt],
@@ -919,7 +971,9 @@ def save_fbpick_physics_qc_gather_png(
 		alpha=0.75,
 		label='robust window end',
 	)
-	axes[0].set_title('waveform and picks')
+	axes[0].set_title(
+		f'waveform and picks (norm={norm_mode}, p{float(clip_percentile):g})'
+	)
 	axes[0].set_xlabel('Trace Index')
 	axes[0].set_ylabel('Sample Index')
 	axes[0].legend(loc='upper right', fontsize=8)

--- a/packages/seisai-engine/tests/test_fbpick_physics_qc_cli.py
+++ b/packages/seisai-engine/tests/test_fbpick_physics_qc_cli.py
@@ -30,12 +30,16 @@ def test_load_vis_cfg_parses_skip_keys_and_max_traces() -> None:
             'vis': {
                 'skip_gather_keys': {'ffid': [0], 'cmp': [-1, 2]},
                 'max_traces_per_gather': 10000,
+                'waveform_norm': 'per_trace',
+                'clip_percentile': 99.0,
             }
         }
     )
 
     assert vis_cfg['skip_gather_keys'] == {'ffid': {0}, 'cmp': {-1, 2}}
     assert vis_cfg['max_traces_per_gather'] == 10000
+    assert vis_cfg['waveform_norm'] == 'per_trace'
+    assert vis_cfg['clip_percentile'] == 99.0
 
 
 def test_load_vis_cfg_allows_null_max_traces() -> None:
@@ -55,6 +59,12 @@ def test_load_vis_cfg_allows_null_max_traces() -> None:
         {'skip_gather_keys': {1: [0]}},
         {'max_traces_per_gather': 0},
         {'max_traces_per_gather': True},
+        {'waveform_norm': 'invalid'},
+        {'waveform_norm': 1},
+        {'clip_percentile': 0.0},
+        {'clip_percentile': 100.1},
+        {'clip_percentile': True},
+        {'clip_percentile': '99.0'},
     ],
 )
 def test_load_vis_cfg_rejects_invalid_new_fields(vis: dict[str, object]) -> None:
@@ -159,3 +169,42 @@ def test_save_vis_pngs_skips_oversized_before_mmap_access(
     assert f'No gather PNGs written for {segy_path}: all candidates were skipped' in (
         captured.out
     )
+
+
+def test_save_vis_pngs_passes_waveform_display_config(tmp_path: Path) -> None:
+    captured: dict[str, object] = {}
+
+    def _save(out_png: Path, **kwargs: object) -> Path:
+        captured.update(kwargs)
+        return out_png
+
+    segy_path = tmp_path / 'line' / 'small.sgy'
+    segy_path.parent.mkdir()
+    info = _ffid_info({1: [0, 1]})
+    info['mmap'] = [
+        np.asarray([0.0, 1.0, -1.0], dtype=np.float32),
+        np.asarray([0.0, 1000.0, -1000.0], dtype=np.float32),
+    ]
+    runtime = SimpleNamespace(save_fbpick_physics_qc_gather_png=_save)
+
+    out_paths = physics_qc_cli._save_vis_pngs(
+        info=info,
+        segy_path=str(segy_path),
+        out_dir=tmp_path / 'out',
+        gt_pick_i=np.asarray([1, 1], dtype=np.int64),
+        coarse_pick_i=np.asarray([1, 1], dtype=np.int64),
+        robust_pick_i=np.asarray([1, 1], dtype=np.int64),
+        dataset_cfg={'primary_keys': ['ffid']},
+        vis_cfg={
+            'max_gathers_per_file': 1,
+            'skip_gather_keys': {},
+            'max_traces_per_gather': None,
+            'waveform_norm': 'per_trace',
+            'clip_percentile': 98.5,
+        },
+        runtime=runtime,
+    )
+
+    assert len(out_paths) == 1
+    assert captured['waveform_norm'] == 'per_trace'
+    assert captured['clip_percentile'] == 98.5

--- a/packages/seisai-engine/tests/test_fbpick_physics_qc_cli.py
+++ b/packages/seisai-engine/tests/test_fbpick_physics_qc_cli.py
@@ -1,0 +1,161 @@
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+import cli.run_fbpick_physics_qc as physics_qc_cli
+
+
+def _ffid_info(key_to_indices: dict[int, list[int] | np.ndarray]) -> dict[str, object]:
+    max_index = max(
+        int(np.max(np.asarray(indices, dtype=np.int64)))
+        for indices in key_to_indices.values()
+        if int(np.asarray(indices).size) > 0
+    )
+    return {
+        'ffid_key_to_indices': {
+            key: np.asarray(indices, dtype=np.int64)
+            for key, indices in key_to_indices.items()
+        },
+        'chno_values': np.arange(max_index + 1, dtype=np.int64),
+    }
+
+
+def test_load_vis_cfg_parses_skip_keys_and_max_traces() -> None:
+    vis_cfg = physics_qc_cli._load_vis_cfg(
+        {
+            'vis': {
+                'skip_gather_keys': {'ffid': [0], 'cmp': [-1, 2]},
+                'max_traces_per_gather': 10000,
+            }
+        }
+    )
+
+    assert vis_cfg['skip_gather_keys'] == {'ffid': {0}, 'cmp': {-1, 2}}
+    assert vis_cfg['max_traces_per_gather'] == 10000
+
+
+def test_load_vis_cfg_allows_null_max_traces() -> None:
+    vis_cfg = physics_qc_cli._load_vis_cfg(
+        {'vis': {'max_traces_per_gather': None}}
+    )
+
+    assert vis_cfg['max_traces_per_gather'] is None
+
+
+@pytest.mark.parametrize(
+    'vis',
+    [
+        {'skip_gather_keys': None},
+        {'skip_gather_keys': {'ffid': [False]}},
+        {'skip_gather_keys': {'ffid': (0,)}},
+        {'skip_gather_keys': {1: [0]}},
+        {'max_traces_per_gather': 0},
+        {'max_traces_per_gather': True},
+    ],
+)
+def test_load_vis_cfg_rejects_invalid_new_fields(vis: dict[str, object]) -> None:
+    with pytest.raises((TypeError, ValueError)):
+        physics_qc_cli._load_vis_cfg({'vis': vis})
+
+
+def test_iter_vis_gathers_skips_configured_key() -> None:
+    info = _ffid_info({0: [0, 1], 1: [2], 2: [3]})
+
+    yielded = list(
+        physics_qc_cli._iter_vis_gathers(
+            info,
+            primary_keys=['ffid'],
+            max_gathers=2,
+            skip_gather_keys={'ffid': {0}},
+            max_traces_per_gather=None,
+            segy_path='line.sgy',
+        )
+    )
+
+    assert [gather_key for _, gather_key, _ in yielded] == [1, 2]
+
+
+def test_iter_vis_gathers_counts_accepted_gathers_not_skipped() -> None:
+    info = _ffid_info({0: [0], 1: [1], 2: [2], 3: [3]})
+
+    yielded = list(
+        physics_qc_cli._iter_vis_gathers(
+            info,
+            primary_keys=['ffid'],
+            max_gathers=2,
+            skip_gather_keys={'ffid': {0}},
+            max_traces_per_gather=None,
+            segy_path='line.sgy',
+        )
+    )
+
+    assert [gather_key for _, gather_key, _ in yielded] == [1, 2]
+
+
+def test_iter_vis_gathers_skips_oversized_gather(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    info = _ffid_info({1: np.arange(5), 2: np.arange(5, 7)})
+
+    yielded = list(
+        physics_qc_cli._iter_vis_gathers(
+            info,
+            primary_keys=['ffid'],
+            max_gathers=1,
+            skip_gather_keys={},
+            max_traces_per_gather=3,
+            segy_path='/data/line.sgy',
+        )
+    )
+
+    assert [gather_key for _, gather_key, _ in yielded] == [2]
+    captured = capsys.readouterr()
+    assert (
+        'skip oversized gather: file=/data/line.sgy '
+        'primary=ffid key=1 traces=5 limit=3'
+    ) in captured.out
+
+
+def test_save_vis_pngs_skips_oversized_before_mmap_access(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    class FailingMmap:
+        def __getitem__(self, index: int) -> np.ndarray:
+            raise AssertionError(f'mmap should not be read for skipped gather {index}')
+
+    def _unexpected_save(*args, **kwargs) -> Path:
+        raise AssertionError('PNG writer should not be called')
+
+    segy_path = tmp_path / 'line' / 'huge.sgy'
+    segy_path.parent.mkdir()
+    info = _ffid_info({1: np.arange(5)})
+    info['mmap'] = FailingMmap()
+    runtime = SimpleNamespace(save_fbpick_physics_qc_gather_png=_unexpected_save)
+
+    out_paths = physics_qc_cli._save_vis_pngs(
+        info=info,
+        segy_path=str(segy_path),
+        out_dir=tmp_path / 'out',
+        gt_pick_i=np.zeros(5, dtype=np.int64),
+        coarse_pick_i=np.zeros(5, dtype=np.int64),
+        robust_pick_i=np.zeros(5, dtype=np.int64),
+        dataset_cfg={'primary_keys': ['ffid']},
+        vis_cfg={
+            'max_gathers_per_file': 1,
+            'skip_gather_keys': {},
+            'max_traces_per_gather': 3,
+        },
+        runtime=runtime,
+    )
+
+    assert out_paths == []
+    captured = capsys.readouterr()
+    assert 'skip oversized gather:' in captured.out
+    assert f'No gather PNGs written for {segy_path}: all candidates were skipped' in (
+        captured.out
+    )

--- a/packages/seisai-engine/tests/test_viewer_fbpick.py
+++ b/packages/seisai-engine/tests/test_viewer_fbpick.py
@@ -5,8 +5,10 @@ from seisai_engine.infer.ckpt_meta import resolve_output_ids, resolve_softmax_ax
 from seisai_engine.viewer.fbpick import (
     _apply_softmax,
     _crop_logits_chw,
+    _normalize_waveform_for_qc_display,
     _pad_chw_to_min_tile,
     _resolve_channel_index,
+    save_fbpick_physics_qc_gather_png,
 )
 
 
@@ -201,3 +203,86 @@ def test_resolve_channel_index_accepts_supported_forms() -> None:
         _resolve_channel_index('p', output_ids=output_ids)
     with pytest.raises(ValueError):
         _resolve_channel_index('ch7', output_ids=output_ids)
+
+
+def test_qc_display_per_trace_normalization_preserves_each_trace_scale() -> None:
+    wave = np.asarray(
+        [
+            [0.0, 1.0, -2.0, 4.0],
+            [0.0, 250.0, -500.0, 1000.0],
+        ],
+        dtype=np.float32,
+    )
+
+    out = _normalize_waveform_for_qc_display(
+        wave,
+        mode='per_trace',
+        clip_percentile=100.0,
+    )
+
+    assert out.shape == wave.shape
+    assert out.dtype == np.float32
+    assert np.max(np.abs(out)) <= 1.0
+    assert np.max(np.abs(out[0])) > 0.99
+    assert np.max(np.abs(out[1])) > 0.99
+
+
+def test_qc_display_per_trace_normalization_handles_zero_traces() -> None:
+    wave = np.asarray(
+        [
+            [0.0, 0.0, 0.0],
+            [1.0e-8, -1.0e-8, 0.0],
+            [1.0, -2.0, 3.0],
+        ],
+        dtype=np.float32,
+    )
+
+    out = _normalize_waveform_for_qc_display(
+        wave,
+        mode='per_trace',
+        clip_percentile=99.0,
+    )
+
+    assert out.shape == wave.shape
+    assert out.dtype == np.float32
+    assert np.all(np.isfinite(out))
+    assert np.array_equal(out[0], np.zeros_like(out[0]))
+    assert np.max(np.abs(out)) <= 1.0
+
+
+def test_qc_display_normalization_rejects_invalid_mode() -> None:
+    wave = np.ones((2, 3), dtype=np.float32)
+
+    with pytest.raises(ValueError):
+        _normalize_waveform_for_qc_display(
+            wave,
+            mode='invalid',
+            clip_percentile=99.0,
+        )
+
+
+def test_save_fbpick_physics_qc_gather_png_per_trace_smoke(tmp_path) -> None:
+    out_png = tmp_path / 'gather.png'
+    wave = np.asarray(
+        [
+            [0.0, 0.5, 1.0, -0.5],
+            [0.0, 500.0, 1000.0, -500.0],
+            [0.0, -1.0, -0.5, 0.25],
+        ],
+        dtype=np.float32,
+    )
+    picks = np.asarray([1, 2, 1], dtype=np.int64)
+
+    out_path = save_fbpick_physics_qc_gather_png(
+        out_png,
+        raw_wave_hw=wave,
+        gt_pick_i=picks,
+        coarse_pick_i=picks,
+        robust_pick_i=picks,
+        waveform_norm='per_trace',
+        clip_percentile=99.0,
+    )
+
+    assert out_path == out_png.resolve()
+    assert out_path.is_file()
+    assert out_path.stat().st_size > 0

--- a/proc/fbpick/site54/configs/config_run_fbpick_physics_qc.yaml
+++ b/proc/fbpick/site54/configs/config_run_fbpick_physics_qc.yaml
@@ -11,6 +11,8 @@ dataset:
   use_header_cache: true
 
 vis:
+  waveform_norm: per_trace
+  clip_percentile: 99.0
   max_gathers_per_file: 8
   save_cdf: true
   save_summary_csv: true


### PR DESCRIPTION
Closes #51

## Summary
- [fbpick-physics-qc] Skip invalid or oversized gathers in physics QC visualization

## Changed files
- `cli/run_fbpick_physics_qc.py`
- `packages/seisai-engine/tests/test_fbpick_physics_qc_cli.py`

## Checks
- `.work/codex/checks.log`: 834 passed, 5 warnings in 60.74s (0:01:00)

## Review
- `.work/codex/review.txt`: accept: yes
- findings: blocker 0, major 0, minor 0
