### PR TITLE
`detect_event_pick_cluster` に cluster window 内の unique trace counting mode を追加する

### DIFF
--- a/packages/seisai-dataset/src/seisai_dataset/noise_decider.py
+++ b/packages/seisai-dataset/src/seisai_dataset/noise_decider.py
@@ -41,6 +41,7 @@ class EventDetectConfig:
     min_on_ms: float = 8.0
     refr_ms: float = 80.0
     win_ms: float = 30.0
+    cluster_count_mode: Literal['trigger', 'unique_trace'] = 'trigger'
 
 
 # ---- 結果オブジェクト ----
@@ -88,6 +89,12 @@ def decide_noise(
     if cfg.thr_on < cfg.thr_off:
         msg = 'thr_on must be >= thr_off'
         raise ValueError(msg)
+    if cfg.cluster_count_mode not in ('trigger', 'unique_trace'):
+        msg = (
+            "cluster_count_mode must be 'trigger' or 'unique_trace', "
+            f'got {cfg.cluster_count_mode!r}'
+        )
+        raise ValueError(msg)
 
     # 1) 前処理(包絡は任意)
     sig = compute_envelope(x, axis=-1) if cfg.use_envelope else x
@@ -106,6 +113,7 @@ def decide_noise(
         win_ms=cfg.win_ms,
         min_traces=M,
         eps=cfg.eps,
+        cluster_count_mode=cfg.cluster_count_mode,
     )
     if is_event_B:
         return NoiseDecision(False, 'reject_B', None, pick_hist, cluster)

--- a/packages/seisai-dataset/tests/test_noise_decider.py
+++ b/packages/seisai-dataset/tests/test_noise_decider.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+from seisai_dataset import noise_decider
+from seisai_dataset.noise_decider import EventDetectConfig, decide_noise
+
+
+def test_event_detect_config_forwards_cluster_count_mode(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, object] = {}
+
+    def fake_pick_cluster(*_args, cluster_count_mode: str, **_kwargs):
+        captured['cluster_count_mode'] = cluster_count_mode
+        return False, np.zeros(8, dtype=np.int32), np.zeros(8, dtype=np.int32)
+
+    def fake_majority(*_args, **_kwargs):
+        return False, np.zeros(8, dtype=np.int32)
+
+    monkeypatch.setattr(noise_decider, 'detect_event_pick_cluster', fake_pick_cluster)
+    monkeypatch.setattr(noise_decider, 'detect_event_stalta_majority', fake_majority)
+
+    cfg = EventDetectConfig(use_envelope=False, cluster_count_mode='unique_trace')
+    decision = decide_noise(np.zeros((2, 8), dtype=np.float32), 0.001, cfg)
+
+    assert decision.is_noise is True
+    assert captured['cluster_count_mode'] == 'unique_trace'
+
+
+def test_decide_noise_rejects_invalid_cluster_count_mode() -> None:
+    cfg = EventDetectConfig(use_envelope=False, cluster_count_mode='bad')
+
+    with pytest.raises(ValueError, match='cluster_count_mode'):
+        decide_noise(np.zeros((2, 8), dtype=np.float32), 0.001, cfg)

--- a/packages/seisai-pick/src/seisai_pick/detectors.py
+++ b/packages/seisai-pick/src/seisai_pick/detectors.py
@@ -1,3 +1,5 @@
+from typing import Literal
+
 import numpy as np
 from numba import njit
 
@@ -58,6 +60,48 @@ def _picks_hist_from_R(
 
 
 @njit(cache=True, fastmath=True)
+def _picks_hist_and_mask_from_R(
+    R: np.ndarray,
+    thr_on: float,
+    thr_off: float,
+    min_on_len: int,
+    refr_len: int,
+    hist: np.ndarray,
+    mask: np.ndarray,
+) -> None:
+    """STALTA時系列 R から pick hist と trace別 pick mask を同時に作る."""
+    T = R.size
+    if T == 0:
+        return
+    if thr_on < thr_off:
+        msg = 'thr_on must be >= thr_off'
+        raise ValueError(msg)
+    if min_on_len < 1 or refr_len < 1:
+        msg = 'min_on_len and refr_len must be >= 1'
+        raise ValueError(msg)
+
+    t = 0
+    run = 0
+    while t < T:
+        v = R[t]
+        if v >= thr_on:
+            run += 1
+            if run >= min_on_len:
+                t0 = t - (run - 1)  # run開始
+                if 0 <= t0 < T:
+                    hist[t0] += 1
+                    mask[t0] = True
+                # リフラクトリ突入
+                t = t0 + refr_len
+                run = 0
+                continue
+        elif v <= thr_off:
+            run = 0
+        # thr_off < v < thr_on のときは run を保持(ヒステリシス)
+        t += 1
+
+
+@njit(cache=True, fastmath=True)
 def _stalta_pick_hist(
     x_ht: np.ndarray,
     ns: int,
@@ -75,6 +119,29 @@ def _stalta_pick_hist(
         R = stalta_1d(x_ht[h], ns, nl, eps)
         _picks_hist_from_R(R, thr_on, thr_off, min_on_len, refr_len, hist)
     return hist
+
+
+@njit(cache=True, fastmath=True)
+def _stalta_pick_hist_and_trace_mask(
+    x_ht: np.ndarray,
+    ns: int,
+    nl: int,
+    eps: float,
+    thr_on: float,
+    thr_off: float,
+    min_on_len: int,
+    refr_len: int,
+) -> tuple[np.ndarray, np.ndarray]:
+    """(H,T) の各トレースに対して pick hist と trace別 pick mask を返す."""
+    H, T = x_ht.shape
+    hist = np.zeros(T, dtype=np.int32)
+    mask = np.zeros((H, T), dtype=np.bool_)
+    for h in range(H):
+        R = stalta_1d(x_ht[h], ns, nl, eps)
+        _picks_hist_and_mask_from_R(
+            R, thr_on, thr_off, min_on_len, refr_len, hist, mask[h]
+        )
+    return hist, mask
 
 
 @njit(cache=True, fastmath=True)
@@ -101,6 +168,30 @@ def _sliding_sum_same(hist: np.ndarray, win: int) -> np.ndarray:
     return out
 
 
+@njit(cache=True, fastmath=True)
+def _sliding_unique_trace_count(pick_mask_ht: np.ndarray, win: int) -> np.ndarray:
+    """_sliding_sum_same と同じ窓定義で、pick がある trace 数を数える."""
+    H, T = pick_mask_ht.shape
+    win = max(win, 1)
+    out = np.zeros(T, dtype=np.int32)
+    half = win // 2
+    for h in range(H):
+        cs = np.zeros(T + 1, dtype=np.int32)
+        for i in range(T):
+            cs[i + 1] = cs[i] + (1 if pick_mask_ht[h, i] else 0)
+        for t in range(T):
+            a = t - half
+            a = max(a, 0)
+            b = a + win
+            if b > T:
+                b = T
+                a = b - win
+                a = max(a, 0)
+            if cs[b] - cs[a] > 0:
+                out[t] += 1
+    return out
+
+
 def detect_event_pick_cluster(
     x_ht: np.ndarray,
     dt_sec: float,
@@ -114,12 +205,13 @@ def detect_event_pick_cluster(
     win_ms: float = 30.0,
     min_traces: int = 8,
     eps: float = 1e-12,
+    cluster_count_mode: Literal['trigger', 'unique_trace'] = 'trigger',
 ) -> tuple[bool, np.ndarray, np.ndarray]:
     """リフラクトリ付き「初動候補クラスタ」方式。
     戻り値: (is_event, pick_hist[T], cluster_counts[T]).
 
     - pick_hist[t]: 各トレースで抽出された初動run開始のヒスト(同一tに複数あれば合算)
-    - cluster_counts[t]: 窓long=win_msの移動和(時刻t近傍のクラスタ本数)
+    - cluster_counts[t]: modeに応じた窓long=win_msのクラスタ本数
     - is_event: max(cluster_counts) >= min_traces
     """
     if x_ht.ndim != 2:
@@ -132,6 +224,12 @@ def detect_event_pick_cluster(
     if H == 0 or T == 0:
         msg = 'empty input'
         raise ValueError(msg)
+    if cluster_count_mode not in ('trigger', 'unique_trace'):
+        msg = (
+            "cluster_count_mode must be 'trigger' or 'unique_trace', "
+            f'got {cluster_count_mode!r}'
+        )
+        raise ValueError(msg)
 
     ns = _ms_to_samples(dt_sec, sta_ms)
     nl = max(ns + 1, _ms_to_samples(dt_sec, lta_ms))
@@ -139,17 +237,31 @@ def detect_event_pick_cluster(
     refr_len = _ms_to_samples(dt_sec, refr_ms)
     win = _ms_to_samples(dt_sec, win_ms)
 
-    pick_hist = _stalta_pick_hist(
-        x_ht.astype(np.float64, copy=False),
-        ns,
-        nl,
-        float(eps),
-        float(thr_on),
-        float(thr_off),
-        int(min_on_len),
-        int(refr_len),
-    )
-    cluster = _sliding_sum_same(pick_hist, int(win))
+    x_f64 = x_ht.astype(np.float64, copy=False)
+    if cluster_count_mode == 'trigger':
+        pick_hist = _stalta_pick_hist(
+            x_f64,
+            ns,
+            nl,
+            float(eps),
+            float(thr_on),
+            float(thr_off),
+            int(min_on_len),
+            int(refr_len),
+        )
+        cluster = _sliding_sum_same(pick_hist, int(win))
+    else:
+        pick_hist, pick_mask = _stalta_pick_hist_and_trace_mask(
+            x_f64,
+            ns,
+            nl,
+            float(eps),
+            float(thr_on),
+            float(thr_off),
+            int(min_on_len),
+            int(refr_len),
+        )
+        cluster = _sliding_unique_trace_count(pick_mask, int(win))
     is_event = int(cluster.max()) >= int(min_traces)
     return bool(is_event), pick_hist, cluster
 

--- a/packages/seisai-pick/tests/test_detectors_pick_cluster.py
+++ b/packages/seisai-pick/tests/test_detectors_pick_cluster.py
@@ -1,0 +1,148 @@
+import numpy as np
+import pytest
+from seisai_pick import detectors
+from seisai_pick.detectors import (
+    _sliding_sum_same,
+    _sliding_unique_trace_count,
+    detect_event_pick_cluster,
+)
+
+
+def test_detect_event_pick_cluster_default_matches_trigger_mode() -> None:
+    rng = np.random.default_rng(123)
+    x_ht = rng.normal(size=(3, 64)).astype(np.float32)
+
+    implicit = detect_event_pick_cluster(
+        x_ht,
+        0.001,
+        sta_ms=2.0,
+        lta_ms=8.0,
+        min_on_ms=1.0,
+        win_ms=6.0,
+    )
+    explicit = detect_event_pick_cluster(
+        x_ht,
+        0.001,
+        sta_ms=2.0,
+        lta_ms=8.0,
+        min_on_ms=1.0,
+        win_ms=6.0,
+        cluster_count_mode='trigger',
+    )
+
+    assert implicit[0] == explicit[0]
+    assert np.array_equal(implicit[1], explicit[1])
+    assert np.array_equal(implicit[2], explicit[2])
+
+
+def test_sliding_unique_trace_count_deduplicates_repeated_trace_picks() -> None:
+    pick_mask = np.zeros((1, 12), dtype=np.bool_)
+    pick_mask[0, 4] = True
+    pick_mask[0, 6] = True
+    pick_hist = pick_mask.sum(axis=0).astype(np.int32)
+
+    trigger_counts = _sliding_sum_same(pick_hist, 5)
+    unique_counts = _sliding_unique_trace_count(pick_mask, 5)
+
+    assert int(trigger_counts.max()) == 2
+    assert int(unique_counts.max()) == 1
+
+
+def test_sliding_unique_trace_count_counts_multiple_traces() -> None:
+    pick_mask = np.zeros((2, 12), dtype=np.bool_)
+    pick_mask[0, 4] = True
+    pick_mask[1, 6] = True
+
+    unique_counts = _sliding_unique_trace_count(pick_mask, 5)
+
+    assert int(unique_counts.max()) == 2
+
+
+def test_sliding_unique_trace_count_keeps_separated_same_trace_at_one() -> None:
+    pick_mask = np.zeros((1, 20), dtype=np.bool_)
+    pick_mask[0, 3] = True
+    pick_mask[0, 14] = True
+
+    unique_counts = _sliding_unique_trace_count(pick_mask, 5)
+
+    assert int(unique_counts.max()) == 1
+
+
+def test_detect_event_pick_cluster_unique_trace_mode_runs_real_detector() -> None:
+    rng = np.random.default_rng(456)
+    x_ht = rng.normal(size=(3, 48)).astype(np.float32)
+
+    is_event, pick_hist, cluster = detect_event_pick_cluster(
+        x_ht,
+        0.001,
+        sta_ms=1.0,
+        lta_ms=4.0,
+        min_on_ms=1.0,
+        win_ms=4.0,
+        cluster_count_mode='unique_trace',
+    )
+
+    assert isinstance(is_event, bool)
+    assert pick_hist.shape == (48,)
+    assert cluster.shape == (48,)
+    assert np.all(cluster <= x_ht.shape[0])
+
+
+def test_detect_event_pick_cluster_uses_selected_count_mode(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    pick_hist = np.zeros(12, dtype=np.int32)
+    pick_hist[[4, 6]] = 1
+    pick_mask = np.zeros((1, 12), dtype=np.bool_)
+    pick_mask[0, [4, 6]] = True
+
+    def fake_hist(*_args) -> np.ndarray:
+        return pick_hist.copy()
+
+    def fake_hist_and_mask(*_args) -> tuple[np.ndarray, np.ndarray]:
+        return pick_hist.copy(), pick_mask.copy()
+
+    monkeypatch.setattr(detectors, '_stalta_pick_hist', fake_hist)
+    monkeypatch.setattr(
+        detectors, '_stalta_pick_hist_and_trace_mask', fake_hist_and_mask
+    )
+
+    x_ht = np.zeros((1, 12), dtype=np.float32)
+    trigger_event, trigger_hist, trigger_cluster = detect_event_pick_cluster(
+        x_ht,
+        1.0,
+        sta_ms=1000.0,
+        lta_ms=2000.0,
+        win_ms=5000.0,
+        min_traces=2,
+        cluster_count_mode='trigger',
+    )
+    unique_event, unique_hist, unique_cluster = detect_event_pick_cluster(
+        x_ht,
+        1.0,
+        sta_ms=1000.0,
+        lta_ms=2000.0,
+        win_ms=5000.0,
+        min_traces=2,
+        cluster_count_mode='unique_trace',
+    )
+
+    assert trigger_event is True
+    assert unique_event is False
+    assert np.array_equal(trigger_hist, pick_hist)
+    assert np.array_equal(unique_hist, pick_hist)
+    assert int(trigger_cluster.max()) == 2
+    assert int(unique_cluster.max()) == 1
+
+
+def test_detect_event_pick_cluster_rejects_invalid_count_mode() -> None:
+    x_ht = np.zeros((1, 8), dtype=np.float32)
+
+    with pytest.raises(ValueError, match='cluster_count_mode'):
+        detect_event_pick_cluster(
+            x_ht,
+            0.001,
+            sta_ms=1.0,
+            lta_ms=2.0,
+            cluster_count_mode='bad',
+        )


### PR DESCRIPTION
Closes #113

## Summary
- `detect_event_pick_cluster` に cluster window 内の unique trace counting mode を追加する

## Changed files
- `packages/seisai-dataset/src/seisai_dataset/noise_decider.py`
- `packages/seisai-dataset/tests/test_noise_decider.py`
- `packages/seisai-pick/src/seisai_pick/detectors.py`
- `packages/seisai-pick/tests/test_detectors_pick_cluster.py`

## Checks
- `.work/codex/checks.log`: 1088 passed, 5 warnings in 83.48s (0:01:23)

## Review
- `.work/codex/review.txt`: accept: yes
- findings: blocker 0, major 0, minor 0
