### PR TITLE
[fbpick-fine-viewer] Add gather-based QC visualization for fine inference

### DIFF
--- a/cli/run_fbpick_physics_qc.py
+++ b/cli/run_fbpick_physics_qc.py
@@ -9,6 +9,10 @@ from types import SimpleNamespace
 from typing import Any
 
 import numpy as np
+from seisai_engine.pipelines.fbpick.common.qc_gathers import (
+	iter_qc_gathers,
+	sort_gather_indices_for_qc,
+)
 
 __all__ = ['main', 'run_pipeline']
 
@@ -296,20 +300,11 @@ def _sort_gather_indices(
 	primary_key: str,
 	indices: np.ndarray,
 ) -> np.ndarray:
-	idx = np.asarray(indices, dtype=np.int64)
-	if idx.size == 0:
-		return idx
-	if primary_key == 'ffid':
-		secondary = np.asarray(info['chno_values'], dtype=np.int64)[idx]
-	elif primary_key == 'chno':
-		secondary = np.asarray(info['ffid_values'], dtype=np.int64)[idx]
-	elif primary_key == 'cmp':
-		secondary = np.asarray(info['offsets'], dtype=np.float32)[idx]
-	else:
-		msg = f'unsupported dataset.primary_keys value: {primary_key}'
-		raise ValueError(msg)
-	order = np.argsort(secondary, kind='mergesort')
-	return idx[order]
+	return sort_gather_indices_for_qc(
+		info,
+		primary_key=primary_key,
+		indices=indices,
+	)
 
 
 def _iter_vis_gathers(
@@ -321,47 +316,14 @@ def _iter_vis_gathers(
 	max_traces_per_gather: int | None,
 	segy_path: str | Path | None = None,
 ):
-	yielded = 0
-	for primary_key in primary_keys:
-		if primary_key not in ('ffid', 'chno', 'cmp'):
-			msg = f'unsupported dataset.primary_keys value: {primary_key}'
-			raise ValueError(msg)
-		key_to_indices = info.get(f'{primary_key}_key_to_indices')
-		if key_to_indices is None:
-			continue
-		skip_for_primary = skip_gather_keys.get(primary_key, set())
-		for gather_key in sorted(key_to_indices):
-			if yielded >= int(max_gathers):
-				return
-			gather_key_i = int(gather_key)
-			raw_indices = key_to_indices[gather_key]
-			n_traces = int(len(raw_indices))
-			if gather_key_i in skip_for_primary:
-				print(
-					f'skip gather by key: file={segy_path} '
-					f'primary={primary_key} key={gather_key_i} traces={n_traces}'
-				)
-				continue
-			if (
-				max_traces_per_gather is not None
-				and n_traces > int(max_traces_per_gather)
-			):
-				print(
-					f'skip oversized gather: file={segy_path} '
-					f'primary={primary_key} key={gather_key_i} '
-					f'traces={n_traces} limit={int(max_traces_per_gather)}'
-				)
-				continue
-			indices = np.asarray(raw_indices, dtype=np.int64)
-			trace_indices = _sort_gather_indices(
-				info,
-				primary_key=primary_key,
-				indices=indices,
-			)
-			if int(trace_indices.size) <= 0:
-				continue
-			yield primary_key, gather_key_i, trace_indices
-			yielded += 1
+	yield from iter_qc_gathers(
+		info,
+		primary_keys=primary_keys,
+		max_gathers=max_gathers,
+		skip_gather_keys=skip_gather_keys,
+		max_traces_per_gather=max_traces_per_gather,
+		segy_path=segy_path,
+	)
 
 
 def _write_per_file_outputs(

--- a/docs/fbpick_fine_infer.md
+++ b/docs/fbpick_fine_infer.md
@@ -49,3 +49,30 @@ physics output:
 
 In that layout, the inferred same-directory coarse path is wrong, so fine
 inference should point to both upstream outputs explicitly.
+
+## Viewer QC
+
+Fine inference can write gather-based QC PNGs without materializing the full
+SEG-Y waveform:
+
+```yaml
+viewer:
+  enabled: true
+  save_overview_png: false
+  save_gather_png: true
+  max_gathers_per_file: 8
+  skip_gather_keys:
+    ffid: [0]
+  max_traces_per_gather: 10000
+  waveform_norm: per_trace
+  dpi: 150
+  clip_percentile: 99.0
+```
+
+Gather QC uses `dataset.primary_keys` such as `ffid`, skips configured keys and
+oversized gathers before reading waveform traces, and writes a limited set of
+per-gather PNGs under `<out_dir>/<parent>__<stem>.fine_qc/`.
+
+The legacy `save_overview_png` path draws all traces from the full SEG-Y file.
+For large production datasets, keep `save_overview_png: false` and use
+gather-based QC.

--- a/examples/config_infer_fbpick_fine.yaml
+++ b/examples/config_infer_fbpick_fine.yaml
@@ -41,7 +41,13 @@ infer:
 
 viewer:
   enabled: true
-  save_overview_png: true
+  save_overview_png: false
+  save_gather_png: true
+  max_gathers_per_file: 8
+  skip_gather_keys:
+    ffid: [0]
+  max_traces_per_gather: 10000
+  waveform_norm: per_trace
   dpi: 150
   clip_percentile: 99.0
 

--- a/packages/seisai-engine/src/seisai_engine/pipelines/fbpick/common/__init__.py
+++ b/packages/seisai-engine/src/seisai_engine/pipelines/fbpick/common/__init__.py
@@ -26,6 +26,7 @@ from .io import (
     validate_fbpick_final_payload,
     validate_fine_result_payload,
 )
+from .qc_gathers import iter_qc_gathers, sort_gather_indices_for_qc
 from .ref_stats import compute_ref_stats, compute_ref_stats_from_records
 
 __all__ = [
@@ -51,9 +52,11 @@ __all__ = [
     'load_robust_npz',
     'load_norm_refs_cfg',
     'read_git_sha',
+    'iter_qc_gathers',
     'save_coarse_npz',
     'save_fbpick_final_npz',
     'save_robust_npz',
+    'sort_gather_indices_for_qc',
     'validate_fbpick_final_payload',
     'validate_fine_result_payload',
 ]

--- a/packages/seisai-engine/src/seisai_engine/pipelines/fbpick/common/qc_gathers.py
+++ b/packages/seisai-engine/src/seisai_engine/pipelines/fbpick/common/qc_gathers.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+from collections.abc import Iterator, Mapping, Sequence
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+__all__ = [
+    'iter_qc_gathers',
+    'sort_gather_indices_for_qc',
+]
+
+SUPPORTED_QC_PRIMARY_KEYS = ('ffid', 'chno', 'cmp')
+
+
+def sort_gather_indices_for_qc(
+    info: Mapping[str, Any],
+    *,
+    primary_key: str,
+    indices: np.ndarray,
+) -> np.ndarray:
+    idx = np.asarray(indices, dtype=np.int64)
+    if idx.size == 0:
+        return idx
+    if primary_key == 'ffid':
+        secondary = np.asarray(info['chno_values'], dtype=np.int64)[idx]
+    elif primary_key == 'chno':
+        secondary = np.asarray(info['ffid_values'], dtype=np.int64)[idx]
+    elif primary_key == 'cmp':
+        secondary = np.asarray(info['offsets'], dtype=np.float32)[idx]
+    else:
+        msg = f'unsupported dataset.primary_keys value: {primary_key}'
+        raise ValueError(msg)
+    order = np.argsort(secondary, kind='mergesort')
+    return idx[order]
+
+
+def iter_qc_gathers(
+    info: Mapping[str, Any],
+    *,
+    primary_keys: Sequence[str],
+    max_gathers: int,
+    skip_gather_keys: Mapping[str, set[int] | frozenset[int]],
+    max_traces_per_gather: int | None,
+    segy_path: str | Path | None = None,
+) -> Iterator[tuple[str, int, np.ndarray]]:
+    yielded = 0
+    max_gathers_int = int(max_gathers)
+    if max_gathers_int <= 0:
+        return
+
+    for primary_key in primary_keys:
+        if primary_key not in SUPPORTED_QC_PRIMARY_KEYS:
+            msg = f'unsupported dataset.primary_keys value: {primary_key}'
+            raise ValueError(msg)
+        key_to_indices = info.get(f'{primary_key}_key_to_indices')
+        if key_to_indices is None:
+            continue
+        skip_for_primary = skip_gather_keys.get(primary_key, set())
+        for gather_key in sorted(key_to_indices):
+            if yielded >= max_gathers_int:
+                return
+            gather_key_i = int(gather_key)
+            raw_indices = key_to_indices[gather_key]
+            n_traces = int(len(raw_indices))
+            if gather_key_i in skip_for_primary:
+                print(
+                    f'skip gather by key: file={segy_path} '
+                    f'primary={primary_key} key={gather_key_i} traces={n_traces}'
+                )
+                continue
+            if (
+                max_traces_per_gather is not None
+                and n_traces > int(max_traces_per_gather)
+            ):
+                print(
+                    f'skip oversized gather: file={segy_path} '
+                    f'primary={primary_key} key={gather_key_i} '
+                    f'traces={n_traces} limit={int(max_traces_per_gather)}'
+                )
+                continue
+            indices = np.asarray(raw_indices, dtype=np.int64)
+            trace_indices = sort_gather_indices_for_qc(
+                info,
+                primary_key=primary_key,
+                indices=indices,
+            )
+            if int(trace_indices.size) <= 0:
+                continue
+            yield primary_key, gather_key_i, trace_indices
+            yielded += 1

--- a/packages/seisai-engine/src/seisai_engine/pipelines/fbpick/fine/config.py
+++ b/packages/seisai-engine/src/seisai_engine/pipelines/fbpick/fine/config.py
@@ -146,6 +146,11 @@ class FineInferRuntimeCfg:
 class FineViewerCfg:
     enabled: bool
     save_overview_png: bool
+    save_gather_png: bool
+    max_gathers_per_file: int
+    skip_gather_keys: dict[str, frozenset[int]]
+    max_traces_per_gather: int | None
+    waveform_norm: str
     dpi: int
     clip_percentile: float
 
@@ -507,11 +512,57 @@ def _load_viewer_cfg(cfg: dict) -> FineViewerCfg:
         msg = 'viewer.clip_percentile must lie in (0, 100]'
         raise ValueError(msg)
 
+    max_gathers_per_file = int(optional_int(viewer_cfg, 'max_gathers_per_file', 8))
+    if max_gathers_per_file < 0:
+        msg = 'viewer.max_gathers_per_file must be >= 0'
+        raise ValueError(msg)
+
+    skip_gather_keys_raw = viewer_cfg.get('skip_gather_keys', {})
+    if not isinstance(skip_gather_keys_raw, dict) or not all(
+        isinstance(key, str) for key in skip_gather_keys_raw
+    ):
+        msg = 'viewer.skip_gather_keys must be dict[str, list[int]]'
+        raise TypeError(msg)
+    skip_gather_keys: dict[str, frozenset[int]] = {}
+    for primary_key, values in skip_gather_keys_raw.items():
+        if not isinstance(values, list) or not all(
+            isinstance(item, int) and not isinstance(item, bool) for item in values
+        ):
+            msg = 'viewer.skip_gather_keys must be dict[str, list[int]]'
+            raise TypeError(msg)
+        skip_gather_keys[primary_key] = frozenset(int(item) for item in values)
+
+    max_traces_per_gather_raw = viewer_cfg.get('max_traces_per_gather', 10000)
+    if max_traces_per_gather_raw is None:
+        max_traces_per_gather = None
+    elif isinstance(max_traces_per_gather_raw, bool) or not isinstance(
+        max_traces_per_gather_raw, int
+    ):
+        msg = 'viewer.max_traces_per_gather must be int > 0 or null'
+        raise TypeError(msg)
+    elif int(max_traces_per_gather_raw) <= 0:
+        msg = 'viewer.max_traces_per_gather must be int > 0 or null'
+        raise ValueError(msg)
+    else:
+        max_traces_per_gather = int(max_traces_per_gather_raw)
+
+    waveform_norm = optional_str(viewer_cfg, 'waveform_norm', 'global').strip()
+    if waveform_norm not in ('global', 'per_trace'):
+        msg = 'viewer.waveform_norm must be one of: global, per_trace'
+        raise ValueError(msg)
+
     return FineViewerCfg(
         enabled=bool(optional_bool(viewer_cfg, 'enabled', default=False)),
         save_overview_png=bool(
-            optional_bool(viewer_cfg, 'save_overview_png', default=True)
+            optional_bool(viewer_cfg, 'save_overview_png', default=False)
         ),
+        save_gather_png=bool(
+            optional_bool(viewer_cfg, 'save_gather_png', default=False)
+        ),
+        max_gathers_per_file=max_gathers_per_file,
+        skip_gather_keys=skip_gather_keys,
+        max_traces_per_gather=max_traces_per_gather,
+        waveform_norm=waveform_norm,
         dpi=dpi,
         clip_percentile=clip_percentile,
     )

--- a/packages/seisai-engine/src/seisai_engine/pipelines/fbpick/fine/infer.py
+++ b/packages/seisai-engine/src/seisai_engine/pipelines/fbpick/fine/infer.py
@@ -27,6 +27,7 @@ from seisai_engine.pipelines.common import (
 from seisai_engine.pipelines.fbpick.common import (
     build_fbpick_final_payload,
     build_lineage_payload,
+    iter_qc_gathers,
     load_coarse_npz,
     load_robust_npz,
     save_fbpick_final_npz,
@@ -36,7 +37,7 @@ from seisai_engine.pipelines.fbpick.common import (
 from .build_dataset import build_raw_infer_dataset, collate_input_meta_list
 from .build_model import build_model
 from .build_plan import build_plan
-from .config import FineInferConfig, load_fine_infer_config
+from .config import FineInferConfig, FineViewerCfg, load_fine_infer_config
 
 __all__ = [
     'infer_coarse_npz_path_from_robust_npz_path',
@@ -77,6 +78,11 @@ _SAFE_OVERRIDE_PATHS = frozenset(
         'window_center.fallback_npz_key',
         'viewer.enabled',
         'viewer.save_overview_png',
+        'viewer.save_gather_png',
+        'viewer.max_gathers_per_file',
+        'viewer.skip_gather_keys',
+        'viewer.max_traces_per_gather',
+        'viewer.waveform_norm',
         'viewer.dpi',
         'viewer.clip_percentile',
     }
@@ -125,7 +131,12 @@ def _default_cfg() -> dict[str, Any]:
         },
         'viewer': {
             'enabled': False,
-            'save_overview_png': True,
+            'save_overview_png': False,
+            'save_gather_png': False,
+            'max_gathers_per_file': 8,
+            'skip_gather_keys': {},
+            'max_traces_per_gather': 10000,
+            'waveform_norm': 'global',
             'dpi': 150,
             'clip_percentile': 99.0,
         },
@@ -447,6 +458,128 @@ def _derive_overview_png_path(*, segy_path: str | Path, out_dir: str | Path) -> 
     return Path(out_dir).expanduser().resolve() / f'{Path(segy_path).stem}.overview.png'
 
 
+def _derive_qc_tag(segy_path: str | Path) -> str:
+    segy = Path(segy_path)
+    parent_name = segy.parent.name
+    if parent_name:
+        return parent_name + '__' + segy.stem
+    return segy.stem
+
+
+def _derive_fine_qc_dir(*, segy_path: str | Path, out_dir: str | Path) -> Path:
+    return (
+        Path(out_dir).expanduser().resolve()
+        / f'{_derive_qc_tag(segy_path)}.fine_qc'
+    )
+
+
+def _build_fine_qc_info(
+    *, segy_path: str | Path, typed: FineInferConfig
+) -> dict[str, Any]:
+    import segyio
+    from seisai_dataset.file_info import build_file_info
+
+    return build_file_info(
+        str(segy_path),
+        ffid_byte=segyio.TraceField.FieldRecord,
+        chno_byte=segyio.TraceField.TraceNumber,
+        cmp_byte=segyio.TraceField.CDP,
+        use_header_cache=bool(typed.dataset.use_header_cache),
+        include_centroids=False,
+        waveform_mode='mmap',
+        segy_endian=str(typed.dataset.infer_endian),
+    )
+
+
+def _close_info(info: dict[str, Any]) -> None:
+    segy_obj = info.get('segy_obj')
+    if segy_obj is not None:
+        segy_obj.close()
+
+
+def _validate_fine_qc_info_against_payload(
+    info: dict[str, Any],
+    *,
+    final_payload: dict[str, np.ndarray],
+) -> None:
+    n_traces = int(np.asarray(final_payload['n_traces']).item())
+    n_samples_orig = int(np.asarray(final_payload['n_samples_orig']).item())
+    dt_sec = float(np.asarray(final_payload['dt_sec']).item())
+    if int(info['n_traces']) != n_traces:
+        msg = f'QC info n_traces {int(info["n_traces"])} != final n_traces {n_traces}'
+        raise ValueError(msg)
+    if int(info['n_samples']) != n_samples_orig:
+        msg = (
+            f'QC info n_samples {int(info["n_samples"])} != '
+            f'final n_samples_orig {n_samples_orig}'
+        )
+        raise ValueError(msg)
+    if not np.isclose(float(info['dt_sec']), dt_sec, rtol=0.0, atol=1e-9):
+        msg = f'QC info dt_sec {float(info["dt_sec"])} != final dt_sec {dt_sec}'
+        raise ValueError(msg)
+
+
+def _save_fine_gather_qc_pngs(
+    *,
+    info: dict[str, Any],
+    segy_path: str | Path,
+    out_dir: str | Path,
+    final_payload: dict[str, np.ndarray],
+    viewer: FineViewerCfg,
+    primary_keys: tuple[str, ...],
+    save_png_func=None,
+) -> list[Path]:
+    max_gathers = int(viewer.max_gathers_per_file)
+    if max_gathers <= 0:
+        return []
+
+    if save_png_func is None:
+        from seisai_engine.viewer.fbpick import save_fbpick_fine_qc_gather_png
+
+        save_png_func = save_fbpick_fine_qc_gather_png
+
+    _validate_fine_qc_info_against_payload(info, final_payload=final_payload)
+    out_subdir = _derive_fine_qc_dir(segy_path=segy_path, out_dir=out_dir)
+    out_paths: list[Path] = []
+    for gather_idx, (primary_key, gather_key, trace_indices) in enumerate(
+        iter_qc_gathers(
+            info,
+            primary_keys=primary_keys,
+            max_gathers=max_gathers,
+            skip_gather_keys=viewer.skip_gather_keys,
+            max_traces_per_gather=viewer.max_traces_per_gather,
+            segy_path=segy_path,
+        )
+    ):
+        x_hw = np.stack(
+            [
+                np.asarray(info['mmap'][int(i)], dtype=np.float32)
+                for i in trace_indices
+            ],
+            axis=0,
+        )
+        out_png = out_subdir / f'gather_{gather_idx:04d}.png'
+        title = f'{Path(segy_path).name} {primary_key}={gather_key}'
+        out_paths.append(
+            save_png_func(
+                out_png,
+                raw_wave_hw=x_hw,
+                final_payload=final_payload,
+                trace_indices=trace_indices,
+                title=title,
+                dpi=viewer.dpi,
+                clip_percentile=viewer.clip_percentile,
+                waveform_norm=viewer.waveform_norm,
+            )
+        )
+    if not out_paths:
+        print(
+            f'No fine gather PNGs written for {segy_path}: '
+            'all candidates were skipped'
+        )
+    return out_paths
+
+
 def _load_fine_ckpt_cfg_for_merge(
     *,
     infer_cfg_for_ckpt: dict[str, Any],
@@ -609,8 +742,14 @@ def run_fine_infer(
     save_overview = bool(
         save_output and typed.viewer.enabled and typed.viewer.save_overview_png
     )
+    save_gather_png = bool(
+        save_output and typed.viewer.enabled and typed.viewer.save_gather_png
+    )
     if save_overview and typed.paths.out_dir is None:
         msg = 'viewer overview export requires paths.out_dir'
+        raise ValueError(msg)
+    if save_gather_png and typed.paths.out_dir is None:
+        msg = 'viewer gather QC export requires paths.out_dir'
         raise ValueError(msg)
 
     raw_wave_hw_out: dict[str, np.ndarray] | None
@@ -684,6 +823,22 @@ def run_fine_infer(
             dpi=typed.viewer.dpi,
             clip_percentile=typed.viewer.clip_percentile,
         )
+    if save_gather_png:
+        info = _build_fine_qc_info(
+            segy_path=typed.paths.segy_files[0],
+            typed=typed,
+        )
+        try:
+            _save_fine_gather_qc_pngs(
+                info=info,
+                segy_path=typed.paths.segy_files[0],
+                out_dir=typed.paths.out_dir,
+                final_payload=final_payload,
+                viewer=typed.viewer,
+                primary_keys=typed.dataset.primary_keys,
+            )
+        finally:
+            _close_info(info)
     return final_payload
 
 

--- a/packages/seisai-engine/src/seisai_engine/viewer/__init__.py
+++ b/packages/seisai-engine/src/seisai_engine/viewer/__init__.py
@@ -7,6 +7,7 @@ __all__ = [
     'infer_denoise_hw',
     'infer_prob_hw',
     'render_fbpick_overview',
+    'save_fbpick_fine_qc_gather_png',
     'save_fbpick_overview_png',
 ]
 
@@ -15,6 +16,10 @@ _EXPORTS = {
     'infer_denoise_hw': ('.denoise', 'infer_denoise_hw'),
     'infer_prob_hw': ('.fbpick', 'infer_prob_hw'),
     'render_fbpick_overview': ('.fbpick', 'render_fbpick_overview'),
+    'save_fbpick_fine_qc_gather_png': (
+        '.fbpick',
+        'save_fbpick_fine_qc_gather_png',
+    ),
     'save_fbpick_overview_png': ('.fbpick', 'save_fbpick_overview_png'),
 }
 

--- a/packages/seisai-engine/src/seisai_engine/viewer/fbpick.py
+++ b/packages/seisai-engine/src/seisai_engine/viewer/fbpick.py
@@ -16,6 +16,7 @@ __all__ = [
 	'infer_prob_hw',
 	'render_fbpick_overview',
 	'save_fbpick_debug_png',
+	'save_fbpick_fine_qc_gather_png',
 	'save_fbpick_overview_png',
 	'save_fbpick_physics_qc_cdf_png',
 	'save_fbpick_physics_qc_gather_png',
@@ -1008,6 +1009,224 @@ def save_fbpick_physics_qc_gather_png(
 	axes[2].set_xlabel('Trace Index')
 	axes[2].set_yticks([0])
 	axes[2].set_yticklabels(['mask'])
+
+	if title is not None:
+		fig.suptitle(str(title))
+		fig.tight_layout(rect=(0.0, 0.0, 1.0, 0.93))
+	else:
+		fig.tight_layout()
+
+	out_path = Path(out_png).expanduser().resolve()
+	out_path.parent.mkdir(parents=True, exist_ok=True)
+	fig.savefig(out_path, dpi=dpi_int)
+	plt.close(fig)
+	return out_path
+
+
+def save_fbpick_fine_qc_gather_png(
+	out_png: str | Path,
+	*,
+	raw_wave_hw: np.ndarray,
+	final_payload: Mapping[str, np.ndarray],
+	trace_indices: np.ndarray,
+	title: str | None = None,
+	dpi: int = 150,
+	clip_percentile: float = 99.0,
+	waveform_norm: str = 'global',
+) -> Path:
+	import matplotlib.pyplot as plt
+
+	wave = np.ascontiguousarray(np.asarray(raw_wave_hw, dtype=np.float32))
+	if wave.ndim != 2:
+		msg = f'raw_wave_hw must be 2D, got {wave.shape}'
+		raise ValueError(msg)
+
+	n_traces, n_samples = wave.shape
+	if n_traces <= 0 or n_samples <= 0:
+		msg = 'raw_wave_hw must be non-empty'
+		raise ValueError(msg)
+
+	trace_idx = np.asarray(trace_indices, dtype=np.int64)
+	if trace_idx.ndim != 1 or int(trace_idx.shape[0]) != n_traces:
+		msg = f'trace_indices must be 1D with length {n_traces}'
+		raise ValueError(msg)
+
+	dpi_int = int(dpi)
+	if dpi_int <= 0:
+		msg = 'dpi must be > 0'
+		raise ValueError(msg)
+
+	if 'n_traces' not in final_payload:
+		msg = 'final payload missing key: n_traces'
+		raise KeyError(msg)
+	n_total = int(np.asarray(final_payload['n_traces']).item())
+	if np.any(trace_idx < 0) or np.any(trace_idx >= n_total):
+		msg = 'trace_indices contains out-of-range values for final payload'
+		raise ValueError(msg)
+
+	coarse_pick_i = _require_overview_vector(
+		final_payload, 'coarse_pick_i', length=n_total
+	)[trace_idx].astype(np.int64, copy=False)
+	robust_pick_i = _require_overview_vector(
+		final_payload, 'robust_pick_i', length=n_total
+	)[trace_idx].astype(np.int64, copy=False)
+	window_start_i = _require_overview_vector(
+		final_payload, 'window_start_i', length=n_total
+	)[trace_idx].astype(np.int64, copy=False)
+	window_end_i = _require_overview_vector(
+		final_payload, 'window_end_i', length=n_total
+	)[trace_idx].astype(np.int64, copy=False)
+	final_pick_i = _require_overview_vector(
+		final_payload, 'final_pick_i', length=n_total
+	)[trace_idx].astype(np.int64, copy=False)
+	high_conf_mask = np.asarray(
+		_require_overview_vector(final_payload, 'high_conf_mask', length=n_total)[
+			trace_idx
+		],
+		dtype=np.bool_,
+	)
+	reject_mask = np.asarray(
+		_require_overview_vector(final_payload, 'reject_mask', length=n_total)[
+			trace_idx
+		],
+		dtype=np.bool_,
+	)
+	final_conf = _require_overview_vector(
+		final_payload, 'final_conf', length=n_total
+	)[trace_idx].astype(np.float32, copy=False)
+
+	x = np.arange(n_traces, dtype=np.float32)
+	norm_mode = str(waveform_norm)
+	wave_display = _normalize_waveform_for_qc_display(
+		wave,
+		mode=norm_mode,
+		clip_percentile=clip_percentile,
+	)
+	if norm_mode == 'global':
+		display_vmin = -_resolve_overview_clip(wave, clip_percentile=clip_percentile)
+		display_vmax = -display_vmin
+	else:
+		display_vmin = -1.0
+		display_vmax = 1.0
+
+	fig_width = min(max(12.0, float(n_traces) / 100.0), 24.0)
+	fig, axes = plt.subplots(
+		1,
+		3,
+		figsize=(fig_width, 6.0),
+		gridspec_kw={'width_ratios': [2.4, 1.3, 0.8]},
+	)
+
+	axes[0].imshow(
+		wave_display.T,
+		cmap='gray',
+		aspect='auto',
+		interpolation='nearest',
+		origin='upper',
+		vmin=display_vmin,
+		vmax=display_vmax,
+	)
+	axes[0].plot(
+		x,
+		coarse_pick_i.astype(np.float32),
+		color='#7fd3ff',
+		lw=1.0,
+		alpha=0.9,
+		label='coarse_pick_i',
+	)
+	axes[0].plot(
+		x,
+		robust_pick_i.astype(np.float32),
+		color='yellow',
+		lw=1.0,
+		alpha=0.9,
+		label='robust_pick_i',
+	)
+	axes[0].plot(
+		x,
+		np.clip(window_start_i, 0, n_samples - 1).astype(np.float32),
+		color='yellow',
+		lw=0.8,
+		ls='--',
+		alpha=0.75,
+		label='window_start_i',
+	)
+	axes[0].plot(
+		x,
+		np.clip(window_end_i, 0, n_samples - 1).astype(np.float32),
+		color='yellow',
+		lw=0.8,
+		ls=':',
+		alpha=0.75,
+		label='window_end_i',
+	)
+	axes[0].plot(
+		x,
+		final_pick_i.astype(np.float32),
+		color='red',
+		lw=1.2,
+		alpha=0.95,
+		label='final_pick_i',
+	)
+	axes[0].scatter(
+		x[high_conf_mask],
+		final_pick_i.astype(np.float32)[high_conf_mask],
+		color='lime',
+		s=14.0,
+		alpha=0.95,
+		label='high_conf_final_pick',
+		zorder=5,
+	)
+	axes[0].set_title(
+		f'waveform and picks (norm={norm_mode}, p{float(clip_percentile):g})'
+	)
+	axes[0].set_xlabel('Trace Index')
+	axes[0].set_ylabel('Sample Index')
+	axes[0].legend(loc='upper right', fontsize=8)
+
+	final_minus_robust = final_pick_i.astype(np.float32) - robust_pick_i.astype(
+		np.float32
+	)
+	axes[1].plot(
+		x,
+		final_minus_robust,
+		color='red',
+		lw=1.0,
+		label='final - robust',
+	)
+	for y in (0, 32, -32, 64, -64, 127, -127):
+		if y == 0:
+			axes[1].axhline(y, color='black', lw=0.9, alpha=0.8)
+		elif abs(y) == 127:
+			axes[1].axhline(y, color='red', lw=0.8, ls='--', alpha=0.65)
+		else:
+			axes[1].axhline(y, color='gray', lw=0.8, ls='--', alpha=0.55)
+	axes[1].set_title('final offset')
+	axes[1].set_xlabel('Trace Index')
+	axes[1].set_ylabel('Sample Offset')
+	axes[1].legend(loc='upper right', fontsize=8)
+
+	mask_values = np.stack(
+		[
+			high_conf_mask.astype(np.float32),
+			(~reject_mask).astype(np.float32),
+			np.clip(final_conf, 0.0, 1.0).astype(np.float32),
+		],
+		axis=0,
+	)
+	axes[2].imshow(
+		mask_values,
+		cmap='viridis',
+		aspect='auto',
+		interpolation='nearest',
+		origin='upper',
+		vmin=0.0,
+		vmax=1.0,
+	)
+	axes[2].set_title('confidence masks')
+	axes[2].set_xlabel('Trace Index')
+	axes[2].set_yticks([0, 1, 2])
+	axes[2].set_yticklabels(['high', 'accepted', 'conf'])
 
 	if title is not None:
 		fig.suptitle(str(title))

--- a/packages/seisai-engine/tests/test_fbpick_fine.py
+++ b/packages/seisai-engine/tests/test_fbpick_fine.py
@@ -11,6 +11,7 @@ from torch.utils.data import DataLoader, Subset
 
 import seisai_dataset.infer_window_dataset as infer_window_dataset
 import seisai_dataset.segy_gather_pipeline_dataset as segy_gather_pipeline_dataset
+import seisai_engine.pipelines.fbpick.fine.infer as fine_infer_module
 from seisai_dataset.file_info import FileInfo
 from seisai_engine.pipelines.common import load_checkpoint
 from seisai_engine.pipelines.fbpick.common import (
@@ -43,6 +44,7 @@ from seisai_engine.pipelines.fbpick.fine import (
 )
 from seisai_engine.pipelines.fbpick.fine.infer import (
     _prepare_fine_infer_cfg,
+    _save_fine_gather_qc_pngs,
     main as run_fine_infer_main,
     require_existing_coarse_npz_path,
     resolve_fine_coarse_npz_path,
@@ -106,6 +108,60 @@ def _make_file_info(path: str, traces: np.ndarray, *, dt_sec: float) -> FileInfo
         ffid_centroids=None,
         chno_centroids=None,
     )
+
+
+def _make_qc_info(
+    *,
+    traces: np.ndarray | object,
+    key_to_indices: dict[int, list[int] | np.ndarray],
+    n_traces: int,
+    n_samples: int,
+    dt_sec: float = 0.002,
+) -> dict[str, object]:
+    return {
+        'path': 'qc.sgy',
+        'mmap': traces,
+        'segy_obj': _DummySegy(),
+        'dt_sec': float(dt_sec),
+        'n_traces': int(n_traces),
+        'n_samples': int(n_samples),
+        'ffid_values': np.ones(n_traces, dtype=np.int32),
+        'chno_values': np.arange(1, n_traces + 1, dtype=np.int32),
+        'cmp_values': None,
+        'ffid_key_to_indices': {
+            key: np.asarray(indices, dtype=np.int64)
+            for key, indices in key_to_indices.items()
+        },
+        'chno_key_to_indices': None,
+        'cmp_key_to_indices': None,
+        'offsets': np.arange(n_traces, dtype=np.float32),
+    }
+
+
+def _make_final_payload_for_qc(
+    *,
+    n_traces: int,
+    n_samples: int,
+    dt_sec: float = 0.002,
+) -> dict[str, np.ndarray]:
+    base = np.arange(n_traces, dtype=np.int32)
+    coarse = np.clip(10 + base, 0, n_samples - 1).astype(np.int32)
+    robust = np.clip(coarse + 1, 0, n_samples - 1).astype(np.int32)
+    final = np.clip(robust + 1, 0, n_samples - 1).astype(np.int32)
+    return {
+        'dt_sec': np.asarray(dt_sec, dtype=np.float32),
+        'n_samples_orig': np.asarray(n_samples, dtype=np.int32),
+        'n_traces': np.asarray(n_traces, dtype=np.int32),
+        'trace_indices': np.arange(n_traces, dtype=np.int64),
+        'coarse_pick_i': coarse,
+        'robust_pick_i': robust,
+        'window_start_i': np.maximum(final - 128, 0).astype(np.int32),
+        'window_end_i': np.minimum(final + 127, n_samples - 1).astype(np.int32),
+        'final_pick_i': final,
+        'high_conf_mask': np.ones(n_traces, dtype=np.bool_),
+        'reject_mask': np.zeros(n_traces, dtype=np.bool_),
+        'final_conf': np.ones(n_traces, dtype=np.float32),
+    }
 
 
 def _patch_synthetic_file_infos(
@@ -664,6 +720,43 @@ def test_load_fine_infer_config_returns_default_high_conf_threshold(
     assert typed.infer.high_conf_threshold == pytest.approx(0.5)
     assert typed.window_center.npz_key == 'robust_pick_i'
     assert typed.window_center.fallback_npz_key is None
+    assert typed.viewer.enabled is False
+    assert typed.viewer.save_overview_png is False
+    assert typed.viewer.save_gather_png is False
+
+
+def test_load_fine_infer_config_parses_gather_viewer(tmp_path: Path) -> None:
+    cfg = _make_fine_infer_config(
+        tmp_path,
+        segy_path='dummy.sgy',
+        robust_path='dummy.robust.npz',
+    )
+    cfg['viewer'] = {
+        'enabled': True,
+        'save_overview_png': False,
+        'save_gather_png': True,
+        'max_gathers_per_file': 3,
+        'skip_gather_keys': {'ffid': [0], 'cmp': [-1]},
+        'max_traces_per_gather': 10000,
+        'waveform_norm': 'per_trace',
+        'dpi': 120,
+        'clip_percentile': 98.5,
+    }
+
+    typed = load_fine_infer_config(cfg)
+
+    assert typed.viewer.enabled is True
+    assert typed.viewer.save_overview_png is False
+    assert typed.viewer.save_gather_png is True
+    assert typed.viewer.max_gathers_per_file == 3
+    assert typed.viewer.skip_gather_keys == {
+        'ffid': frozenset({0}),
+        'cmp': frozenset({-1}),
+    }
+    assert typed.viewer.max_traces_per_gather == 10000
+    assert typed.viewer.waveform_norm == 'per_trace'
+    assert typed.viewer.dpi == 120
+    assert typed.viewer.clip_percentile == pytest.approx(98.5)
 
 
 def test_load_fine_infer_config_parses_window_center(tmp_path: Path) -> None:
@@ -1699,6 +1792,173 @@ def test_run_fine_infer_uses_explicit_coarse_npz_path(
 
     validate_fbpick_final_payload(result, high_conf_threshold=0.5)
     np.testing.assert_array_equal(result['final_pick_i'], final_pick.astype(np.int32))
+
+
+def test_save_fine_gather_qc_pngs_skips_configured_key_and_counts_accepted(
+    tmp_path: Path,
+) -> None:
+    traces = np.arange(3 * 8, dtype=np.float32).reshape(3, 8)
+    info = _make_qc_info(
+        traces=traces,
+        key_to_indices={0: [0], 1: [1], 2: [2]},
+        n_traces=3,
+        n_samples=8,
+    )
+    cfg = _make_fine_infer_config(
+        tmp_path,
+        segy_path='dummy.sgy',
+        robust_path='dummy.robust.npz',
+    )
+    cfg['viewer'] = {
+        'enabled': True,
+        'save_gather_png': True,
+        'max_gathers_per_file': 2,
+        'skip_gather_keys': {'ffid': [0]},
+        'max_traces_per_gather': None,
+        'waveform_norm': 'per_trace',
+    }
+    viewer = load_fine_infer_config(cfg).viewer
+    captured: list[np.ndarray] = []
+
+    def _save(out_png: Path, **kwargs: object) -> Path:
+        captured.append(np.asarray(kwargs['trace_indices'], dtype=np.int64))
+        assert kwargs['waveform_norm'] == 'per_trace'
+        return Path(out_png)
+
+    out_paths = _save_fine_gather_qc_pngs(
+        info=info,
+        segy_path=tmp_path / 'line' / 'small.sgy',
+        out_dir=tmp_path / 'out',
+        final_payload=_make_final_payload_for_qc(n_traces=3, n_samples=8),
+        viewer=viewer,
+        primary_keys=('ffid',),
+        save_png_func=_save,
+    )
+
+    assert len(out_paths) == 2
+    assert [int(indices[0]) for indices in captured] == [1, 2]
+
+
+def test_save_fine_gather_qc_pngs_skips_oversized_before_mmap_access(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    class FailingMmap:
+        def __getitem__(self, index: int) -> np.ndarray:
+            raise AssertionError(f'mmap should not be read for skipped gather {index}')
+
+    def _unexpected_save(*args, **kwargs) -> Path:
+        raise AssertionError('PNG writer should not be called')
+
+    info = _make_qc_info(
+        traces=FailingMmap(),
+        key_to_indices={1: np.arange(5)},
+        n_traces=5,
+        n_samples=8,
+    )
+    cfg = _make_fine_infer_config(
+        tmp_path,
+        segy_path='dummy.sgy',
+        robust_path='dummy.robust.npz',
+    )
+    cfg['viewer'] = {
+        'enabled': True,
+        'save_gather_png': True,
+        'max_gathers_per_file': 1,
+        'skip_gather_keys': {},
+        'max_traces_per_gather': 3,
+    }
+    viewer = load_fine_infer_config(cfg).viewer
+    segy_path = tmp_path / 'line' / 'huge.sgy'
+
+    out_paths = _save_fine_gather_qc_pngs(
+        info=info,
+        segy_path=segy_path,
+        out_dir=tmp_path / 'out',
+        final_payload=_make_final_payload_for_qc(n_traces=5, n_samples=8),
+        viewer=viewer,
+        primary_keys=('ffid',),
+        save_png_func=_unexpected_save,
+    )
+
+    assert out_paths == []
+    captured = capsys.readouterr()
+    assert 'skip oversized gather:' in captured.out
+    assert f'No fine gather PNGs written for {segy_path}: all candidates were skipped' in (
+        captured.out
+    )
+
+
+def test_run_fine_infer_gather_qc_does_not_materialize_full_waveform(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    n_traces = 160
+    n_samples = 512
+    dt_sec = 0.002
+    trace_axis = np.arange(n_traces, dtype=np.int32)
+    robust = 220 + ((trace_axis % 7) - 3) * 4
+    final_pick = robust + ((trace_axis % 5) - 2) * 7
+
+    traces = np.zeros((n_traces, n_samples), dtype=np.float32)
+    for trace_idx, pick_idx in enumerate(final_pick.tolist()):
+        traces[trace_idx, int(pick_idx)] = 10.0 + 0.01 * float(trace_idx)
+
+    segy_path = _register_synthetic_segy(tmp_path, 'fine_gather_qc.sgy', traces)
+    _write_coarse_with_n_samples(
+        tmp_path / 'fine_gather_qc.coarse.npz',
+        coarse_pick_i=robust.astype(np.int32),
+        n_samples_orig=n_samples,
+        dt_sec=dt_sec,
+    )
+    robust_path = _write_robust_with_n_samples(
+        tmp_path / 'fine_gather_qc.robust.npz',
+        robust_pick_i=robust,
+        n_samples_orig=n_samples,
+        dt_sec=dt_sec,
+    )
+    _patch_synthetic_file_infos(
+        monkeypatch,
+        traces_by_path={segy_path: traces},
+        dt_sec=dt_sec,
+    )
+
+    def _fail_extract(*args, **kwargs) -> np.ndarray:
+        raise AssertionError('full waveform overview extraction should not run')
+
+    captured: dict[str, object] = {}
+
+    def _fake_build_qc_info(*args, **kwargs) -> dict[str, object]:
+        captured['build_qc_info'] = True
+        return {'segy_obj': _DummySegy()}
+
+    def _fake_save_qc(**kwargs: object) -> list[Path]:
+        captured['save_qc'] = True
+        return []
+
+    monkeypatch.setattr(fine_infer_module, '_extract_raw_wave_hw', _fail_extract)
+    monkeypatch.setattr(fine_infer_module, '_build_fine_qc_info', _fake_build_qc_info)
+    monkeypatch.setattr(fine_infer_module, '_save_fine_gather_qc_pngs', _fake_save_qc)
+
+    cfg = _make_fine_infer_config(
+        tmp_path,
+        segy_path=segy_path,
+        robust_path=robust_path,
+    )
+    cfg['viewer'] = {
+        'enabled': True,
+        'save_overview_png': False,
+        'save_gather_png': True,
+    }
+
+    result = run_fine_infer(
+        model=_IdentityFineModel(),
+        cfg=cfg,
+        device=torch.device('cpu'),
+    )
+
+    validate_fbpick_final_payload(result, high_conf_threshold=0.5)
+    assert captured == {'build_qc_info': True, 'save_qc': True}
 
 
 def test_fine_infer_main_merges_ckpt_cfg_and_writes_final_payload(

--- a/packages/seisai-engine/tests/test_viewer_fbpick.py
+++ b/packages/seisai-engine/tests/test_viewer_fbpick.py
@@ -8,6 +8,7 @@ from seisai_engine.viewer.fbpick import (
     _normalize_waveform_for_qc_display,
     _pad_chw_to_min_tile,
     _resolve_channel_index,
+    save_fbpick_fine_qc_gather_png,
     save_fbpick_physics_qc_gather_png,
 )
 
@@ -279,6 +280,44 @@ def test_save_fbpick_physics_qc_gather_png_per_trace_smoke(tmp_path) -> None:
         gt_pick_i=picks,
         coarse_pick_i=picks,
         robust_pick_i=picks,
+        waveform_norm='per_trace',
+        clip_percentile=99.0,
+    )
+
+    assert out_path == out_png.resolve()
+    assert out_path.is_file()
+    assert out_path.stat().st_size > 0
+
+
+def test_save_fbpick_fine_qc_gather_png_per_trace_smoke(tmp_path) -> None:
+    out_png = tmp_path / 'fine_gather.png'
+    wave = np.asarray(
+        [
+            [0.0, 0.5, 1.0, -0.5],
+            [0.0, 500.0, 1000.0, -500.0],
+            [0.0, -1.0, -0.5, 0.25],
+        ],
+        dtype=np.float32,
+    )
+    n_traces = 3
+    picks = np.asarray([1, 2, 1], dtype=np.int32)
+    final_payload = {
+        'n_traces': np.asarray(n_traces, dtype=np.int32),
+        'coarse_pick_i': picks,
+        'robust_pick_i': picks,
+        'window_start_i': np.zeros(n_traces, dtype=np.int32),
+        'window_end_i': np.full(n_traces, 3, dtype=np.int32),
+        'final_pick_i': picks,
+        'high_conf_mask': np.asarray([True, False, True], dtype=np.bool_),
+        'reject_mask': np.asarray([False, True, False], dtype=np.bool_),
+        'final_conf': np.asarray([0.9, 0.4, 0.8], dtype=np.float32),
+    }
+
+    out_path = save_fbpick_fine_qc_gather_png(
+        out_png,
+        raw_wave_hw=wave,
+        final_payload=final_payload,
+        trace_indices=np.arange(n_traces, dtype=np.int64),
         waveform_norm='per_trace',
         clip_percentile=99.0,
     )

--- a/proc/fbpick/site54/configs/config_infer_fbpick_fine.yaml
+++ b/proc/fbpick/site54/configs/config_infer_fbpick_fine.yaml
@@ -41,7 +41,13 @@ infer:
 
 viewer:
   enabled: true
-  save_overview_png: true
+  save_overview_png: false
+  save_gather_png: true
+  max_gathers_per_file: 8
+  skip_gather_keys:
+    ffid: [0]
+  max_traces_per_gather: 10000
+  waveform_norm: per_trace
   dpi: 150
   clip_percentile: 99.0
 

--- a/proc/fbpick/site54/configs/config_infer_fbpick_fine_smoke.yaml
+++ b/proc/fbpick/site54/configs/config_infer_fbpick_fine_smoke.yaml
@@ -35,6 +35,13 @@ infer:
 viewer:
   enabled: false
   save_overview_png: false
+  save_gather_png: false
+  max_gathers_per_file: 8
+  skip_gather_keys:
+    ffid:
+    - 0
+  max_traces_per_gather: 10000
+  waveform_norm: per_trace
   dpi: 150
   clip_percentile: 99.0
 model:


### PR DESCRIPTION
Closes #56

## Summary
- [fbpick-fine-viewer] Add gather-based QC visualization for fine inference

## Changed files
- `cli/run_fbpick_physics_qc.py`
- `docs/fbpick_fine_infer.md`
- `examples/config_infer_fbpick_fine.yaml`
- `packages/seisai-engine/src/seisai_engine/pipelines/fbpick/common/__init__.py`
- `packages/seisai-engine/src/seisai_engine/pipelines/fbpick/common/qc_gathers.py`
- `packages/seisai-engine/src/seisai_engine/pipelines/fbpick/fine/config.py`
- `packages/seisai-engine/src/seisai_engine/pipelines/fbpick/fine/infer.py`
- `packages/seisai-engine/src/seisai_engine/viewer/__init__.py`
- `packages/seisai-engine/src/seisai_engine/viewer/fbpick.py`
- `packages/seisai-engine/tests/test_fbpick_fine.py`
- `packages/seisai-engine/tests/test_viewer_fbpick.py`
- `proc/fbpick/site54/configs/config_infer_fbpick_fine.yaml`
- `proc/fbpick/site54/configs/config_infer_fbpick_fine_smoke.yaml`

## Checks
- `.work/codex/checks.log`: 861 passed, 5 warnings in 71.60s (0:01:11)

## Review
- `.work/codex/review.txt`: accept: yes
- findings: blocker 0, major 0, minor 0
