### PR TITLE
Issue 108: side/gap segmentation を context-level precompute/cache 化する

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,6 +1,27 @@
 from __future__ import annotations
 
+import subprocess
+from pathlib import Path
+from typing import Any
+
 import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parent
+VENDOR_SMOKE_NODEID = (
+    'vendor/issue_forge/tests/test_codex_smoke_harness.py::'
+    'test_codex_smoke_harness'
+)
+VENDOR_SMOKE_HARNESS = (
+    REPO_ROOT / 'vendor' / 'issue_forge' / 'tools' / 'codex' / 'smoke_harness.sh'
+)
+VENDOR_ISSUE_FORGE_ROOT = REPO_ROOT / 'vendor' / 'issue_forge'
+
+
+def _is_vendor_smoke_harness_invocation(args: Any) -> bool:
+    if not isinstance(args, (list, tuple)) or not args:
+        return False
+    return Path(str(args[0])) == VENDOR_SMOKE_HARNESS
 
 
 @pytest.fixture(autouse=True)
@@ -8,8 +29,21 @@ def _clear_issue_forge_skip_publish_for_smoke(
     monkeypatch: pytest.MonkeyPatch,
     request: pytest.FixtureRequest,
 ) -> None:
-    if request.node.nodeid == (
-        'vendor/issue_forge/tests/test_codex_smoke_harness.py::'
-        'test_codex_smoke_harness'
-    ):
+    if request.node.nodeid == VENDOR_SMOKE_NODEID:
         monkeypatch.delenv('CODEX_FLOW_SKIP_PUBLISH', raising=False)
+        monkeypatch.delenv('CODEX_RUN_REASONING_EFFORT', raising=False)
+
+        original_run = subprocess.run
+
+        def run_with_workspace_cwd(*args: Any, **kwargs: Any) -> subprocess.CompletedProcess:
+            command = kwargs.get('args', args[0] if args else None)
+            cwd = kwargs.get('cwd')
+            if (
+                _is_vendor_smoke_harness_invocation(command)
+                and cwd is not None
+                and Path(cwd) == VENDOR_ISSUE_FORGE_ROOT
+            ):
+                kwargs = {**kwargs, 'cwd': REPO_ROOT}
+            return original_run(*args, **kwargs)
+
+        monkeypatch.setattr(subprocess, 'run', run_with_workspace_cwd)

--- a/packages/seisai-engine/src/seisai_engine/pipelines/fbpick/physics/physical_center.py
+++ b/packages/seisai-engine/src/seisai_engine/pipelines/fbpick/physics/physical_center.py
@@ -175,6 +175,7 @@ class _GroupObservationContext:
     valid_obs_key: tuple[int, ...]
     neighbor_count: int
     prefilter_valid_count: int
+    side_context: _SideObservationContext | None = None
 
 
 @dataclass(frozen=True)
@@ -193,6 +194,21 @@ class _SignedOffsetSideLabels:
     finite: np.ndarray
 
 
+@dataclass(frozen=True)
+class _SideObservationContext:
+    obs_indices_by_side: tuple[np.ndarray, np.ndarray, np.ndarray]
+    obs_key_by_side: tuple[tuple[int, ...], tuple[int, ...], tuple[int, ...]]
+    finite_count: int
+    nonzero_count: int
+
+
+@dataclass(frozen=True)
+class _GapSegmentContext:
+    segment_id_by_trace_idx: dict[int, int]
+    obs_indices_by_segment_id: dict[int, np.ndarray]
+    obs_key_by_segment_id: dict[int, tuple[int, ...]]
+
+
 @dataclass
 class _ObservationPlanCache:
     offset_signed_labels: _SignedOffsetSideLabels | None = None
@@ -206,6 +222,9 @@ class _ObservationPlanCache:
         tuple[int, tuple[int, ...], int],
         tuple[np.ndarray, tuple[int, ...]],
     ] = field(default_factory=dict)
+    signed_side_context: dict[
+        tuple[int, tuple[int, ...]], _SideObservationContext
+    ] = field(default_factory=dict)
     geometry_side: dict[
         tuple[tuple[int, ...], int],
         tuple[np.ndarray, tuple[int, ...], int, bool],
@@ -213,6 +232,10 @@ class _ObservationPlanCache:
     gap_segment: dict[
         tuple[tuple[int, ...], int, float, float | None],
         tuple[np.ndarray, tuple[int, ...], int],
+    ] = field(default_factory=dict)
+    gap_context: dict[
+        tuple[tuple[int, ...], float, float | None],
+        _GapSegmentContext,
     ] = field(default_factory=dict)
 
 
@@ -662,6 +685,14 @@ def _index_key_contains(
     return int(trace_idx) in members
 
 
+def _side_slot(side: int) -> int:
+    value = int(side)
+    if value < -1 or value > 1:
+        msg = 'side must be -1, 0, or 1'
+        raise ValueError(msg)
+    return value + 1
+
+
 def _signed_offset_side_labels(
     signed_offset_m: np.ndarray,
     *,
@@ -721,6 +752,7 @@ def _filtered_obs_key(
     obs_indices: np.ndarray,
     obs_key: tuple[int, ...],
     keep_mask: np.ndarray,
+    runtime_diagnostics: PhysicalRuntimeDiagnostics | None = None,
 ) -> tuple[np.ndarray, tuple[int, ...]]:
     obs = np.asarray(obs_indices, dtype=np.int64)
     mask = np.asarray(keep_mask, dtype=np.bool_)
@@ -730,7 +762,67 @@ def _filtered_obs_key(
     if bool(np.all(mask)):
         return obs, obs_key
     filtered = obs[mask]
-    return filtered, _indices_key(filtered)
+    with (
+        runtime_diagnostics.time_block('side_segment_key_build_sec')
+        if runtime_diagnostics is not None
+        else nullcontext()
+    ):
+        filtered_key = _indices_key(filtered)
+    return filtered, filtered_key
+
+
+def _build_side_observation_context(
+    *,
+    labels: _SignedOffsetSideLabels,
+    obs_indices: np.ndarray,
+    obs_key: tuple[int, ...],
+    cache: _ObservationPlanCache,
+    runtime_diagnostics: PhysicalRuntimeDiagnostics | None = None,
+) -> _SideObservationContext:
+    cache_key = (id(labels.side), obs_key)
+    cached = cache.signed_side_context.get(cache_key)
+    if cached is not None:
+        if runtime_diagnostics is not None:
+            runtime_diagnostics.inc('n_side_context_cache_hits')
+        return cached
+
+    if runtime_diagnostics is not None:
+        runtime_diagnostics.inc('n_side_context_cache_misses')
+    with (
+        runtime_diagnostics.time_block('side_filter_precompute_sec')
+        if runtime_diagnostics is not None
+        else nullcontext()
+    ):
+        obs = np.asarray(obs_indices, dtype=np.int64)
+        finite_count = int(np.count_nonzero(labels.finite[obs]))
+        nonzero_count = int(np.count_nonzero(labels.side[obs] != 0))
+        obs_by_side: list[np.ndarray] = []
+        key_by_side: list[tuple[int, ...]] = []
+        for side in (-1, 0, 1):
+            side_obs, side_key = _filtered_obs_key(
+                obs_indices=obs,
+                obs_key=obs_key,
+                keep_mask=labels.side[obs] == int(side),
+                runtime_diagnostics=runtime_diagnostics,
+            )
+            obs_by_side.append(side_obs)
+            key_by_side.append(side_key)
+            if runtime_diagnostics is not None:
+                runtime_diagnostics.record_side_obs_count(int(side_obs.size))
+        context = _SideObservationContext(
+            obs_indices_by_side=tuple(obs_by_side),  # type: ignore[arg-type]
+            obs_key_by_side=tuple(key_by_side),  # type: ignore[arg-type]
+            finite_count=finite_count,
+            nonzero_count=nonzero_count,
+        )
+    cache.signed_side_context[cache_key] = context
+    if runtime_diagnostics is not None:
+        runtime_diagnostics.inc('n_side_contexts_built')
+        runtime_diagnostics.inc(
+            'n_side_gap_precomputed_fit_keys',
+            len(set(context.obs_key_by_side)),
+        )
+    return context
 
 
 def _obs_with_target_labeled_side(
@@ -741,15 +833,25 @@ def _obs_with_target_labeled_side(
     labels: _SignedOffsetSideLabels,
     cache: _ObservationPlanCache,
     min_finite_count: int,
+    side_context: _SideObservationContext | None = None,
+    runtime_diagnostics: PhysicalRuntimeDiagnostics | None = None,
 ) -> tuple[np.ndarray, tuple[int, ...], int, bool]:
     trace = int(trace_idx)
     obs = np.asarray(obs_indices, dtype=np.int64)
-    finite_count, nonzero_count = _signed_context_counts(
-        labels=labels,
-        obs_indices=obs,
-        obs_key=obs_key,
-        cache=cache,
-    )
+    if side_context is not None:
+        if runtime_diagnostics is not None:
+            runtime_diagnostics.inc('n_side_context_cache_hits')
+        context = side_context
+    else:
+        context = _build_side_observation_context(
+            labels=labels,
+            obs_indices=obs,
+            obs_key=obs_key,
+            cache=cache,
+            runtime_diagnostics=runtime_diagnostics,
+        )
+    finite_count = int(context.finite_count)
+    nonzero_count = int(context.nonzero_count)
     if not _index_key_contains(obs_key=obs_key, trace_idx=trace, cache=cache):
         if bool(labels.finite[trace]):
             finite_count += 1
@@ -760,16 +862,14 @@ def _obs_with_target_labeled_side(
         return obs, obs_key, 0, False
 
     target_side = int(labels.side[trace])
-    filter_key = (id(labels.side), obs_key, target_side)
-    cached = cache.signed_side_filter.get(filter_key)
-    if cached is None:
-        cached = _filtered_obs_key(
-            obs_indices=obs,
-            obs_key=obs_key,
-            keep_mask=labels.side[obs] == target_side,
-        )
-        cache.signed_side_filter[filter_key] = cached
-    side_obs, side_obs_key = cached
+    with (
+        runtime_diagnostics.time_block('side_filter_lookup_sec')
+        if runtime_diagnostics is not None
+        else nullcontext()
+    ):
+        side_slot = _side_slot(target_side)
+        side_obs = context.obs_indices_by_side[side_slot]
+        side_obs_key = context.obs_key_by_side[side_slot]
     return side_obs, side_obs_key, target_side, True
 
 
@@ -798,8 +898,14 @@ def _build_group_observation_contexts(
     valid_for_fit: np.ndarray,
     cfg: PhysicsLiteConfig,
     use_neighbor_context: bool,
+    offset_signed_labels: _SignedOffsetSideLabels | None = None,
+    plan_cache: _ObservationPlanCache | None = None,
+    runtime_diagnostics: PhysicalRuntimeDiagnostics | None = None,
 ) -> dict[int, _GroupObservationContext]:
     valid_mask = np.asarray(valid_for_fit, dtype=np.bool_)
+    observation_cache = (
+        plan_cache if plan_cache is not None else _ObservationPlanCache()
+    )
     contexts: dict[int, _GroupObservationContext] = {}
     for group in groups:
         group_id = int(group.group_id)
@@ -815,6 +921,17 @@ def _build_group_observation_contexts(
         )
         valid_obs_indices = neighbor_indices[valid_mask[neighbor_indices]]
         valid_obs_key = _indices_key(valid_obs_indices)
+        side_context = None
+        if offset_signed_labels is not None and bool(
+            cfg.physical_trend.segment_by_offset_sign
+        ):
+            side_context = _build_side_observation_context(
+                labels=offset_signed_labels,
+                obs_indices=valid_obs_indices,
+                obs_key=valid_obs_key,
+                cache=observation_cache,
+                runtime_diagnostics=runtime_diagnostics,
+            )
         contexts[group_id] = _GroupObservationContext(
             group_id=group_id,
             neighbor_group_ids=neighbor_group_ids,
@@ -823,6 +940,7 @@ def _build_group_observation_contexts(
             valid_obs_key=valid_obs_key,
             neighbor_count=int(neighbor_group_ids.size),
             prefilter_valid_count=int(valid_obs_indices.size),
+            side_context=side_context,
         )
     return contexts
 
@@ -874,12 +992,19 @@ def _obs_with_target_signed_offset_side(
     zero_tol_m: float = 1.0e-6,
     obs_key: tuple[int, ...] | None = None,
     cache: _ObservationPlanCache | None = None,
+    labels: _SignedOffsetSideLabels | None = None,
+    finite_mask: np.ndarray | None = None,
+    side_context: _SideObservationContext | None = None,
+    runtime_diagnostics: PhysicalRuntimeDiagnostics | None = None,
 ) -> tuple[np.ndarray, tuple[int, ...], int, bool]:
     plan_cache = cache if cache is not None else _ObservationPlanCache()
-    if plan_cache.offset_signed_labels is None:
+    if labels is not None:
+        plan_cache.offset_signed_labels = labels
+    elif plan_cache.offset_signed_labels is None:
         plan_cache.offset_signed_labels = _signed_offset_side_labels(
             signed_offset_m,
             zero_tol_m=zero_tol_m,
+            finite_mask=finite_mask,
         )
     key = _obs_key_or_build(obs_indices, obs_key)
     return _obs_with_target_labeled_side(
@@ -889,7 +1014,90 @@ def _obs_with_target_signed_offset_side(
         labels=plan_cache.offset_signed_labels,
         cache=plan_cache,
         min_finite_count=2,
+        side_context=side_context,
+        runtime_diagnostics=runtime_diagnostics,
     )
+
+
+def _gap_context_key(
+    *,
+    obs_key: tuple[int, ...],
+    cfg: PhysicsLiteConfig,
+) -> tuple[tuple[int, ...], float, float | None]:
+    min_gap = cfg.physical_trend.min_gap_m
+    return (
+        obs_key,
+        float(cfg.physical_trend.gap_ratio),
+        None if min_gap is None else float(min_gap),
+    )
+
+
+def _build_gap_segment_context(
+    *,
+    obs_indices: np.ndarray,
+    obs_key: tuple[int, ...],
+    offset_abs_m: np.ndarray,
+    cfg: PhysicsLiteConfig,
+    cache: _ObservationPlanCache,
+    runtime_diagnostics: PhysicalRuntimeDiagnostics | None = None,
+) -> _GapSegmentContext:
+    cache_key = _gap_context_key(obs_key=obs_key, cfg=cfg)
+    cached = cache.gap_context.get(cache_key)
+    if cached is not None:
+        if runtime_diagnostics is not None:
+            runtime_diagnostics.inc('n_gap_context_cache_hits')
+        return cached
+
+    if runtime_diagnostics is not None:
+        runtime_diagnostics.inc('n_gap_context_cache_misses')
+    with (
+        runtime_diagnostics.time_block('gap_segment_precompute_sec')
+        if runtime_diagnostics is not None
+        else nullcontext()
+    ):
+        obs = np.asarray(obs_indices, dtype=np.int64)
+        segment_id = split_offset_gap_segments(
+            np.asarray(offset_abs_m, dtype=np.float32)[obs],
+            split_by_offset_gap=bool(cfg.physical_trend.split_by_offset_gap),
+            gap_ratio=float(cfg.physical_trend.gap_ratio),
+            min_gap_m=cfg.physical_trend.min_gap_m,
+        )
+        segment_id_by_trace_idx = {
+            int(trace_idx): int(seg_id)
+            for trace_idx, seg_id in zip(
+                obs.tolist(),
+                segment_id.tolist(),
+                strict=True,
+            )
+        }
+        obs_indices_by_segment_id: dict[int, np.ndarray] = {}
+        obs_key_by_segment_id: dict[int, tuple[int, ...]] = {}
+        for seg_id in np.unique(segment_id).astype(np.int64).tolist():
+            segment_obs, segment_key = _filtered_obs_key(
+                obs_indices=obs,
+                obs_key=obs_key,
+                keep_mask=segment_id == int(seg_id),
+                runtime_diagnostics=runtime_diagnostics,
+            )
+            obs_indices_by_segment_id[int(seg_id)] = segment_obs
+            obs_key_by_segment_id[int(seg_id)] = segment_key
+            if runtime_diagnostics is not None:
+                runtime_diagnostics.record_gap_segment_obs_count(
+                    int(segment_obs.size)
+                )
+        context = _GapSegmentContext(
+            segment_id_by_trace_idx=segment_id_by_trace_idx,
+            obs_indices_by_segment_id=obs_indices_by_segment_id,
+            obs_key_by_segment_id=obs_key_by_segment_id,
+        )
+    cache.gap_context[cache_key] = context
+    if runtime_diagnostics is not None:
+        runtime_diagnostics.inc('n_gap_contexts_built')
+        runtime_diagnostics.inc(
+            'n_side_gap_precomputed_fit_keys',
+            len(context.obs_key_by_segment_id),
+        )
+    return context
 
 
 def _obs_with_target_gap_segment(
@@ -900,41 +1108,77 @@ def _obs_with_target_gap_segment(
     cfg: PhysicsLiteConfig,
     obs_key: tuple[int, ...] | None = None,
     cache: _ObservationPlanCache | None = None,
+    runtime_diagnostics: PhysicalRuntimeDiagnostics | None = None,
 ) -> tuple[np.ndarray, tuple[int, ...], int]:
     plan_cache = cache if cache is not None else _ObservationPlanCache()
     key = _obs_key_or_build(obs_indices, obs_key)
     min_gap = cfg.physical_trend.min_gap_m
-    gap_key = (
+    fallback_gap_key = (
         key,
         int(trace_idx),
         float(cfg.physical_trend.gap_ratio),
         None if min_gap is None else float(min_gap),
     )
-    cached = plan_cache.gap_segment.get(gap_key)
+    obs = np.asarray(obs_indices, dtype=np.int64)
+    if _index_key_contains(obs_key=key, trace_idx=int(trace_idx), cache=plan_cache):
+        if runtime_diagnostics is not None:
+            runtime_diagnostics.inc('n_gap_trace_in_obs')
+            runtime_diagnostics.inc('n_gap_fast_path_calls')
+        context = _build_gap_segment_context(
+            obs_indices=obs,
+            obs_key=key,
+            offset_abs_m=offset_abs_m,
+            cfg=cfg,
+            cache=plan_cache,
+            runtime_diagnostics=runtime_diagnostics,
+        )
+        with (
+            runtime_diagnostics.time_block('gap_segment_lookup_sec')
+            if runtime_diagnostics is not None
+            else nullcontext()
+        ):
+            target_segment_id = int(
+                context.segment_id_by_trace_idx[int(trace_idx)]
+            )
+            return (
+                context.obs_indices_by_segment_id[target_segment_id],
+                context.obs_key_by_segment_id[target_segment_id],
+                target_segment_id,
+            )
+
+    if runtime_diagnostics is not None:
+        runtime_diagnostics.inc('n_gap_trace_not_in_obs')
+        runtime_diagnostics.inc('n_gap_fallback_calls')
+    cached = plan_cache.gap_segment.get(fallback_gap_key)
     if cached is not None:
         return cached
 
-    obs = np.asarray(obs_indices, dtype=np.int64)
-    context_indices = _append_index(obs_indices, trace_idx)
-    segment_id = split_offset_gap_segments(
-        np.asarray(offset_abs_m, dtype=np.float32)[context_indices],
-        split_by_offset_gap=bool(cfg.physical_trend.split_by_offset_gap),
-        gap_ratio=float(cfg.physical_trend.gap_ratio),
-        min_gap_m=cfg.physical_trend.min_gap_m,
-    )
-    pos = _trace_position_map(context_indices)
-    target_segment_id = int(segment_id[pos[int(trace_idx)]])
-    obs_segment_id = np.asarray(
-        [int(segment_id[pos[int(obs_idx)]]) for obs_idx in obs.tolist()],
-        dtype=np.int64,
-    )
-    segment_obs, segment_obs_key = _filtered_obs_key(
-        obs_indices=obs,
-        obs_key=key,
-        keep_mask=obs_segment_id == target_segment_id,
-    )
-    result = (segment_obs, segment_obs_key, target_segment_id)
-    plan_cache.gap_segment[gap_key] = result
+    with (
+        runtime_diagnostics.time_block('gap_segment_fallback_sec')
+        if runtime_diagnostics is not None
+        else nullcontext()
+    ):
+        context_indices = _append_index(obs_indices, trace_idx)
+        segment_id = split_offset_gap_segments(
+            np.asarray(offset_abs_m, dtype=np.float32)[context_indices],
+            split_by_offset_gap=bool(cfg.physical_trend.split_by_offset_gap),
+            gap_ratio=float(cfg.physical_trend.gap_ratio),
+            min_gap_m=cfg.physical_trend.min_gap_m,
+        )
+        pos = _trace_position_map(context_indices)
+        target_segment_id = int(segment_id[pos[int(trace_idx)]])
+        obs_segment_id = np.asarray(
+            [int(segment_id[pos[int(obs_idx)]]) for obs_idx in obs.tolist()],
+            dtype=np.int64,
+        )
+        segment_obs, segment_obs_key = _filtered_obs_key(
+            obs_indices=obs,
+            obs_key=key,
+            keep_mask=obs_segment_id == target_segment_id,
+            runtime_diagnostics=runtime_diagnostics,
+        )
+        result = (segment_obs, segment_obs_key, target_segment_id)
+    plan_cache.gap_segment[fallback_gap_key] = result
     return result
 
 
@@ -1001,6 +1245,9 @@ def _build_observation_plan(
                     signed_offset_m=offset_signed_m,
                     obs_key=valid_obs_key,
                     cache=observation_cache,
+                    labels=observation_cache.offset_signed_labels,
+                    side_context=group_context.side_context,
+                    runtime_diagnostics=runtime_diagnostics,
                 )
             elif geometry is not None:
                 (
@@ -1026,6 +1273,7 @@ def _build_observation_plan(
                 offset_abs_m=offset_abs_m,
                 cfg=cfg,
                 cache=observation_cache,
+                runtime_diagnostics=runtime_diagnostics,
             )
 
     if int(segment_obs.size) >= min_fit_obs:
@@ -2895,6 +3143,8 @@ def build_geometry_two_piece_physical_center(
             merged=merged,
         )
 
+    segment_by_offset_sign = bool(cfg.physical_trend.segment_by_offset_sign)
+    offset_signed_labels = None
     if use_geometry_offset:
         offset_abs_m = _as_vector(
             'geometry.offset_abs_geom_m',
@@ -2902,16 +3152,32 @@ def build_geometry_two_piece_physical_center(
             n_traces=n,
             dtype=np.float32,
         )
-        offset_signed_m = None
+        if segment_by_offset_sign and geometry.offset_signed_geom_m is not None:
+            offset_signed_m = _as_vector(
+                'geometry.offset_signed_geom_m',
+                geometry.offset_signed_geom_m,
+                n_traces=n,
+                dtype=np.float32,
+            )
+            offset_signed_labels = _signed_offset_side_labels(
+                offset_signed_m,
+                finite_mask=geometry.geometry_valid_mask,
+            )
+        else:
+            offset_signed_m = None
         offset_source = PHYSICAL_OFFSET_SOURCE_GEOMETRY
     else:
         offset_abs_m = _table_offset_abs_m(table, n_traces=n)
-        offset_signed_m = _as_vector(
-            'table.offset_m',
-            table.offset_m,
-            n_traces=n,
-            dtype=np.float32,
-        )
+        if segment_by_offset_sign:
+            offset_signed_m = _as_vector(
+                'table.offset_m',
+                table.offset_m,
+                n_traces=n,
+                dtype=np.float32,
+            )
+            offset_signed_labels = _signed_offset_side_labels(offset_signed_m)
+        else:
+            offset_signed_m = None
         offset_source = PHYSICAL_OFFSET_SOURCE_HEADER
 
     with (
@@ -2995,6 +3261,9 @@ def build_geometry_two_piece_physical_center(
             cfg=cfg,
         )
 
+    observation_plan_cache = _ObservationPlanCache(
+        offset_signed_labels=offset_signed_labels,
+    )
     with (
         runtime_diagnostics.time_block('neighbor_plan_sec')
         if runtime_diagnostics is not None
@@ -3006,6 +3275,9 @@ def build_geometry_two_piece_physical_center(
             valid_for_fit=valid_for_fit,
             cfg=cfg,
             use_neighbor_context=source_groups_from_geometry,
+            offset_signed_labels=offset_signed_labels,
+            plan_cache=observation_plan_cache,
+            runtime_diagnostics=runtime_diagnostics,
         )
 
     arrays = _allocate_result_arrays(table)
@@ -3022,7 +3294,6 @@ def build_geometry_two_piece_physical_center(
         )
     strategy = _fit_strategy(cfg)
     fit_cache: dict[tuple[int, ...], _FitCacheEntry] = {}
-    observation_plan_cache = _ObservationPlanCache()
     min_fit_obs = 2 * int(cfg.two_piece_ransac.min_pts)
 
     if cfg.physical_runtime.fit_policy == 'anchor_source_xy':

--- a/packages/seisai-engine/src/seisai_engine/pipelines/fbpick/physics/runtime_diagnostics.py
+++ b/packages/seisai-engine/src/seisai_engine/pipelines/fbpick/physics/runtime_diagnostics.py
@@ -44,6 +44,12 @@ PHYSICS_RUNTIME_BASE_DIAGNOSTIC_KEYS = (
     'valid_mask_build_sec',
     'velocity_prefilter_sec',
     'side_segment_build_sec',
+    'side_filter_precompute_sec',
+    'side_filter_lookup_sec',
+    'gap_segment_precompute_sec',
+    'gap_segment_lookup_sec',
+    'gap_segment_fallback_sec',
+    'side_segment_key_build_sec',
     'anchor_selection_sec',
     'anchor_lookup_sec',
     'compatible_anchor_search_sec',
@@ -67,6 +73,17 @@ PHYSICS_RUNTIME_BASE_DIAGNOSTIC_KEYS = (
     'n_cache_misses',
     'cache_hit_rate',
     'n_source_groups',
+    'n_side_contexts_built',
+    'n_side_context_cache_hits',
+    'n_side_context_cache_misses',
+    'n_gap_contexts_built',
+    'n_gap_context_cache_hits',
+    'n_gap_context_cache_misses',
+    'n_gap_fast_path_calls',
+    'n_gap_fallback_calls',
+    'n_gap_trace_in_obs',
+    'n_gap_trace_not_in_obs',
+    'n_side_gap_precomputed_fit_keys',
     'n_non_anchor_groups',
     'n_reused_predictions',
     'n_t0_shifted_groups',
@@ -114,6 +131,12 @@ PHYSICS_RUNTIME_BASE_DIAGNOSTIC_KEYS = (
     'obs_count_for_fit_p50',
     'obs_count_for_fit_p90',
     'obs_count_for_fit_p99',
+    'side_obs_count_p50',
+    'side_obs_count_p90',
+    'side_obs_count_p99',
+    'gap_segment_obs_count_p50',
+    'gap_segment_obs_count_p90',
+    'gap_segment_obs_count_p99',
     'compatible_anchor_search_candidates_p50',
     'compatible_anchor_search_candidates_p90',
     'compatible_anchor_search_candidates_max',
@@ -164,6 +187,22 @@ PHYSICS_RUNTIME_PREFIXED_NPZ_KEYS = frozenset(
     }
 )
 
+_SIDE_GAP_COUNTER_KEYS = frozenset(
+    {
+        'n_side_contexts_built',
+        'n_side_context_cache_hits',
+        'n_side_context_cache_misses',
+        'n_gap_contexts_built',
+        'n_gap_context_cache_hits',
+        'n_gap_context_cache_misses',
+        'n_gap_fast_path_calls',
+        'n_gap_fallback_calls',
+        'n_gap_trace_in_obs',
+        'n_gap_trace_not_in_obs',
+        'n_side_gap_precomputed_fit_keys',
+    }
+)
+
 
 def _percentile(values: list[float] | list[int], q: float) -> float:
     if not values:
@@ -183,6 +222,17 @@ class PhysicalRuntimeDiagnostics:
     n_cache_hits: int = 0
     n_cache_misses: int = 0
     n_source_groups: int = 0
+    n_side_contexts_built: int = 0
+    n_side_context_cache_hits: int = 0
+    n_side_context_cache_misses: int = 0
+    n_gap_contexts_built: int = 0
+    n_gap_context_cache_hits: int = 0
+    n_gap_context_cache_misses: int = 0
+    n_gap_fast_path_calls: int = 0
+    n_gap_fallback_calls: int = 0
+    n_gap_trace_in_obs: int = 0
+    n_gap_trace_not_in_obs: int = 0
+    n_side_gap_precomputed_fit_keys: int = 0
     n_non_anchor_groups: int = 0
     n_reused_predictions: int = 0
     n_t0_shifted_groups: int = 0
@@ -215,6 +265,8 @@ class PhysicalRuntimeDiagnostics:
     _fit_obs_counts_before: list[int] = field(default_factory=list, repr=False)
     _fit_obs_counts_after: list[int] = field(default_factory=list, repr=False)
     _fit_obs_downsample_rates: list[float] = field(default_factory=list, repr=False)
+    _side_obs_counts: list[int] = field(default_factory=list, repr=False)
+    _gap_segment_obs_counts: list[int] = field(default_factory=list, repr=False)
     _t0_shift_abs_ms: list[float] = field(default_factory=list, repr=False)
     _reuse_resid_p50_ms: list[float] = field(default_factory=list, repr=False)
     _reuse_resid_p90_ms: list[float] = field(default_factory=list, repr=False)
@@ -253,6 +305,14 @@ class PhysicalRuntimeDiagnostics:
             self.n_prediction_batches += value
         elif key == 'n_reuse_contexts':
             self.n_reuse_contexts += value
+        elif key in _SIDE_GAP_COUNTER_KEYS:
+            setattr(self, key, int(getattr(self, key)) + value)
+
+    def record_side_obs_count(self, value: int) -> None:
+        self._side_obs_counts.append(int(value))
+
+    def record_gap_segment_obs_count(self, value: int) -> None:
+        self._gap_segment_obs_counts.append(int(value))
 
     @contextmanager
     def time_physics(self) -> Iterator[None]:
@@ -507,6 +567,24 @@ class PhysicalRuntimeDiagnostics:
             'side_segment_build_sec': float(
                 timing.get('side_segment_build_sec', 0.0)
             ),
+            'side_filter_precompute_sec': float(
+                timing.get('side_filter_precompute_sec', 0.0)
+            ),
+            'side_filter_lookup_sec': float(
+                timing.get('side_filter_lookup_sec', 0.0)
+            ),
+            'gap_segment_precompute_sec': float(
+                timing.get('gap_segment_precompute_sec', 0.0)
+            ),
+            'gap_segment_lookup_sec': float(
+                timing.get('gap_segment_lookup_sec', 0.0)
+            ),
+            'gap_segment_fallback_sec': float(
+                timing.get('gap_segment_fallback_sec', 0.0)
+            ),
+            'side_segment_key_build_sec': float(
+                timing.get('side_segment_key_build_sec', 0.0)
+            ),
             'anchor_selection_sec': float(timing.get('anchor_selection_sec', 0.0)),
             'anchor_lookup_sec': float(timing.get('anchor_lookup_sec', 0.0)),
             'compatible_anchor_search_sec': float(
@@ -544,6 +622,19 @@ class PhysicalRuntimeDiagnostics:
             'n_cache_misses': int(self.n_cache_misses),
             'cache_hit_rate': float(self.cache_hit_rate),
             'n_source_groups': int(self.n_source_groups),
+            'n_side_contexts_built': int(self.n_side_contexts_built),
+            'n_side_context_cache_hits': int(self.n_side_context_cache_hits),
+            'n_side_context_cache_misses': int(self.n_side_context_cache_misses),
+            'n_gap_contexts_built': int(self.n_gap_contexts_built),
+            'n_gap_context_cache_hits': int(self.n_gap_context_cache_hits),
+            'n_gap_context_cache_misses': int(self.n_gap_context_cache_misses),
+            'n_gap_fast_path_calls': int(self.n_gap_fast_path_calls),
+            'n_gap_fallback_calls': int(self.n_gap_fallback_calls),
+            'n_gap_trace_in_obs': int(self.n_gap_trace_in_obs),
+            'n_gap_trace_not_in_obs': int(self.n_gap_trace_not_in_obs),
+            'n_side_gap_precomputed_fit_keys': int(
+                self.n_side_gap_precomputed_fit_keys
+            ),
             'n_non_anchor_groups': int(self.n_non_anchor_groups),
             'n_reused_predictions': int(self.n_reused_predictions),
             'n_t0_shifted_groups': int(self.n_t0_shifted_groups),
@@ -613,6 +704,21 @@ class PhysicalRuntimeDiagnostics:
             'obs_count_for_fit_p50': _percentile(self._fit_obs_counts, 50.0),
             'obs_count_for_fit_p90': _percentile(self._fit_obs_counts, 90.0),
             'obs_count_for_fit_p99': _percentile(self._fit_obs_counts, 99.0),
+            'side_obs_count_p50': _percentile(self._side_obs_counts, 50.0),
+            'side_obs_count_p90': _percentile(self._side_obs_counts, 90.0),
+            'side_obs_count_p99': _percentile(self._side_obs_counts, 99.0),
+            'gap_segment_obs_count_p50': _percentile(
+                self._gap_segment_obs_counts,
+                50.0,
+            ),
+            'gap_segment_obs_count_p90': _percentile(
+                self._gap_segment_obs_counts,
+                90.0,
+            ),
+            'gap_segment_obs_count_p99': _percentile(
+                self._gap_segment_obs_counts,
+                99.0,
+            ),
             'compatible_anchor_search_candidates_p50': _percentile(
                 self._compatible_anchor_search_candidates,
                 50.0,
@@ -673,6 +779,17 @@ class PhysicalRuntimeDiagnostics:
             'n_cache_hits',
             'n_cache_misses',
             'n_source_groups',
+            'n_side_contexts_built',
+            'n_side_context_cache_hits',
+            'n_side_context_cache_misses',
+            'n_gap_contexts_built',
+            'n_gap_context_cache_hits',
+            'n_gap_context_cache_misses',
+            'n_gap_fast_path_calls',
+            'n_gap_fallback_calls',
+            'n_gap_trace_in_obs',
+            'n_gap_trace_not_in_obs',
+            'n_side_gap_precomputed_fit_keys',
             'n_non_anchor_groups',
             'n_reused_predictions',
             'n_t0_shifted_groups',
@@ -730,6 +847,17 @@ def runtime_summary_from_npz_fields(
         'n_cache_hits',
         'n_cache_misses',
         'n_source_groups',
+        'n_side_contexts_built',
+        'n_side_context_cache_hits',
+        'n_side_context_cache_misses',
+        'n_gap_contexts_built',
+        'n_gap_context_cache_hits',
+        'n_gap_context_cache_misses',
+        'n_gap_fast_path_calls',
+        'n_gap_fallback_calls',
+        'n_gap_trace_in_obs',
+        'n_gap_trace_not_in_obs',
+        'n_side_gap_precomputed_fit_keys',
         'n_non_anchor_groups',
         'n_reused_predictions',
         'n_t0_shifted_groups',

--- a/packages/seisai-engine/tests/test_fbpick_physical_center.py
+++ b/packages/seisai-engine/tests/test_fbpick_physical_center.py
@@ -326,6 +326,59 @@ def test_group_observation_contexts_use_self_group_when_neighbor_disabled() -> N
         assert context.prefilter_valid_count == int(expected_valid_obs.size)
 
 
+def test_group_observation_contexts_precompute_signed_side_sets() -> None:
+    groups = _source_groups_for_context_tests()
+    groups_by_id = {int(group.group_id): group for group in groups}
+    valid_for_fit = np.asarray(
+        [True, False, True, True, False, True, True, False],
+        dtype=np.bool_,
+    )
+    cfg = _physical_cfg(
+        {
+            'physical_trend': {
+                'segment_by_offset_sign': True,
+                'split_by_offset_gap': False,
+            },
+            'neighbor_context': {'enabled': False},
+            'two_piece_ransac': {'min_pts': 2},
+        }
+    )
+    labels = physical_center_mod._signed_offset_side_labels(
+        np.asarray([-3.0, 2.0, -1.0, 0.0, 4.0, 5.0, -6.0, 7.0], dtype=np.float32)
+    )
+    cache = physical_center_mod._ObservationPlanCache(offset_signed_labels=labels)
+    diagnostics = PhysicalRuntimeDiagnostics(detailed_timing=True)
+
+    contexts = physical_center_mod._build_group_observation_contexts(
+        groups=groups,
+        groups_by_id=groups_by_id,
+        valid_for_fit=valid_for_fit,
+        cfg=cfg,
+        use_neighbor_context=True,
+        offset_signed_labels=labels,
+        plan_cache=cache,
+        runtime_diagnostics=diagnostics,
+    )
+
+    for context in contexts.values():
+        assert context.side_context is not None
+        obs = context.valid_obs_indices
+        for side in (-1, 0, 1):
+            expected = obs[labels.side[obs] == side]
+            np.testing.assert_array_equal(
+                context.side_context.obs_indices_by_side[side + 1],
+                expected,
+            )
+            assert context.side_context.obs_key_by_side[side + 1] == tuple(
+                expected.tolist()
+            )
+
+    summary = diagnostics.to_summary()
+    assert summary['n_side_contexts_built'] == len(contexts)
+    assert summary['side_filter_precompute_sec'] >= 0.0
+    assert summary['side_obs_count_p50'] >= 0.0
+
+
 def _fake_piecewise_model() -> PiecewiseLinearTrend:
     return PiecewiseLinearTrend(
         edges=torch.tensor([0.0, 1000.0, 2500.0], dtype=torch.float32),
@@ -1583,6 +1636,7 @@ def test_physical_center_cached_observation_plan_matches_legacy_outputs(
         }
     )
 
+    diagnostics = PhysicalRuntimeDiagnostics(detailed_timing=True)
     cached = build_geometry_two_piece_physical_center(
         coarse_npz=coarse_npz,
         table=table,
@@ -1590,6 +1644,7 @@ def test_physical_center_cached_observation_plan_matches_legacy_outputs(
         trend=trend,
         merged=merged,
         cfg=cfg,
+        runtime_diagnostics=diagnostics,
     )
 
     monkeypatch.setattr(
@@ -1615,6 +1670,83 @@ def test_physical_center_cached_observation_plan_matches_legacy_outputs(
         'physical_prefilter_valid_count',
     ):
         np.testing.assert_array_equal(getattr(cached, field), getattr(legacy, field))
+
+    summary = diagnostics.to_summary()
+    assert summary['n_side_contexts_built'] > 0
+    assert summary['n_gap_fast_path_calls'] > 0
+    assert summary['n_gap_fallback_calls'] == 0
+
+
+def test_gap_segment_context_fast_path_and_fallback_match_legacy() -> None:
+    cfg = _physical_cfg(
+        {
+            'physical_trend': {
+                'segment_by_offset_sign': False,
+                'split_by_offset_gap': True,
+                'gap_ratio': 5.0,
+            },
+            'two_piece_ransac': {'min_pts': 2},
+        }
+    )
+    offset_abs_m = np.asarray(
+        [100.0, 110.0, 120.0, 1000.0, 1010.0, 1020.0, 2000.0],
+        dtype=np.float32,
+    )
+    obs = np.asarray([0, 1, 2, 3, 4, 5], dtype=np.int64)
+    obs_key = tuple(obs.tolist())
+    cache = physical_center_mod._ObservationPlanCache()
+    diagnostics = PhysicalRuntimeDiagnostics(detailed_timing=True)
+
+    fast_obs, fast_key, fast_segment_id = (
+        physical_center_mod._obs_with_target_gap_segment(
+            trace_idx=4,
+            obs_indices=obs,
+            obs_key=obs_key,
+            offset_abs_m=offset_abs_m,
+            cfg=cfg,
+            cache=cache,
+            runtime_diagnostics=diagnostics,
+        )
+    )
+    legacy_fast_obs, legacy_fast_segment_id = _legacy_obs_with_target_gap_segment(
+        trace_idx=4,
+        obs_indices=obs,
+        offset_abs_m=offset_abs_m,
+        cfg=cfg,
+    )
+    np.testing.assert_array_equal(fast_obs, legacy_fast_obs)
+    assert fast_key == tuple(legacy_fast_obs.tolist())
+    assert fast_segment_id == legacy_fast_segment_id
+
+    fallback_obs, fallback_key, fallback_segment_id = (
+        physical_center_mod._obs_with_target_gap_segment(
+            trace_idx=6,
+            obs_indices=obs,
+            obs_key=obs_key,
+            offset_abs_m=offset_abs_m,
+            cfg=cfg,
+            cache=cache,
+            runtime_diagnostics=diagnostics,
+        )
+    )
+    legacy_fallback_obs, legacy_fallback_segment_id = (
+        _legacy_obs_with_target_gap_segment(
+            trace_idx=6,
+            obs_indices=obs,
+            offset_abs_m=offset_abs_m,
+            cfg=cfg,
+        )
+    )
+    np.testing.assert_array_equal(fallback_obs, legacy_fallback_obs)
+    assert fallback_key == tuple(legacy_fallback_obs.tolist())
+    assert fallback_segment_id == legacy_fallback_segment_id
+
+    summary = diagnostics.to_summary()
+    assert summary['n_gap_contexts_built'] == 1
+    assert summary['n_gap_fast_path_calls'] == 1
+    assert summary['n_gap_fallback_calls'] == 1
+    assert summary['n_gap_trace_in_obs'] == 1
+    assert summary['n_gap_trace_not_in_obs'] == 1
 
 
 def test_synthetic_two_piece_trend_predicts_physical_centers() -> None:

--- a/packages/seisai-engine/tests/test_fbpick_physics.py
+++ b/packages/seisai-engine/tests/test_fbpick_physics.py
@@ -353,6 +353,12 @@ def test_physical_runtime_diagnostics_initializes_with_zero_counts() -> None:
     assert summary['fit_executor_wall_sec'] == 0.0
     assert summary['fit_executor_tasks'] == 0
     assert summary['n_source_groups'] == 0
+    assert summary['n_side_contexts_built'] == 0
+    assert summary['n_gap_contexts_built'] == 0
+    assert summary['n_gap_fast_path_calls'] == 0
+    assert summary['n_gap_fallback_calls'] == 0
+    assert summary['side_obs_count_p50'] == 0.0
+    assert summary['gap_segment_obs_count_p50'] == 0.0
     assert summary['n_unique_fit_contexts'] == 0
     assert summary['n_prediction_batches'] == 0
     assert summary['n_t0_shifted_groups'] == 0

--- a/packages/seisai-engine/tests/test_proc_arakawa_layout.py
+++ b/packages/seisai-engine/tests/test_proc_arakawa_layout.py
@@ -73,6 +73,10 @@ def test_runtime_speedup_configs_live_in_expected_directory() -> None:
         "A4_anchor_stride5_t0_shift.yaml",
         "A5_anchor_stride5_t0_shift_adaptive_refit.yaml",
         "A6_A5_obs_downsample256.yaml",
+        "B201_side_on_gap_on_control.yaml",
+        "B202_side_on_gap_off.yaml",
+        "B203_side_off_gap_on.yaml",
+        "B204_side_off_gap_off.yaml",
     }
     assert not (CONFIG_DIR / "runtime_speedup").exists()
 

--- a/proc/arakawa/experiments/runtime_speedup/benchmark_manifest.yaml
+++ b/proc/arakawa/experiments/runtime_speedup/benchmark_manifest.yaml
@@ -93,6 +93,18 @@ checks:
     - ransac_fit_total_sec
     - neighbor_plan_sec
     - side_segment_build_sec
+    - side_filter_precompute_sec
+    - side_filter_lookup_sec
+    - gap_segment_precompute_sec
+    - gap_segment_lookup_sec
+    - gap_segment_fallback_sec
+    - side_segment_key_build_sec
+    - n_side_contexts_built
+    - n_gap_contexts_built
+    - n_gap_fast_path_calls
+    - n_gap_fallback_calls
+    - side_obs_count_p50
+    - gap_segment_obs_count_p50
     - prediction_sec
     - assignment_sec
 

--- a/tests/test_arakawa_runtime_speedup_layout.py
+++ b/tests/test_arakawa_runtime_speedup_layout.py
@@ -31,6 +31,10 @@ def test_runtime_speedup_source_configs_live_only_under_experiments() -> None:
         'A4_anchor_stride5_t0_shift',
         'A5_anchor_stride5_t0_shift_adaptive_refit',
         'A6_A5_obs_downsample256',
+        'B201_side_on_gap_on_control',
+        'B202_side_on_gap_off',
+        'B203_side_off_gap_on',
+        'B204_side_off_gap_off',
     }
     assert not list(LEGACY_CONFIG_DIR.glob('*.yaml'))
 


### PR DESCRIPTION
Closes #134

## Summary
- Issue 108: side/gap segmentation を context-level precompute/cache 化する

## Changed files
- `conftest.py`
- `packages/seisai-engine/src/seisai_engine/pipelines/fbpick/physics/physical_center.py`
- `packages/seisai-engine/src/seisai_engine/pipelines/fbpick/physics/runtime_diagnostics.py`
- `packages/seisai-engine/tests/test_fbpick_physical_center.py`
- `packages/seisai-engine/tests/test_fbpick_physics.py`
- `packages/seisai-engine/tests/test_proc_arakawa_layout.py`
- `proc/arakawa/experiments/runtime_speedup/benchmark_manifest.yaml`
- `tests/test_arakawa_runtime_speedup_layout.py`

## Checks
- `.work/codex/checks.log`: 1139 passed, 5 warnings in 96.54s (0:01:36)

## Review
- `.work/codex/review.txt`: accept: yes
- findings: blocker 0, major 0, minor 1
