### PR TITLE
[fbpick-fine] Add robust-center jitter augmentation with in-window supervision

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,6 +317,7 @@ pytest -q -m integration
 
 - FBPick coarse global-anchor resize 設計: `docs/fbpick_coarse_global_anchor.md`
 - FBPick coarse coverage 評価: `docs/fbpick_coarse_eval.md`
+- FBPick fine training window / jitter 契約: `docs/fbpick_fine_train.md`
 - FBPick fine inference 入力契約: `docs/fbpick_fine_infer.md`
 - SegyGatherPipelineDataset 出力契約: `docs/spec/segy_gather_pipeline_dataset_output_contract.md`
 - SegyGatherPipelineDataset 入力前提 (SEG-Y): `docs/spec/segy_gather_pipeline_dataset_input_assumptions.md`

--- a/docs/fbpick_fine_train.md
+++ b/docs/fbpick_fine_train.md
@@ -1,0 +1,109 @@
+# FBPick Fine Training
+
+This document is the current contract for `fbpick-fine` training local windows.
+Fine inference behavior is documented separately in `docs/fbpick_fine_infer.md`.
+
+## Window Center
+
+Fine training uses the physics / robust output as the local-window center source.
+The default center key is `robust_pick_i`:
+
+```yaml
+window_center:
+  npz_key: robust_pick_i
+  fallback_npz_key: null
+```
+
+`robust_pick_i` remains the default center for training, validation, and
+inference. Do not switch the fine stage to `fine_center_i` or `trend_center_i`
+unless the fine-stage contract is changed.
+
+## Center Jitter
+
+`center_augment` adds training-only perturbations to the selected robust center.
+It simulates realistic error in the upstream coarse / physics center while
+keeping the current fine target and loss unchanged.
+
+Default config preserves the previous behavior:
+
+```yaml
+center_augment:
+  enabled: false
+  train_only: true
+  p_no_jitter: 1.0
+  uniform_jitter_samples: []
+  clip_to_record: true
+  require_fb_inside: true
+```
+
+Recommended site54 training config:
+
+```yaml
+center_augment:
+  enabled: true
+  train_only: true
+  p_no_jitter: 0.7
+  uniform_jitter_samples:
+    - {prob: 0.20, lo: -32, hi: 32}
+    - {prob: 0.08, lo: -64, hi: 64}
+    - {prob: 0.02, lo: -128, hi: 128}
+  clip_to_record: true
+  require_fb_inside: true
+```
+
+Sampling behavior:
+
+- `p_no_jitter` selects `jitter = 0`.
+- Each `uniform_jitter_samples` entry samples an integer offset from `[lo, hi]`,
+  inclusive.
+- The probabilities are normalized internally and may be specified as relative
+  weights, but their sum must be greater than zero.
+- With `clip_to_record: true`, the jittered center is clipped to
+  `[0, n_samples_orig - 1]`.
+- `require_fb_inside: false` is unsupported and rejected.
+
+## Supervision
+
+The target remains the local first-break index:
+
+```text
+fb_idx_view = fb_i - window_start_i
+```
+
+Only windows where the ground-truth first break remains inside the local window
+are used for supervised training. If jitter moves the window so the ground truth
+falls outside the local time range, the sample is rejected and redrawn.
+
+Out-of-window jittered samples are not used as negative / no-pick / noise
+examples. No-pick and noise supervision are out of scope for this fine-training
+contract.
+
+## Validation And Inference
+
+Center jitter is applied only by the fine training dataset. Validation and
+labeled-infer datasets use the configured `window_center` value directly, and
+raw fine inference also uses the configured robust center without jitter.
+
+For deterministic validation and inference, keep:
+
+```yaml
+window_center:
+  npz_key: robust_pick_i
+  fallback_npz_key: null
+```
+
+`center_augment` is not part of the fine inference config.
+
+## Rejection Monitoring
+
+Fine training retries sample construction up to `dataset.max_trials`. Rejection
+accounting includes both non-jitter local-window failures and jitter-induced
+local-window failures:
+
+```text
+rejections: empty=..., min_pick=..., fblc=..., local_window=..., center_jitter=...
+```
+
+Monitor `center_jitter` relative to `local_window` when tuning jitter ranges.
+A high `center_jitter` count means the configured jitter often places the ground
+truth outside the local window and reduces useful supervised samples.

--- a/examples/config_infer_fbpick_fine.yaml
+++ b/examples/config_infer_fbpick_fine.yaml
@@ -23,8 +23,8 @@ transform:
   standardize_eps: 1.0e-8
 
 window_center:
-  npz_key: fine_center_i
-  fallback_npz_key: robust_pick_i
+  npz_key: robust_pick_i
+  fallback_npz_key: null
 
 infer:
   ckpt_path: REPLACE_ME_fine_best.pt

--- a/examples/config_train_fbpick_fine.yaml
+++ b/examples/config_train_fbpick_fine.yaml
@@ -23,8 +23,19 @@ transform:
   standardize_eps: 1.0e-8
 
 window_center:
-  npz_key: fine_center_i
-  fallback_npz_key: robust_pick_i
+  npz_key: robust_pick_i
+  fallback_npz_key: null
+
+center_augment:
+  enabled: true
+  train_only: true
+  p_no_jitter: 0.7
+  uniform_jitter_samples:
+    - {prob: 0.20, lo: -32, hi: 32}
+    - {prob: 0.08, lo: -64, hi: 64}
+    - {prob: 0.02, lo: -128, hi: 128}
+  clip_to_record: true
+  require_fb_inside: true
 
 train:
   seed: 0

--- a/packages/seisai-engine/src/seisai_engine/pipelines/fbpick/fine/__init__.py
+++ b/packages/seisai-engine/src/seisai_engine/pipelines/fbpick/fine/__init__.py
@@ -9,6 +9,7 @@ from .build_dataset import (
     collate_input_meta_list,
     extract_local_windowed_view,
     restore_local_pick_to_raw,
+    sample_center_jitter,
 )
 from .build_model import build_model
 from .build_plan import build_plan
@@ -22,8 +23,10 @@ from .config import (
     FINE_OUT_CHANS,
     FINE_TIME_LEN,
     FINE_TRACE_LEN,
+    FineCenterAugmentCfg,
     FineInferConfig,
     FineTrainConfig,
+    FineUniformJitterCfg,
     FineViewerCfg,
     FineWindowCenterCfg,
     load_fine_infer_config,
@@ -55,11 +58,13 @@ __all__ = [
     'FINE_OUT_CHANS',
     'FINE_TIME_LEN',
     'FINE_TRACE_LEN',
+    'FineCenterAugmentCfg',
     'FineInferenceGatherWindowsDataset',
     'FineInferConfig',
     'FineLocalWindowSampleTransformer',
     'FineTrainBundle',
     'FineTrainConfig',
+    'FineUniformJitterCfg',
     'FineViewerCfg',
     'FineWindowCenterCfg',
     'build_criterion',
@@ -84,5 +89,6 @@ __all__ = [
     'run_fine_infer',
     'run_fine_local_infer',
     'run_train',
+    'sample_center_jitter',
     'validate_coarse_checkpoint_for_fine',
 ]

--- a/packages/seisai-engine/src/seisai_engine/pipelines/fbpick/fine/build_dataset.py
+++ b/packages/seisai-engine/src/seisai_engine/pipelines/fbpick/fine/build_dataset.py
@@ -23,6 +23,7 @@ from seisai_transforms.augment import PerTraceStandardize, ViewCompose
 from seisai_utils.fs import validate_files_exist
 
 from seisai_engine.pipelines.fbpick.common import load_robust_npz
+from seisai_engine.pipelines.fbpick.fine.config import FineCenterAugmentCfg
 
 __all__ = [
     'FineInferenceGatherWindowsDataset',
@@ -36,6 +37,7 @@ __all__ = [
     'collate_input_meta_list',
     'extract_local_windowed_view',
     'restore_local_pick_to_raw',
+    'sample_center_jitter',
 ]
 
 
@@ -157,6 +159,50 @@ def _load_robust_centers_for_info(
         msg = f'{selected_key} must lie in [0, n_samples_orig)'
         raise ValueError(msg)
     return centers
+
+
+def sample_center_jitter(
+    *,
+    size: int,
+    cfg: FineCenterAugmentCfg,
+    rng: np.random.Generator,
+) -> np.ndarray:
+    """Sample integer center offsets; configured weights are normalized internally."""
+    n = int(size)
+    if n < 0:
+        msg = 'size must be non-negative'
+        raise ValueError(msg)
+    out = np.zeros((n,), dtype=np.int64)
+    if n == 0 or not bool(cfg.enabled):
+        return out
+
+    weights = np.asarray(
+        [float(cfg.p_no_jitter)]
+        + [float(component.prob) for component in cfg.uniform_jitter_samples],
+        dtype=np.float64,
+    )
+    if np.any(weights < 0.0):
+        msg = 'center jitter probabilities must be non-negative'
+        raise ValueError(msg)
+    total = float(weights.sum())
+    if total <= 0.0:
+        msg = 'center jitter probabilities must sum to > 0'
+        raise ValueError(msg)
+    weights = weights / total
+
+    choices = rng.choice(int(weights.shape[0]), size=n, p=weights)
+    for component_idx, component in enumerate(cfg.uniform_jitter_samples, start=1):
+        mask = choices == component_idx
+        count = int(np.count_nonzero(mask))
+        if count == 0:
+            continue
+        out[mask] = rng.integers(
+            int(component.lo),
+            int(component.hi) + 1,
+            size=count,
+            dtype=np.int64,
+        )
+    return out
 
 
 def extract_local_windowed_view(
@@ -366,11 +412,13 @@ class _FineLocalWindowTrainDataset(SegyGatherPipelineDataset):
         robust_npz_files: list[str],
         window_center_npz_key: str = 'robust_pick_i',
         window_center_fallback_npz_key: str | None = None,
+        center_augment: FineCenterAugmentCfg | None = None,
         **kwargs,
     ) -> None:
         self._robust_npz_files = list(robust_npz_files)
         self._window_center_npz_key = str(window_center_npz_key)
         self._window_center_fallback_npz_key = window_center_fallback_npz_key
+        self._center_augment = center_augment
         super().__init__(**kwargs)
         if len(self._robust_npz_files) != len(self.file_infos):
             msg = 'robust_npz_files length must match indexed training files'
@@ -388,11 +436,12 @@ class _FineLocalWindowTrainDataset(SegyGatherPipelineDataset):
     def _init_rejection_counters(self) -> dict[str, int]:
         counters = super()._init_rejection_counters()
         counters['local_window'] = 0
+        counters['center_jitter'] = 0
         return counters
 
     def _format_max_trials_error(self, counters: dict[str, int]) -> str:
         parts = []
-        for key in ('empty', 'min_pick', 'fblc', 'local_window'):
+        for key in ('empty', 'min_pick', 'fblc', 'local_window', 'center_jitter'):
             if key in counters:
                 parts.append(f'{key}={counters[key]}')
         rej = ', '.join(parts)
@@ -415,9 +464,25 @@ class _FineLocalWindowTrainDataset(SegyGatherPipelineDataset):
         fb_subset = np.asarray(info.fb[indices], dtype=np.int64)
         centers = self._center_pick_by_path[str(info.path)]
         center_subset = np.asarray(centers[indices], dtype=np.int64)
+        center_jitter_nonzero = False
+        if self._center_augment is not None and bool(self._center_augment.enabled):
+            jitter = sample_center_jitter(
+                size=int(center_subset.shape[0]),
+                cfg=self._center_augment,
+                rng=self._rng,
+            )
+            center_jitter_nonzero = bool(np.any(jitter != 0))
+            center_subset = center_subset + jitter
+            if bool(self._center_augment.clip_to_record):
+                center_subset = np.clip(
+                    center_subset,
+                    0,
+                    int(info.n_samples) - 1,
+                ).astype(np.int64, copy=False)
         return fb_subset, {
             'apply_fb_gates': False,
             'center_subset': center_subset,
+            'center_jitter_nonzero': center_jitter_nonzero,
         }
 
     def _try_build_sample(self, info, counters: dict[str, int]) -> dict | None:
@@ -442,7 +507,10 @@ class _FineLocalWindowTrainDataset(SegyGatherPipelineDataset):
             self._rng,
         )
         if transformed is None:
-            self._count_rejection(counters, 'local_window')
+            if bool(label_state.get('center_jitter_nonzero', False)):
+                self._count_rejection(counters, 'center_jitter')
+            else:
+                self._count_rejection(counters, 'local_window')
             return None
         x_view, meta, offsets, fb_subset_pad, indices_pad, trace_valid = transformed
         view_shape = self._get_view_shape(x_view, label_state)
@@ -679,6 +747,7 @@ def _build_labeled_dataset(
     segy_endian: str,
     window_center_npz_key: str = 'robust_pick_i',
     window_center_fallback_npz_key: str | None = None,
+    center_augment: FineCenterAugmentCfg | None = None,
 ) -> SegyGatherPipelineDataset:
     if sampling_overrides is not None and len(sampling_overrides) != len(segy_files):
         msg = 'sampling_overrides length must match segy_files length'
@@ -705,6 +774,7 @@ def _build_labeled_dataset(
         robust_npz_files=list(robust_npz_files),
         window_center_npz_key=str(window_center_npz_key),
         window_center_fallback_npz_key=window_center_fallback_npz_key,
+        center_augment=center_augment,
         sampling_overrides=sampling_overrides,
         transform=transform,
         sample_transformer=sample_transformer,
@@ -748,6 +818,7 @@ def build_train_dataset(
     segy_endian: str,
     window_center_npz_key: str = 'robust_pick_i',
     window_center_fallback_npz_key: str | None = None,
+    center_augment: FineCenterAugmentCfg | None = None,
 ) -> SegyGatherPipelineDataset:
     return _build_labeled_dataset(
         segy_files=segy_files,
@@ -761,6 +832,7 @@ def build_train_dataset(
         center_index=center_index,
         window_center_npz_key=window_center_npz_key,
         window_center_fallback_npz_key=window_center_fallback_npz_key,
+        center_augment=center_augment,
         standardize_eps=standardize_eps,
         trace_decimate_prob=trace_decimate_prob,
         trace_decimate_stride_range=trace_decimate_stride_range,

--- a/packages/seisai-engine/src/seisai_engine/pipelines/fbpick/fine/config.py
+++ b/packages/seisai-engine/src/seisai_engine/pipelines/fbpick/fine/config.py
@@ -39,6 +39,7 @@ __all__ = [
     'FINE_OUT_CHANS',
     'FINE_TIME_LEN',
     'FINE_TRACE_LEN',
+    'FineCenterAugmentCfg',
     'FineCkptCfg',
     'FineDatasetCfg',
     'FineInferConfig',
@@ -49,6 +50,7 @@ __all__ = [
     'FineTrainCfg',
     'FineTrainConfig',
     'FineTransformCfg',
+    'FineUniformJitterCfg',
     'FineWindowCenterCfg',
     'load_fine_infer_config',
     'load_fine_train_config',
@@ -105,6 +107,23 @@ class FineWindowCenterCfg:
 
 
 @dataclass(frozen=True)
+class FineUniformJitterCfg:
+    prob: float
+    lo: int
+    hi: int
+
+
+@dataclass(frozen=True)
+class FineCenterAugmentCfg:
+    enabled: bool
+    train_only: bool
+    p_no_jitter: float
+    uniform_jitter_samples: tuple[FineUniformJitterCfg, ...]
+    clip_to_record: bool
+    require_fb_inside: bool
+
+
+@dataclass(frozen=True)
 class FineTrainCfg:
     lr: float
     weight_decay: float
@@ -158,6 +177,7 @@ class FineTrainConfig:
     dataset: FineDatasetCfg
     transform: FineTransformCfg
     window_center: FineWindowCenterCfg
+    center_augment: FineCenterAugmentCfg
     train: FineTrainCfg
     init: FineInitCfg
     model_sig: dict[str, Any]
@@ -369,6 +389,106 @@ def _load_window_center_cfg(cfg: dict) -> FineWindowCenterCfg:
     )
 
 
+def _optional_plain_float(
+    cfg: dict,
+    key: str,
+    default: float,
+    *,
+    key_path: str,
+) -> float:
+    if key not in cfg:
+        return float(default)
+    value = cfg[key]
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        msg = f'{key_path} must be float'
+        raise TypeError(msg)
+    return float(value)
+
+
+def _require_plain_float(cfg: dict, key: str, *, key_path: str) -> float:
+    if key not in cfg:
+        msg = f'missing config key: {key_path}'
+        raise ValueError(msg)
+    value = cfg[key]
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        msg = f'{key_path} must be float'
+        raise TypeError(msg)
+    return float(value)
+
+
+def _require_plain_int(cfg: dict, key: str, *, key_path: str) -> int:
+    if key not in cfg:
+        msg = f'missing config key: {key_path}'
+        raise ValueError(msg)
+    value = cfg[key]
+    if isinstance(value, bool) or not isinstance(value, int):
+        msg = f'{key_path} must be int'
+        raise TypeError(msg)
+    return int(value)
+
+
+def _load_center_augment_cfg(cfg: dict) -> FineCenterAugmentCfg:
+    augment_cfg = cfg.get('center_augment')
+    if augment_cfg is None:
+        augment_cfg = {}
+    if not isinstance(augment_cfg, dict):
+        msg = 'center_augment must be dict'
+        raise TypeError(msg)
+
+    p_no_jitter = _optional_plain_float(
+        augment_cfg,
+        'p_no_jitter',
+        1.0,
+        key_path='center_augment.p_no_jitter',
+    )
+    if p_no_jitter < 0.0 or p_no_jitter > 1.0:
+        msg = 'center_augment.p_no_jitter must lie in [0, 1]'
+        raise ValueError(msg)
+
+    raw_components = augment_cfg.get('uniform_jitter_samples', [])
+    if not isinstance(raw_components, list):
+        msg = 'center_augment.uniform_jitter_samples must be list'
+        raise TypeError(msg)
+
+    components: list[FineUniformJitterCfg] = []
+    for idx, item in enumerate(raw_components):
+        if not isinstance(item, dict):
+            msg = 'center_augment.uniform_jitter_samples entries must be dict'
+            raise TypeError(msg)
+        prefix = f'center_augment.uniform_jitter_samples[{idx}]'
+        prob = _require_plain_float(item, 'prob', key_path=f'{prefix}.prob')
+        if prob < 0.0:
+            msg = f'{prefix}.prob must be >= 0'
+            raise ValueError(msg)
+        lo = _require_plain_int(item, 'lo', key_path=f'{prefix}.lo')
+        hi = _require_plain_int(item, 'hi', key_path=f'{prefix}.hi')
+        if lo > hi:
+            msg = f'{prefix}.lo must be <= hi'
+            raise ValueError(msg)
+        components.append(FineUniformJitterCfg(prob=prob, lo=lo, hi=hi))
+
+    prob_sum = p_no_jitter + sum(component.prob for component in components)
+    if prob_sum <= 0.0:
+        msg = 'center_augment probabilities must sum to > 0'
+        raise ValueError(msg)
+
+    require_fb_inside = bool(
+        optional_bool(augment_cfg, 'require_fb_inside', default=True)
+    )
+    if not require_fb_inside:
+        msg = 'center_augment.require_fb_inside must be true'
+        raise ValueError(msg)
+
+    return FineCenterAugmentCfg(
+        enabled=bool(optional_bool(augment_cfg, 'enabled', default=False)),
+        train_only=bool(optional_bool(augment_cfg, 'train_only', default=True)),
+        p_no_jitter=p_no_jitter,
+        uniform_jitter_samples=tuple(components),
+        clip_to_record=bool(optional_bool(augment_cfg, 'clip_to_record', default=True)),
+        require_fb_inside=require_fb_inside,
+    )
+
+
 def _load_viewer_cfg(cfg: dict) -> FineViewerCfg:
     viewer_cfg = cfg.get('viewer')
     if viewer_cfg is None:
@@ -493,6 +613,7 @@ def load_fine_train_config(
         dataset=_load_dataset_cfg(cfg),
         transform=_load_transform_cfg(cfg),
         window_center=_load_window_center_cfg(cfg),
+        center_augment=_load_center_augment_cfg(cfg),
         train=FineTrainCfg(
             lr=float(require_float(train_cfg, 'lr')),
             weight_decay=float(optional_float(train_cfg, 'weight_decay', 0.0)),

--- a/packages/seisai-engine/src/seisai_engine/pipelines/fbpick/fine/train.py
+++ b/packages/seisai-engine/src/seisai_engine/pipelines/fbpick/fine/train.py
@@ -211,6 +211,7 @@ def build_train_bundle(
         segy_endian=typed.dataset.train_endian,
         window_center_npz_key=typed.window_center.npz_key,
         window_center_fallback_npz_key=typed.window_center.fallback_npz_key,
+        center_augment=typed.center_augment,
     )
     ds_infer_full = build_labeled_infer_dataset(
         segy_files=list(typed.paths.infer_segy_files),

--- a/packages/seisai-engine/tests/test_fbpick_fine.py
+++ b/packages/seisai-engine/tests/test_fbpick_fine.py
@@ -24,6 +24,9 @@ from seisai_engine.pipelines.fbpick.common import (
 )
 from seisai_engine.pipelines.fbpick.coarse import build_fbgate, build_model as build_coarse_model
 from seisai_engine.pipelines.fbpick.fine import (
+    FineCenterAugmentCfg,
+    FineUniformJitterCfg,
+    build_labeled_infer_dataset,
     build_model as build_fine_model,
     build_plan,
     build_raw_infer_dataset,
@@ -36,6 +39,7 @@ from seisai_engine.pipelines.fbpick.fine import (
     run_fine_local_infer,
     run_train,
     restore_local_pick_to_raw,
+    sample_center_jitter,
 )
 from seisai_engine.pipelines.fbpick.fine.infer import (
     _prepare_fine_infer_cfg,
@@ -353,6 +357,68 @@ def _make_fine_infer_config(
     }
 
 
+def _build_test_fine_train_dataset(
+    *,
+    segy_path: str,
+    fb_path: str,
+    robust_path: str,
+    center_augment: FineCenterAugmentCfg | None = None,
+    max_trials: int = 8,
+):
+    return build_train_dataset(
+        segy_files=[segy_path],
+        fb_files=[fb_path],
+        robust_npz_files=[robust_path],
+        sampling_overrides=None,
+        plan=build_plan(sigma_ms=3.0, sigma_samples_min=1.5, sigma_samples_max=12.0),
+        fbgate=build_fbgate(apply_on='off', min_pick_ratio=0.0, verbose=False),
+        trace_len=128,
+        time_len=256,
+        center_index=128,
+        standardize_eps=1.0e-8,
+        trace_decimate_prob=0.0,
+        trace_decimate_stride_range=(1, 1),
+        primary_keys=('ffid',),
+        secondary_key_fixed=False,
+        verbose=False,
+        progress=False,
+        max_trials=max_trials,
+        use_header_cache=False,
+        waveform_mode='eager',
+        segy_endian='big',
+        center_augment=center_augment,
+    )
+
+
+def _build_test_fine_labeled_infer_dataset(
+    *,
+    segy_path: str,
+    fb_path: str,
+    robust_path: str,
+    max_trials: int = 8,
+):
+    return build_labeled_infer_dataset(
+        segy_files=[segy_path],
+        fb_files=[fb_path],
+        robust_npz_files=[robust_path],
+        sampling_overrides=None,
+        plan=build_plan(sigma_ms=3.0, sigma_samples_min=1.5, sigma_samples_max=12.0),
+        fbgate=build_fbgate(apply_on='off', min_pick_ratio=0.0, verbose=False),
+        trace_len=128,
+        time_len=256,
+        center_index=128,
+        standardize_eps=1.0e-8,
+        primary_keys=('ffid',),
+        secondary_key_fixed=False,
+        verbose=False,
+        progress=False,
+        max_trials=max_trials,
+        use_header_cache=False,
+        waveform_mode='eager',
+        segy_endian='big',
+    )
+
+
 def _write_coarse_ckpt(tmp_path: Path) -> str:
     path = tmp_path / 'coarse_init.pt'
     model = build_coarse_model(_coarse_model_sig())
@@ -439,10 +505,101 @@ def test_load_fine_train_config_returns_fixed_contract_values(tmp_path: Path) ->
     assert typed.model_sig['out_chans'] == 1
     assert typed.window_center.npz_key == 'robust_pick_i'
     assert typed.window_center.fallback_npz_key is None
+    assert typed.center_augment.enabled is False
+    assert typed.center_augment.train_only is True
+    assert typed.center_augment.p_no_jitter == pytest.approx(1.0)
+    assert typed.center_augment.uniform_jitter_samples == ()
+    assert typed.center_augment.clip_to_record is True
+    assert typed.center_augment.require_fb_inside is True
     assert typed.ckpt.pipeline == 'fbpick'
     assert typed.ckpt.stage == 'fine'
     assert typed.ckpt.output_ids == ('P',)
     assert typed.ckpt.softmax_axis == 'time'
+
+
+def test_load_fine_train_config_parses_center_augment(tmp_path: Path) -> None:
+    cfg = _make_fine_train_config(
+        tmp_path,
+        segy_path='dummy.sgy',
+        fb_path='dummy.npy',
+        robust_path='dummy.robust.npz',
+    )
+    cfg['center_augment'] = {
+        'enabled': True,
+        'train_only': True,
+        'p_no_jitter': 0.7,
+        'uniform_jitter_samples': [
+            {'prob': 0.2, 'lo': -32, 'hi': 32},
+            {'prob': 0.1, 'lo': -64, 'hi': 64},
+        ],
+        'clip_to_record': True,
+        'require_fb_inside': True,
+    }
+
+    typed = load_fine_train_config(cfg, base_dir=tmp_path)
+
+    assert typed.center_augment.enabled is True
+    assert typed.center_augment.train_only is True
+    assert typed.center_augment.p_no_jitter == pytest.approx(0.7)
+    assert typed.center_augment.clip_to_record is True
+    assert typed.center_augment.require_fb_inside is True
+    assert typed.center_augment.uniform_jitter_samples == (
+        FineUniformJitterCfg(prob=0.2, lo=-32, hi=32),
+        FineUniformJitterCfg(prob=0.1, lo=-64, hi=64),
+    )
+
+
+@pytest.mark.parametrize(
+    ('center_augment', 'error_type', 'message'),
+    [
+        (
+            {'enabled': True, 'p_no_jitter': -0.1},
+            ValueError,
+            'center_augment.p_no_jitter must lie in [0, 1]',
+        ),
+        (
+            {'enabled': True, 'p_no_jitter': 0.0, 'uniform_jitter_samples': []},
+            ValueError,
+            'center_augment probabilities must sum to > 0',
+        ),
+        (
+            {
+                'enabled': True,
+                'uniform_jitter_samples': [{'prob': 1.0, 'lo': 4, 'hi': 3}],
+            },
+            ValueError,
+            'center_augment.uniform_jitter_samples[0].lo must be <= hi',
+        ),
+        (
+            {'enabled': True, 'require_fb_inside': False},
+            ValueError,
+            'center_augment.require_fb_inside must be true',
+        ),
+        (
+            {'enabled': True, 'uniform_jitter_samples': [{'prob': True, 'lo': 0, 'hi': 0}]},
+            TypeError,
+            'center_augment.uniform_jitter_samples[0].prob must be float',
+        ),
+    ],
+)
+def test_load_fine_train_config_rejects_invalid_center_augment(
+    tmp_path: Path,
+    center_augment: dict,
+    error_type: type[Exception],
+    message: str,
+) -> None:
+    cfg = _make_fine_train_config(
+        tmp_path,
+        segy_path='dummy.sgy',
+        fb_path='dummy.npy',
+        robust_path='dummy.robust.npz',
+    )
+    cfg['center_augment'] = center_augment
+
+    with pytest.raises(error_type) as exc:
+        load_fine_train_config(cfg, base_dir=tmp_path)
+
+    assert message in str(exc.value)
 
 
 @pytest.mark.parametrize(
@@ -539,6 +696,27 @@ def test_load_fine_infer_config_parses_explicit_coarse_npz_files(
     typed = load_fine_infer_config(cfg)
 
     assert typed.paths.coarse_npz_files == ('other_dir/dummy.coarse.npz',)
+
+
+def test_sample_center_jitter_is_reproducible_and_uses_weight_mixture() -> None:
+    cfg = FineCenterAugmentCfg(
+        enabled=True,
+        train_only=True,
+        p_no_jitter=0.5,
+        uniform_jitter_samples=(FineUniformJitterCfg(prob=0.5, lo=10, hi=10),),
+        clip_to_record=True,
+        require_fb_inside=True,
+    )
+
+    first = sample_center_jitter(size=64, cfg=cfg, rng=np.random.default_rng(123))
+    second = sample_center_jitter(size=64, cfg=cfg, rng=np.random.default_rng(123))
+
+    np.testing.assert_array_equal(first, second)
+    assert first.dtype == np.int64
+    assert first.shape == (64,)
+    assert set(first.tolist()).issubset({0, 10})
+    assert 0 in first
+    assert 10 in first
 
 
 def test_prepare_fine_infer_cfg_expands_coarse_npz_listfile(tmp_path: Path) -> None:
@@ -785,6 +963,196 @@ def test_fine_train_dataset_rejects_when_gt_pick_is_outside_local_window(
     try:
         ds._rng = np.random.default_rng(0)
         with pytest.raises(RuntimeError, match='local_window=1'):
+            _ = ds[0]
+    finally:
+        ds.close()
+
+
+def test_fine_train_center_augment_constant_jitter_shifts_center(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    n_traces = 128
+    n_samples = 512
+    dt_sec = 0.002
+    traces = np.zeros((n_traces, n_samples), dtype=np.float32)
+    robust = np.full((n_traces,), 100, dtype=np.int32)
+    fb = np.full((n_traces,), 110, dtype=np.int64)
+
+    segy_path = _register_synthetic_segy(tmp_path, 'jitter_shift.sgy', traces)
+    fb_path = _write_fb(tmp_path / 'jitter_shift_fb.npy', fb)
+    robust_path = _write_robust_with_n_samples(
+        tmp_path / 'jitter_shift.robust.npz',
+        robust_pick_i=robust,
+        n_samples_orig=n_samples,
+        dt_sec=dt_sec,
+    )
+    _patch_synthetic_file_infos(
+        monkeypatch,
+        traces_by_path={segy_path: traces},
+        dt_sec=dt_sec,
+    )
+    center_augment = FineCenterAugmentCfg(
+        enabled=True,
+        train_only=True,
+        p_no_jitter=0.0,
+        uniform_jitter_samples=(FineUniformJitterCfg(prob=1.0, lo=10, hi=10),),
+        clip_to_record=True,
+        require_fb_inside=True,
+    )
+    ds = _build_test_fine_train_dataset(
+        segy_path=segy_path,
+        fb_path=fb_path,
+        robust_path=robust_path,
+        center_augment=center_augment,
+    )
+
+    try:
+        ds._rng = np.random.default_rng(0)
+        sample = ds[0]
+    finally:
+        ds.close()
+
+    meta = sample['meta']
+    np.testing.assert_array_equal(meta['center_raw_i'], np.full((128,), 110, dtype=np.int32))
+    np.testing.assert_array_equal(meta['window_start_i'], np.full((128,), -18, dtype=np.int32))
+
+
+def test_fine_labeled_infer_dataset_does_not_apply_center_jitter(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    n_traces = 128
+    n_samples = 512
+    dt_sec = 0.002
+    traces = np.zeros((n_traces, n_samples), dtype=np.float32)
+    robust = np.full((n_traces,), 100, dtype=np.int32)
+    fb = np.full((n_traces,), 110, dtype=np.int64)
+
+    segy_path = _register_synthetic_segy(tmp_path, 'jitter_valid.sgy', traces)
+    fb_path = _write_fb(tmp_path / 'jitter_valid_fb.npy', fb)
+    robust_path = _write_robust_with_n_samples(
+        tmp_path / 'jitter_valid.robust.npz',
+        robust_pick_i=robust,
+        n_samples_orig=n_samples,
+        dt_sec=dt_sec,
+    )
+    _patch_synthetic_file_infos(
+        monkeypatch,
+        traces_by_path={segy_path: traces},
+        dt_sec=dt_sec,
+    )
+    ds = _build_test_fine_labeled_infer_dataset(
+        segy_path=segy_path,
+        fb_path=fb_path,
+        robust_path=robust_path,
+    )
+
+    try:
+        ds._rng = np.random.default_rng(0)
+        sample = ds[0]
+    finally:
+        ds.close()
+
+    meta = sample['meta']
+    np.testing.assert_array_equal(meta['center_raw_i'], robust)
+    np.testing.assert_array_equal(meta['window_start_i'], robust.astype(np.int32) - 128)
+
+
+def test_fine_train_center_augment_clips_to_record(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    n_traces = 128
+    n_samples = 512
+    dt_sec = 0.002
+    traces = np.zeros((n_traces, n_samples), dtype=np.float32)
+    robust = np.full((n_traces,), 5, dtype=np.int32)
+    fb = np.full((n_traces,), 5, dtype=np.int64)
+
+    segy_path = _register_synthetic_segy(tmp_path, 'jitter_clip.sgy', traces)
+    fb_path = _write_fb(tmp_path / 'jitter_clip_fb.npy', fb)
+    robust_path = _write_robust_with_n_samples(
+        tmp_path / 'jitter_clip.robust.npz',
+        robust_pick_i=robust,
+        n_samples_orig=n_samples,
+        dt_sec=dt_sec,
+    )
+    _patch_synthetic_file_infos(
+        monkeypatch,
+        traces_by_path={segy_path: traces},
+        dt_sec=dt_sec,
+    )
+    center_augment = FineCenterAugmentCfg(
+        enabled=True,
+        train_only=True,
+        p_no_jitter=0.0,
+        uniform_jitter_samples=(FineUniformJitterCfg(prob=1.0, lo=-100, hi=-100),),
+        clip_to_record=True,
+        require_fb_inside=True,
+    )
+    ds = _build_test_fine_train_dataset(
+        segy_path=segy_path,
+        fb_path=fb_path,
+        robust_path=robust_path,
+        center_augment=center_augment,
+    )
+
+    try:
+        ds._rng = np.random.default_rng(0)
+        sample = ds[0]
+    finally:
+        ds.close()
+
+    np.testing.assert_array_equal(
+        sample['meta']['center_raw_i'],
+        np.zeros((128,), dtype=np.int32),
+    )
+
+
+def test_fine_train_center_augment_rejects_out_of_window_jitter(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    n_traces = 128
+    n_samples = 1000
+    dt_sec = 0.002
+    traces = np.zeros((n_traces, n_samples), dtype=np.float32)
+    robust = np.full((n_traces,), 500, dtype=np.int32)
+    fb = np.full((n_traces,), 500, dtype=np.int64)
+
+    segy_path = _register_synthetic_segy(tmp_path, 'jitter_reject.sgy', traces)
+    fb_path = _write_fb(tmp_path / 'jitter_reject_fb.npy', fb)
+    robust_path = _write_robust_with_n_samples(
+        tmp_path / 'jitter_reject.robust.npz',
+        robust_pick_i=robust,
+        n_samples_orig=n_samples,
+        dt_sec=dt_sec,
+    )
+    _patch_synthetic_file_infos(
+        monkeypatch,
+        traces_by_path={segy_path: traces},
+        dt_sec=dt_sec,
+    )
+    center_augment = FineCenterAugmentCfg(
+        enabled=True,
+        train_only=True,
+        p_no_jitter=0.0,
+        uniform_jitter_samples=(FineUniformJitterCfg(prob=1.0, lo=300, hi=300),),
+        clip_to_record=True,
+        require_fb_inside=True,
+    )
+    ds = _build_test_fine_train_dataset(
+        segy_path=segy_path,
+        fb_path=fb_path,
+        robust_path=robust_path,
+        center_augment=center_augment,
+        max_trials=1,
+    )
+
+    try:
+        ds._rng = np.random.default_rng(0)
+        with pytest.raises(RuntimeError, match='center_jitter=1'):
             _ = ds[0]
     finally:
         ds.close()

--- a/proc/fbpick/site54/configs/config_infer_fbpick_fine.yaml
+++ b/proc/fbpick/site54/configs/config_infer_fbpick_fine.yaml
@@ -23,8 +23,8 @@ transform:
   standardize_eps: 1.0e-8
 
 window_center:
-  npz_key: fine_center_i
-  fallback_npz_key: robust_pick_i
+  npz_key: robust_pick_i
+  fallback_npz_key: null
 
 infer:
   ckpt_path: /workspace/proc/fbpick/site54/fbpick_coarse_train_out/ckpt/best.pt

--- a/proc/fbpick/site54/configs/config_infer_fbpick_fine_smoke.yaml
+++ b/proc/fbpick/site54/configs/config_infer_fbpick_fine_smoke.yaml
@@ -1,0 +1,44 @@
+paths:
+  segy_files:
+  - /home/dcuser/data/ActiveSeisField/2017_JCCS_noshiro_V-1/profiled-shot_2017V-1.sgy
+  robust_npz_files:
+  - /workspace/proc/fbpick/site54/oof/robust_oof/fold05/2017_JCCS_noshiro_V-1__profiled-shot_2017V-1.robust.npz
+  coarse_npz_files:
+  - /workspace/proc/fbpick/site54/oof/coarse_oof/fold05/2017_JCCS_noshiro_V-1__profiled-shot_2017V-1.coarse.npz
+  out_dir: /workspace/proc/fbpick/site54/fbpick_fine_infer_smoke_out
+dataset:
+  use_header_cache: true
+  verbose: true
+  progress: true
+  primary_keys:
+  - ffid
+  waveform_mode: eager
+  train_endian: big
+  infer_endian: big
+transform:
+  trace_len: 128
+  time_len: 256
+  center_index: 128
+  standardize_eps: 1.0e-08
+window_center:
+  npz_key: robust_pick_i
+  fallback_npz_key: null
+infer:
+  ckpt_path: /workspace/proc/fbpick/site54/fbpick_fine_train_oof_out/ckpt/best.pt
+  device: auto
+  batch_size: 1
+  num_workers: 0
+  overlap_h: 96
+  amp: false
+  use_tqdm: false
+  high_conf_threshold: 0.5
+viewer:
+  enabled: false
+  save_overview_png: false
+  dpi: 150
+  clip_percentile: 99.0
+model:
+  backbone: resnet18
+  pretrained: false
+  in_chans: 1
+  out_chans: 1

--- a/proc/fbpick/site54/configs/config_train_fbpick_fine.yaml
+++ b/proc/fbpick/site54/configs/config_train_fbpick_fine.yaml
@@ -23,8 +23,19 @@ transform:
   standardize_eps: 1.0e-8
 
 window_center:
-  npz_key: fine_center_i
-  fallback_npz_key: robust_pick_i
+  npz_key: robust_pick_i
+  fallback_npz_key: null
+
+center_augment:
+  enabled: true
+  train_only: true
+  p_no_jitter: 0.7
+  uniform_jitter_samples:
+    - {prob: 0.20, lo: -32, hi: 32}
+    - {prob: 0.08, lo: -64, hi: 64}
+    - {prob: 0.02, lo: -128, hi: 128}
+  clip_to_record: true
+  require_fb_inside: true
 
 train:
   seed: 0

--- a/proc/fbpick/site54/configs/config_train_fbpick_fine_oof.yaml
+++ b/proc/fbpick/site54/configs/config_train_fbpick_fine_oof.yaml
@@ -1,0 +1,81 @@
+paths:
+  segy_files: /workspace/proc/fbpick/site54/oof/lists/oof_train_sgy_all.txt
+  fb_files: /workspace/proc/fbpick/site54/oof/lists/oof_train_fb_all.txt
+  robust_npz_files: /workspace/proc/fbpick/site54/oof/lists/oof_train_robust_all.txt
+  infer_segy_files: /workspace/proc/fbpick/site54/oof/lists/oof_train_sgy_all.txt
+  infer_fb_files: /workspace/proc/fbpick/site54/oof/lists/oof_train_fb_all.txt
+  infer_robust_npz_files: /workspace/proc/fbpick/site54/oof/lists/oof_train_robust_all.txt
+  out_dir: /workspace/proc/fbpick/site54/fbpick_fine_train_oof_out
+
+dataset:
+  max_trials: 2048
+  use_header_cache: true
+  verbose: true
+  progress: true
+  primary_keys: [ffid]
+  secondary_key_fixed: false
+  waveform_mode: eager
+  train_endian: big
+  infer_endian: big
+
+transform:
+  trace_len: 128
+  time_len: 256
+  center_index: 128
+  standardize_eps: 1.0e-8
+
+window_center:
+  npz_key: robust_pick_i
+  fallback_npz_key: null
+
+center_augment:
+  enabled: true
+  train_only: true
+  p_no_jitter: 0.7
+  uniform_jitter_samples:
+    - {prob: 0.20, lo: -32, hi: 32}
+    - {prob: 0.08, lo: -64, hi: 64}
+    - {prob: 0.02, lo: -128, hi: 128}
+  clip_to_record: true
+  require_fb_inside: true
+
+train:
+  seed: 0
+  epochs: 30
+  samples_per_epoch: 512
+  batch_size: 8
+  num_workers: 0
+  max_norm: 1.0
+  use_amp: true
+  lr: 1.0e-4
+  weight_decay: 0.0
+  fb_sigma_ms: 3.0
+  sigma_samples_min: 1.5
+  sigma_samples_max: 12.0
+
+infer:
+  seed: 0
+  batch_size: 8
+  num_workers: 0
+  max_batches: 16
+
+vis:
+  n: 8
+  out_subdir: vis
+
+ckpt:
+  save_best_only: true
+  metric: infer_loss
+  mode: min
+
+model:
+  backbone: resnet18
+  pretrained: false
+  in_chans: 1
+  out_chans: 1
+
+init:
+  coarse_ckpt_path: null
+  use_coarse_init: false
+  reset_seg_head: true
+  reset_first_bn_stats: true

--- a/proc/fbpick/site54/configs/config_train_fbpick_fine_smoke.yaml
+++ b/proc/fbpick/site54/configs/config_train_fbpick_fine_smoke.yaml
@@ -1,0 +1,78 @@
+paths:
+  segy_files: /workspace/proc/fbpick/site54/oof/lists/oof_train_sgy_all.txt
+  fb_files: /workspace/proc/fbpick/site54/oof/lists/oof_train_fb_all.txt
+  robust_npz_files: /workspace/proc/fbpick/site54/oof/lists/oof_train_robust_all.txt
+  out_dir: /workspace/proc/fbpick/site54/fbpick_fine_train_smoke_out
+
+dataset:
+  max_trials: 2048
+  use_header_cache: true
+  verbose: true
+  progress: true
+  primary_keys: [ffid]
+  secondary_key_fixed: false
+  waveform_mode: eager
+  train_endian: big
+  infer_endian: big
+
+transform:
+  trace_len: 128
+  time_len: 256
+  center_index: 128
+  standardize_eps: 1.0e-8
+
+window_center:
+  npz_key: robust_pick_i
+  fallback_npz_key: null
+
+center_augment:
+  enabled: true
+  train_only: true
+  p_no_jitter: 0.7
+  uniform_jitter_samples:
+    - {prob: 0.20, lo: -32, hi: 32}
+    - {prob: 0.08, lo: -64, hi: 64}
+    - {prob: 0.02, lo: -128, hi: 128}
+  clip_to_record: true
+  require_fb_inside: true
+
+train:
+  seed: 0
+  epochs: 1
+  samples_per_epoch: 8
+  batch_size: 1
+  num_workers: 0
+  max_norm: 1.0
+  use_amp: true
+  lr: 1.0e-4
+  weight_decay: 0.0
+  fb_sigma_ms: 3.0
+  sigma_samples_min: 1.5
+  sigma_samples_max: 12.0
+
+infer:
+  seed: 0
+  batch_size: 1
+  num_workers: 0
+  max_batches: 1
+
+vis:
+  n: 0
+  out_subdir: vis
+
+ckpt:
+  save_best_only: true
+  metric: infer_loss
+  mode: min
+
+model:
+  backbone: resnet18
+  pretrained: false
+  in_chans: 1
+  out_chans: 1
+
+init:
+  coarse_ckpt_path: null
+  use_coarse_init: false
+  reset_seg_head: true
+  reset_first_bn_stats: true


### PR DESCRIPTION
Closes #54

## Summary
- [fbpick-fine] Add robust-center jitter augmentation with in-window supervision

## Changed files
- `README.md`
- `docs/fbpick_fine_train.md`
- `examples/config_infer_fbpick_fine.yaml`
- `examples/config_train_fbpick_fine.yaml`
- `packages/seisai-engine/src/seisai_engine/pipelines/fbpick/fine/__init__.py`
- `packages/seisai-engine/src/seisai_engine/pipelines/fbpick/fine/build_dataset.py`
- `packages/seisai-engine/src/seisai_engine/pipelines/fbpick/fine/config.py`
- `packages/seisai-engine/src/seisai_engine/pipelines/fbpick/fine/train.py`
- `packages/seisai-engine/tests/test_fbpick_fine.py`
- `proc/fbpick/site54/configs/config_infer_fbpick_fine.yaml`
- `proc/fbpick/site54/configs/config_train_fbpick_fine.yaml`

## Checks
- `.work/codex/checks.log`: 856 passed, 5 warnings in 73.37s (0:01:13)

## Review
- `.work/codex/review.txt`: accept: yes
- findings: blocker 0, major 0, minor 0
