### PR TITLE
Issue 109: Issue 108 side/gap context precompute の follow-up 修正

### DIFF
--- a/packages/seisai-engine/src/seisai_engine/pipelines/fbpick/physics/physical_center.py
+++ b/packages/seisai-engine/src/seisai_engine/pipelines/fbpick/physics/physical_center.py
@@ -181,6 +181,7 @@ class _GroupObservationContext:
 @dataclass(frozen=True)
 class _ObservationPlan:
     obs_indices: np.ndarray
+    obs_key: tuple[int, ...] | None
     neighbor_count: int
     prefilter_valid_count: int
     segment_id: int
@@ -215,13 +216,6 @@ class _ObservationPlanCache:
     index_members: dict[tuple[int, ...], frozenset[int]] = field(
         default_factory=dict,
     )
-    signed_context_counts: dict[
-        tuple[int, tuple[int, ...]], tuple[int, int]
-    ] = field(default_factory=dict)
-    signed_side_filter: dict[
-        tuple[int, tuple[int, ...], int],
-        tuple[np.ndarray, tuple[int, ...]],
-    ] = field(default_factory=dict)
     signed_side_context: dict[
         tuple[int, tuple[int, ...]], _SideObservationContext
     ] = field(default_factory=dict)
@@ -727,26 +721,6 @@ def _signed_offset_side_labels(
     return _SignedOffsetSideLabels(side=side, finite=finite)
 
 
-def _signed_context_counts(
-    *,
-    labels: _SignedOffsetSideLabels,
-    obs_indices: np.ndarray,
-    obs_key: tuple[int, ...],
-    cache: _ObservationPlanCache,
-) -> tuple[int, int]:
-    cache_key = (id(labels.side), obs_key)
-    counts = cache.signed_context_counts.get(cache_key)
-    if counts is not None:
-        return counts
-
-    obs = np.asarray(obs_indices, dtype=np.int64)
-    finite_count = int(np.count_nonzero(labels.finite[obs]))
-    nonzero_count = int(np.count_nonzero(labels.side[obs] != 0))
-    counts = (finite_count, nonzero_count)
-    cache.signed_context_counts[cache_key] = counts
-    return counts
-
-
 def _filtered_obs_key(
     *,
     obs_indices: np.ndarray,
@@ -840,7 +814,7 @@ def _obs_with_target_labeled_side(
     obs = np.asarray(obs_indices, dtype=np.int64)
     if side_context is not None:
         if runtime_diagnostics is not None:
-            runtime_diagnostics.inc('n_side_context_cache_hits')
+            runtime_diagnostics.inc('n_side_context_lookup_calls')
         context = side_context
     else:
         context = _build_side_observation_context(
@@ -994,6 +968,7 @@ def _obs_with_target_signed_offset_side(
     cache: _ObservationPlanCache | None = None,
     labels: _SignedOffsetSideLabels | None = None,
     finite_mask: np.ndarray | None = None,
+    min_finite_count: int = 2,
     side_context: _SideObservationContext | None = None,
     runtime_diagnostics: PhysicalRuntimeDiagnostics | None = None,
 ) -> tuple[np.ndarray, tuple[int, ...], int, bool]:
@@ -1013,7 +988,7 @@ def _obs_with_target_signed_offset_side(
         obs_key=key,
         labels=plan_cache.offset_signed_labels,
         cache=plan_cache,
-        min_finite_count=2,
+        min_finite_count=int(min_finite_count),
         side_context=side_context,
         runtime_diagnostics=runtime_diagnostics,
     )
@@ -1216,6 +1191,7 @@ def _build_observation_plan(
     if prefilter_valid_count < min_fit_obs:
         return _ObservationPlan(
             obs_indices=valid_obs,
+            obs_key=valid_obs_key,
             neighbor_count=neighbor_count,
             prefilter_valid_count=prefilter_valid_count,
             segment_id=-1,
@@ -1246,6 +1222,15 @@ def _build_observation_plan(
                     obs_key=valid_obs_key,
                     cache=observation_cache,
                     labels=observation_cache.offset_signed_labels,
+                    min_finite_count=(
+                        1
+                        if (
+                            geometry is not None
+                            and bool(cfg.physical_trend.use_geometry_offset)
+                            and geometry.offset_signed_geom_m is not None
+                        )
+                        else 2
+                    ),
                     side_context=group_context.side_context,
                     runtime_diagnostics=runtime_diagnostics,
                 )
@@ -1264,9 +1249,10 @@ def _build_observation_plan(
                 )
 
         segment_obs = side_obs
+        segment_obs_key = side_obs_key
         segment_id = 0
         if bool(cfg.physical_trend.split_by_offset_gap):
-            segment_obs, _segment_obs_key, segment_id = _obs_with_target_gap_segment(
+            segment_obs, segment_obs_key, segment_id = _obs_with_target_gap_segment(
                 trace_idx=trace_idx,
                 obs_indices=side_obs,
                 obs_key=side_obs_key,
@@ -1279,6 +1265,7 @@ def _build_observation_plan(
     if int(segment_obs.size) >= min_fit_obs:
         return _ObservationPlan(
             obs_indices=segment_obs,
+            obs_key=segment_obs_key,
             neighbor_count=neighbor_count,
             prefilter_valid_count=prefilter_valid_count,
             segment_id=segment_id,
@@ -1292,6 +1279,7 @@ def _build_observation_plan(
     ):
         return _ObservationPlan(
             obs_indices=side_obs,
+            obs_key=side_obs_key,
             neighbor_count=neighbor_count,
             prefilter_valid_count=prefilter_valid_count,
             segment_id=0,
@@ -1302,6 +1290,7 @@ def _build_observation_plan(
     if side_reliable and int(valid_obs.size) >= min_fit_obs:
         return _ObservationPlan(
             obs_indices=valid_obs,
+            obs_key=valid_obs_key,
             neighbor_count=neighbor_count,
             prefilter_valid_count=prefilter_valid_count,
             segment_id=0,
@@ -1311,6 +1300,7 @@ def _build_observation_plan(
 
     return _ObservationPlan(
         obs_indices=segment_obs,
+        obs_key=segment_obs_key,
         neighbor_count=neighbor_count,
         prefilter_valid_count=prefilter_valid_count,
         segment_id=segment_id,
@@ -1597,8 +1587,30 @@ def _model_diagnostics(
     )
 
 
+def _fit_key_for_obs(
+    obs_indices: np.ndarray,
+    *,
+    precomputed_key: tuple[int, ...] | None = None,
+    runtime_diagnostics: PhysicalRuntimeDiagnostics | None = None,
+    after_sampling: bool = False,
+    count_missing_precomputed: bool = True,
+) -> tuple[int, ...]:
+    if precomputed_key is not None:
+        if runtime_diagnostics is not None:
+            runtime_diagnostics.inc('n_precomputed_fit_key_used')
+        return precomputed_key
+
+    if runtime_diagnostics is not None:
+        if bool(count_missing_precomputed):
+            runtime_diagnostics.inc('n_fit_key_missing_precomputed')
+        runtime_diagnostics.inc('n_fit_key_built_from_indices')
+        if bool(after_sampling):
+            runtime_diagnostics.inc('n_fit_key_built_after_sampling')
+    return _indices_key(obs_indices)
+
+
 def _fit_cache_key(plan: _ObservationPlan) -> tuple[int, ...]:
-    return tuple(np.asarray(plan.obs_indices, dtype=np.int64).tolist())
+    return _fit_key_for_obs(plan.obs_indices, precomputed_key=plan.obs_key)
 
 
 def _offset_spread_failure_reason(
@@ -2141,8 +2153,18 @@ def _prepare_trace_plan_assignment(
             cfg=cfg,
             min_required_obs=int(min_fit_obs),
         )
+    sampling_changed = obs_indices is not plan.obs_indices
+    precomputed_fit_key = None if sampling_changed else plan.obs_key
+    fit_key = _fit_key_for_obs(
+        obs_indices,
+        precomputed_key=precomputed_fit_key,
+        runtime_diagnostics=runtime_diagnostics,
+        after_sampling=sampling_changed,
+        count_missing_precomputed=not sampling_changed,
+    )
     fit_plan = _ObservationPlan(
         obs_indices=obs_indices,
+        obs_key=fit_key,
         neighbor_count=plan.neighbor_count,
         prefilter_valid_count=plan.prefilter_valid_count,
         segment_id=plan.segment_id,
@@ -2152,7 +2174,7 @@ def _prepare_trace_plan_assignment(
     return _TracePlanAssignment(
         trace_idx=int(trace_idx),
         plan=fit_plan,
-        fit_key=_fit_cache_key(fit_plan),
+        fit_key=fit_key,
         obs_count_before_sampling=obs_count_before_sampling,
     )
 

--- a/packages/seisai-engine/src/seisai_engine/pipelines/fbpick/physics/runtime_diagnostics.py
+++ b/packages/seisai-engine/src/seisai_engine/pipelines/fbpick/physics/runtime_diagnostics.py
@@ -76,6 +76,7 @@ PHYSICS_RUNTIME_BASE_DIAGNOSTIC_KEYS = (
     'n_side_contexts_built',
     'n_side_context_cache_hits',
     'n_side_context_cache_misses',
+    'n_side_context_lookup_calls',
     'n_gap_contexts_built',
     'n_gap_context_cache_hits',
     'n_gap_context_cache_misses',
@@ -84,6 +85,10 @@ PHYSICS_RUNTIME_BASE_DIAGNOSTIC_KEYS = (
     'n_gap_trace_in_obs',
     'n_gap_trace_not_in_obs',
     'n_side_gap_precomputed_fit_keys',
+    'n_precomputed_fit_key_used',
+    'n_fit_key_built_from_indices',
+    'n_fit_key_built_after_sampling',
+    'n_fit_key_missing_precomputed',
     'n_non_anchor_groups',
     'n_reused_predictions',
     'n_t0_shifted_groups',
@@ -192,6 +197,7 @@ _SIDE_GAP_COUNTER_KEYS = frozenset(
         'n_side_contexts_built',
         'n_side_context_cache_hits',
         'n_side_context_cache_misses',
+        'n_side_context_lookup_calls',
         'n_gap_contexts_built',
         'n_gap_context_cache_hits',
         'n_gap_context_cache_misses',
@@ -200,6 +206,10 @@ _SIDE_GAP_COUNTER_KEYS = frozenset(
         'n_gap_trace_in_obs',
         'n_gap_trace_not_in_obs',
         'n_side_gap_precomputed_fit_keys',
+        'n_precomputed_fit_key_used',
+        'n_fit_key_built_from_indices',
+        'n_fit_key_built_after_sampling',
+        'n_fit_key_missing_precomputed',
     }
 )
 
@@ -225,6 +235,7 @@ class PhysicalRuntimeDiagnostics:
     n_side_contexts_built: int = 0
     n_side_context_cache_hits: int = 0
     n_side_context_cache_misses: int = 0
+    n_side_context_lookup_calls: int = 0
     n_gap_contexts_built: int = 0
     n_gap_context_cache_hits: int = 0
     n_gap_context_cache_misses: int = 0
@@ -233,6 +244,10 @@ class PhysicalRuntimeDiagnostics:
     n_gap_trace_in_obs: int = 0
     n_gap_trace_not_in_obs: int = 0
     n_side_gap_precomputed_fit_keys: int = 0
+    n_precomputed_fit_key_used: int = 0
+    n_fit_key_built_from_indices: int = 0
+    n_fit_key_built_after_sampling: int = 0
+    n_fit_key_missing_precomputed: int = 0
     n_non_anchor_groups: int = 0
     n_reused_predictions: int = 0
     n_t0_shifted_groups: int = 0
@@ -625,6 +640,7 @@ class PhysicalRuntimeDiagnostics:
             'n_side_contexts_built': int(self.n_side_contexts_built),
             'n_side_context_cache_hits': int(self.n_side_context_cache_hits),
             'n_side_context_cache_misses': int(self.n_side_context_cache_misses),
+            'n_side_context_lookup_calls': int(self.n_side_context_lookup_calls),
             'n_gap_contexts_built': int(self.n_gap_contexts_built),
             'n_gap_context_cache_hits': int(self.n_gap_context_cache_hits),
             'n_gap_context_cache_misses': int(self.n_gap_context_cache_misses),
@@ -634,6 +650,16 @@ class PhysicalRuntimeDiagnostics:
             'n_gap_trace_not_in_obs': int(self.n_gap_trace_not_in_obs),
             'n_side_gap_precomputed_fit_keys': int(
                 self.n_side_gap_precomputed_fit_keys
+            ),
+            'n_precomputed_fit_key_used': int(self.n_precomputed_fit_key_used),
+            'n_fit_key_built_from_indices': int(
+                self.n_fit_key_built_from_indices
+            ),
+            'n_fit_key_built_after_sampling': int(
+                self.n_fit_key_built_after_sampling
+            ),
+            'n_fit_key_missing_precomputed': int(
+                self.n_fit_key_missing_precomputed
             ),
             'n_non_anchor_groups': int(self.n_non_anchor_groups),
             'n_reused_predictions': int(self.n_reused_predictions),
@@ -782,6 +808,7 @@ class PhysicalRuntimeDiagnostics:
             'n_side_contexts_built',
             'n_side_context_cache_hits',
             'n_side_context_cache_misses',
+            'n_side_context_lookup_calls',
             'n_gap_contexts_built',
             'n_gap_context_cache_hits',
             'n_gap_context_cache_misses',
@@ -790,6 +817,10 @@ class PhysicalRuntimeDiagnostics:
             'n_gap_trace_in_obs',
             'n_gap_trace_not_in_obs',
             'n_side_gap_precomputed_fit_keys',
+            'n_precomputed_fit_key_used',
+            'n_fit_key_built_from_indices',
+            'n_fit_key_built_after_sampling',
+            'n_fit_key_missing_precomputed',
             'n_non_anchor_groups',
             'n_reused_predictions',
             'n_t0_shifted_groups',
@@ -850,6 +881,7 @@ def runtime_summary_from_npz_fields(
         'n_side_contexts_built',
         'n_side_context_cache_hits',
         'n_side_context_cache_misses',
+        'n_side_context_lookup_calls',
         'n_gap_contexts_built',
         'n_gap_context_cache_hits',
         'n_gap_context_cache_misses',
@@ -858,6 +890,10 @@ def runtime_summary_from_npz_fields(
         'n_gap_trace_in_obs',
         'n_gap_trace_not_in_obs',
         'n_side_gap_precomputed_fit_keys',
+        'n_precomputed_fit_key_used',
+        'n_fit_key_built_from_indices',
+        'n_fit_key_built_after_sampling',
+        'n_fit_key_missing_precomputed',
         'n_non_anchor_groups',
         'n_reused_predictions',
         'n_t0_shifted_groups',

--- a/packages/seisai-engine/tests/test_fbpick_physical_center.py
+++ b/packages/seisai-engine/tests/test_fbpick_physical_center.py
@@ -213,6 +213,26 @@ def _source_groups_for_context_tests() -> tuple[
     )
 
 
+def _single_group_context(
+    obs_indices: np.ndarray,
+    *,
+    side_context: physical_center_mod._SideObservationContext | None = None,
+) -> dict[int, physical_center_mod._GroupObservationContext]:
+    obs = np.asarray(obs_indices, dtype=np.int64)
+    return {
+        0: physical_center_mod._GroupObservationContext(
+            group_id=0,
+            neighbor_group_ids=np.asarray([0], dtype=np.int64),
+            neighbor_indices=obs,
+            valid_obs_indices=obs,
+            valid_obs_key=tuple(obs.tolist()),
+            neighbor_count=1,
+            prefilter_valid_count=int(obs.size),
+            side_context=side_context,
+        )
+    }
+
+
 def test_group_observation_contexts_match_existing_selection_and_filtering() -> None:
     groups = _source_groups_for_context_tests()
     groups_by_id = {int(group.group_id): group for group in groups}
@@ -379,6 +399,202 @@ def test_group_observation_contexts_precompute_signed_side_sets() -> None:
     assert summary['side_obs_count_p50'] >= 0.0
 
 
+def test_observation_plan_propagates_precomputed_obs_keys() -> None:
+    obs = np.arange(12, dtype=np.int64)
+    offsets = np.asarray(
+        [
+            100.0,
+            110.0,
+            120.0,
+            130.0,
+            1000.0,
+            1010.0,
+            1020.0,
+            1030.0,
+            2000.0,
+            2010.0,
+            2020.0,
+            2030.0,
+        ],
+        dtype=np.float32,
+    )
+
+    disabled_cfg = _physical_cfg(
+        {
+            'physical_trend': {
+                'segment_by_offset_sign': False,
+                'split_by_offset_gap': False,
+            },
+            'neighbor_context': {'enabled': False},
+            'two_piece_ransac': {'min_pts': 2},
+        }
+    )
+    disabled_plan = physical_center_mod._build_observation_plan(
+        trace_idx=4,
+        target_group_id=0,
+        group_context_by_id=_single_group_context(obs),
+        geometry=None,
+        offset_abs_m=offsets,
+        offset_signed_m=None,
+        cfg=disabled_cfg,
+    )
+    assert disabled_plan is not None
+    assert disabled_plan.obs_key == tuple(obs.tolist())
+
+    gap_cfg = _physical_cfg(
+        {
+            'physical_trend': {
+                'segment_by_offset_sign': False,
+                'split_by_offset_gap': True,
+            },
+            'neighbor_context': {'enabled': False},
+            'two_piece_ransac': {'min_pts': 2},
+        }
+    )
+    gap_plan = physical_center_mod._build_observation_plan(
+        trace_idx=8,
+        target_group_id=0,
+        group_context_by_id=_single_group_context(obs),
+        geometry=None,
+        offset_abs_m=offsets,
+        offset_signed_m=None,
+        cfg=gap_cfg,
+    )
+    assert gap_plan is not None
+    np.testing.assert_array_equal(gap_plan.obs_indices, np.asarray([8, 9, 10, 11]))
+    assert gap_plan.obs_key == (8, 9, 10, 11)
+
+    labels = physical_center_mod._signed_offset_side_labels(
+        np.asarray([-1.0] * 4 + [1.0] * 8, dtype=np.float32)
+    )
+    cache = physical_center_mod._ObservationPlanCache(offset_signed_labels=labels)
+    side_context = physical_center_mod._build_side_observation_context(
+        labels=labels,
+        obs_indices=obs,
+        obs_key=tuple(obs.tolist()),
+        cache=cache,
+    )
+    side_cfg = _physical_cfg(
+        {
+            'physical_trend': {
+                'segment_by_offset_sign': True,
+                'split_by_offset_gap': False,
+            },
+            'neighbor_context': {'enabled': False},
+            'two_piece_ransac': {'min_pts': 2},
+        }
+    )
+    side_plan = physical_center_mod._build_observation_plan(
+        trace_idx=4,
+        target_group_id=0,
+        group_context_by_id=_single_group_context(obs, side_context=side_context),
+        geometry=None,
+        offset_abs_m=offsets,
+        offset_signed_m=labels.side.astype(np.float32),
+        cfg=side_cfg,
+        plan_cache=cache,
+    )
+    assert side_plan is not None
+    np.testing.assert_array_equal(side_plan.obs_indices, np.arange(4, 12))
+    assert side_plan.obs_key == tuple(range(4, 12))
+
+    side_gap_cfg = _physical_cfg(
+        {
+            'physical_trend': {
+                'segment_by_offset_sign': True,
+                'split_by_offset_gap': True,
+            },
+            'neighbor_context': {'enabled': False},
+            'two_piece_ransac': {'min_pts': 2},
+        }
+    )
+    side_gap_plan = physical_center_mod._build_observation_plan(
+        trace_idx=8,
+        target_group_id=0,
+        group_context_by_id=_single_group_context(obs, side_context=side_context),
+        geometry=None,
+        offset_abs_m=offsets,
+        offset_signed_m=labels.side.astype(np.float32),
+        cfg=side_gap_cfg,
+        plan_cache=cache,
+    )
+    assert side_gap_plan is not None
+    np.testing.assert_array_equal(
+        side_gap_plan.obs_indices,
+        np.asarray([8, 9, 10, 11]),
+    )
+    assert side_gap_plan.obs_key == (8, 9, 10, 11)
+
+    fallback_plan = physical_center_mod._build_observation_plan(
+        trace_idx=10,
+        target_group_id=0,
+        group_context_by_id=_single_group_context(obs[:8]),
+        geometry=None,
+        offset_abs_m=np.asarray(
+            [
+                100.0,
+                110.0,
+                120.0,
+                130.0,
+                1000.0,
+                1010.0,
+                1020.0,
+                1030.0,
+                2000.0,
+                2010.0,
+                1025.0,
+            ],
+            dtype=np.float32,
+        ),
+        offset_signed_m=None,
+        cfg=gap_cfg,
+    )
+    assert fallback_plan is not None
+    assert fallback_plan.obs_key == tuple(fallback_plan.obs_indices.tolist())
+
+
+def test_side_context_lookup_diagnostics_are_separate_from_cache_hits() -> None:
+    obs = np.arange(4, dtype=np.int64)
+    obs_key = tuple(obs.tolist())
+    labels = physical_center_mod._signed_offset_side_labels(
+        np.asarray([-2.0, -1.0, 1.0, 2.0], dtype=np.float32)
+    )
+    cache = physical_center_mod._ObservationPlanCache(offset_signed_labels=labels)
+    diagnostics = PhysicalRuntimeDiagnostics(detailed_timing=True)
+
+    context = physical_center_mod._build_side_observation_context(
+        labels=labels,
+        obs_indices=obs,
+        obs_key=obs_key,
+        cache=cache,
+        runtime_diagnostics=diagnostics,
+    )
+    cached_context = physical_center_mod._build_side_observation_context(
+        labels=labels,
+        obs_indices=obs,
+        obs_key=obs_key,
+        cache=cache,
+        runtime_diagnostics=diagnostics,
+    )
+    assert cached_context is context
+
+    physical_center_mod._obs_with_target_signed_offset_side(
+        trace_idx=2,
+        obs_indices=obs,
+        signed_offset_m=labels.side.astype(np.float32),
+        obs_key=obs_key,
+        cache=cache,
+        labels=labels,
+        side_context=context,
+        runtime_diagnostics=diagnostics,
+    )
+
+    summary = diagnostics.to_summary()
+    assert summary['n_side_contexts_built'] == 1
+    assert summary['n_side_context_cache_hits'] == 1
+    assert summary['n_side_context_lookup_calls'] == 1
+
+
 def _fake_piecewise_model() -> PiecewiseLinearTrend:
     return PiecewiseLinearTrend(
         edges=torch.tensor([0.0, 1000.0, 2500.0], dtype=torch.float32),
@@ -520,6 +736,7 @@ def test_parallel_cached_context_hit_accounting_excludes_owner_trace() -> None:
     diagnostics = PhysicalRuntimeDiagnostics()
     plan = physical_center_mod._ObservationPlan(
         obs_indices=np.arange(4, dtype=np.int64),
+        obs_key=(0, 1, 2, 3),
         neighbor_count=1,
         prefilter_valid_count=4,
         segment_id=0,
@@ -552,9 +769,51 @@ def test_parallel_cached_context_hit_accounting_excludes_owner_trace() -> None:
     assert diagnostics.n_cache_hits == 3
 
 
+def test_fit_key_for_obs_uses_precomputed_key_without_rebuilding(
+    monkeypatch,
+) -> None:
+    def fail_indices_key(_indices: np.ndarray) -> tuple[int, ...]:
+        raise AssertionError('_indices_key should not be called')
+
+    monkeypatch.setattr(physical_center_mod, '_indices_key', fail_indices_key)
+    diagnostics = PhysicalRuntimeDiagnostics()
+
+    key = physical_center_mod._fit_key_for_obs(
+        np.asarray([10, 11], dtype=np.int64),
+        precomputed_key=(10, 11),
+        runtime_diagnostics=diagnostics,
+    )
+
+    assert key == (10, 11)
+    assert diagnostics.n_precomputed_fit_key_used == 1
+    assert diagnostics.n_fit_key_built_from_indices == 0
+
+
+def test_fit_key_for_obs_records_index_build_and_sampling_counters() -> None:
+    diagnostics = PhysicalRuntimeDiagnostics()
+
+    key = physical_center_mod._fit_key_for_obs(
+        np.asarray([2, 4], dtype=np.int64),
+        runtime_diagnostics=diagnostics,
+    )
+    sampled_key = physical_center_mod._fit_key_for_obs(
+        np.asarray([4], dtype=np.int64),
+        runtime_diagnostics=diagnostics,
+        after_sampling=True,
+        count_missing_precomputed=False,
+    )
+
+    assert key == (2, 4)
+    assert sampled_key == (4,)
+    assert diagnostics.n_fit_key_built_from_indices == 2
+    assert diagnostics.n_fit_key_built_after_sampling == 1
+    assert diagnostics.n_fit_key_missing_precomputed == 1
+
+
 def test_fit_task_cache_preserves_specific_prefit_failure_reason() -> None:
     plan = physical_center_mod._ObservationPlan(
         obs_indices=np.arange(4, dtype=np.int64),
+        obs_key=(0, 1, 2, 3),
         neighbor_count=1,
         prefilter_valid_count=4,
         segment_id=0,
@@ -597,6 +856,7 @@ def test_prefit_task_failure_does_not_record_ransac_fit_call() -> None:
     diagnostics = PhysicalRuntimeDiagnostics()
     plan = physical_center_mod._ObservationPlan(
         obs_indices=np.arange(4, dtype=np.int64),
+        obs_key=(0, 1, 2, 3),
         neighbor_count=1,
         prefilter_valid_count=4,
         segment_id=0,
@@ -645,6 +905,7 @@ def test_assign_model_prediction_batch_matches_single_trace_assignment() -> None
     )
     plan = physical_center_mod._ObservationPlan(
         obs_indices=np.arange(3, dtype=np.int64),
+        obs_key=(0, 1, 2),
         neighbor_count=1,
         prefilter_valid_count=3,
         segment_id=0,
@@ -703,6 +964,7 @@ def test_assign_model_prediction_batch_handles_vector_shift_and_invalid() -> Non
     )
     plan = physical_center_mod._ObservationPlan(
         obs_indices=np.arange(4, dtype=np.int64),
+        obs_key=(0, 1, 2, 3),
         neighbor_count=1,
         prefilter_valid_count=4,
         segment_id=0,
@@ -1328,6 +1590,168 @@ def test_thread_fit_executor_propagates_worker_fit_runtime_error(monkeypatch) ->
         )
 
 
+def _saved_signed_geometry(
+    *,
+    offset_abs_m: np.ndarray,
+    offset_signed_m: np.ndarray,
+    geometry_valid_mask: np.ndarray,
+) -> physical_center_mod.CoarseGeometry:
+    offsets = np.asarray(offset_abs_m, dtype=np.float32)
+    n_traces = int(offsets.size)
+    return physical_center_mod.CoarseGeometry(
+        source_x_m=np.zeros((n_traces,), dtype=np.float32),
+        source_y_m=np.zeros((n_traces,), dtype=np.float32),
+        receiver_x_m=offsets.astype(np.float32, copy=True),
+        receiver_y_m=np.zeros((n_traces,), dtype=np.float32),
+        offset_abs_geom_m=offsets,
+        geometry_valid_mask=np.asarray(geometry_valid_mask, dtype=np.bool_),
+        offset_signed_geom_m=np.asarray(offset_signed_m, dtype=np.float32),
+    )
+
+
+def _saved_geometry_plan_pair(
+    *,
+    trace_idx: int,
+    offset_abs_m: np.ndarray,
+    offset_signed_m: np.ndarray,
+    geometry_valid_mask: np.ndarray,
+    cfg: object,
+) -> tuple[
+    physical_center_mod._ObservationPlan,
+    physical_center_mod._ObservationPlan,
+]:
+    obs = np.arange(int(np.asarray(offset_abs_m).size), dtype=np.int64)
+    geometry = _saved_signed_geometry(
+        offset_abs_m=offset_abs_m,
+        offset_signed_m=offset_signed_m,
+        geometry_valid_mask=geometry_valid_mask,
+    )
+    labels = physical_center_mod._signed_offset_side_labels(
+        offset_signed_m,
+        finite_mask=geometry.geometry_valid_mask,
+    )
+    group = physical_center_mod.SourceGroup(
+        group_id=0,
+        source_key_x=0,
+        source_key_y=0,
+        source_x_m=0.0,
+        source_y_m=0.0,
+        trace_indices=obs,
+    )
+    cache = physical_center_mod._ObservationPlanCache(offset_signed_labels=labels)
+    contexts = physical_center_mod._build_group_observation_contexts(
+        groups=(group,),
+        groups_by_id={0: group},
+        valid_for_fit=np.ones((obs.size,), dtype=np.bool_),
+        cfg=cfg,
+        use_neighbor_context=False,
+        offset_signed_labels=labels,
+        plan_cache=cache,
+    )
+    fast = physical_center_mod._build_observation_plan(
+        trace_idx=trace_idx,
+        target_group_id=0,
+        group_context_by_id=contexts,
+        geometry=geometry,
+        offset_abs_m=offset_abs_m,
+        offset_signed_m=offset_signed_m,
+        cfg=cfg,
+        plan_cache=cache,
+    )
+    legacy = _legacy_build_observation_plan(
+        trace_idx=trace_idx,
+        target_group_id=0,
+        group_context_by_id=contexts,
+        geometry=geometry,
+        offset_abs_m=offset_abs_m,
+        offset_signed_m=None,
+        cfg=cfg,
+    )
+    assert fast is not None
+    assert legacy is not None
+    return fast, legacy
+
+
+@pytest.mark.parametrize('split_by_offset_gap', [False, True])
+def test_saved_geometry_signed_offset_fast_path_matches_legacy_edge_cases(
+    split_by_offset_gap: bool,
+) -> None:
+    cfg = _physical_cfg(
+        {
+            'physical_trend': {
+                'use_geometry_offset': True,
+                'segment_by_offset_sign': True,
+                'split_by_offset_gap': split_by_offset_gap,
+            },
+            'neighbor_context': {'enabled': False},
+            'two_piece_ransac': {'min_pts': 2},
+        }
+    )
+    offset_abs_m = np.asarray(
+        [
+            100.0,
+            110.0,
+            120.0,
+            130.0,
+            500.0,
+            510.0,
+            520.0,
+            530.0,
+            1000.0,
+            1010.0,
+            1020.0,
+            1030.0,
+        ],
+        dtype=np.float32,
+    )
+    offset_signed_m = np.asarray(
+        [
+            -100.0,
+            -110.0,
+            -120.0,
+            -130.0,
+            0.0,
+            np.nan,
+            np.nan,
+            0.0,
+            1000.0,
+            1010.0,
+            1020.0,
+            1030.0,
+        ],
+        dtype=np.float32,
+    )
+    geometry_valid_mask = np.asarray(
+        [True, True, True, True, True, False, True, True, True, True, True, True]
+    )
+
+    for trace_idx in (0, 5, 8):
+        fast, legacy = _saved_geometry_plan_pair(
+            trace_idx=trace_idx,
+            offset_abs_m=offset_abs_m,
+            offset_signed_m=offset_signed_m,
+            geometry_valid_mask=geometry_valid_mask,
+            cfg=cfg,
+        )
+        np.testing.assert_array_equal(fast.obs_indices, legacy.obs_indices)
+        assert fast.obs_key == tuple(fast.obs_indices.tolist())
+        assert fast.side == legacy.side
+        assert fast.relaxed == legacy.relaxed
+        assert fast.segment_id == legacy.segment_id
+
+    sparse_fast, sparse_legacy = _saved_geometry_plan_pair(
+        trace_idx=3,
+        offset_abs_m=np.asarray([100.0, 110.0, 120.0, 130.0], dtype=np.float32),
+        offset_signed_m=np.asarray([np.nan, np.nan, np.nan, 130.0], dtype=np.float32),
+        geometry_valid_mask=np.asarray([False, False, False, True]),
+        cfg=cfg,
+    )
+    np.testing.assert_array_equal(sparse_fast.obs_indices, sparse_legacy.obs_indices)
+    assert sparse_fast.side == sparse_legacy.side
+    assert sparse_fast.relaxed == sparse_legacy.relaxed
+    assert sparse_fast.segment_id == sparse_legacy.segment_id
+
+
 def test_physical_center_uses_saved_signed_offset_for_side_segmentation(
     monkeypatch,
 ) -> None:
@@ -1519,6 +1943,7 @@ def _legacy_build_observation_plan(
     if prefilter_valid_count < min_fit_obs:
         return physical_center_mod._ObservationPlan(
             obs_indices=valid_obs,
+            obs_key=tuple(np.asarray(valid_obs, dtype=np.int64).tolist()),
             neighbor_count=neighbor_count,
             prefilter_valid_count=prefilter_valid_count,
             segment_id=-1,
@@ -1558,6 +1983,7 @@ def _legacy_build_observation_plan(
     if int(segment_obs.size) >= min_fit_obs:
         return physical_center_mod._ObservationPlan(
             obs_indices=segment_obs,
+            obs_key=tuple(np.asarray(segment_obs, dtype=np.int64).tolist()),
             neighbor_count=neighbor_count,
             prefilter_valid_count=prefilter_valid_count,
             segment_id=segment_id,
@@ -1571,6 +1997,7 @@ def _legacy_build_observation_plan(
     ):
         return physical_center_mod._ObservationPlan(
             obs_indices=side_obs,
+            obs_key=tuple(np.asarray(side_obs, dtype=np.int64).tolist()),
             neighbor_count=neighbor_count,
             prefilter_valid_count=prefilter_valid_count,
             segment_id=0,
@@ -1581,6 +2008,7 @@ def _legacy_build_observation_plan(
     if side_reliable and int(valid_obs.size) >= min_fit_obs:
         return physical_center_mod._ObservationPlan(
             obs_indices=valid_obs,
+            obs_key=tuple(np.asarray(valid_obs, dtype=np.int64).tolist()),
             neighbor_count=neighbor_count,
             prefilter_valid_count=prefilter_valid_count,
             segment_id=0,
@@ -1590,6 +2018,7 @@ def _legacy_build_observation_plan(
 
     return physical_center_mod._ObservationPlan(
         obs_indices=segment_obs,
+        obs_key=tuple(np.asarray(segment_obs, dtype=np.int64).tolist()),
         neighbor_count=neighbor_count,
         prefilter_valid_count=prefilter_valid_count,
         segment_id=segment_id,

--- a/packages/seisai-engine/tests/test_fbpick_physics.py
+++ b/packages/seisai-engine/tests/test_fbpick_physics.py
@@ -354,9 +354,14 @@ def test_physical_runtime_diagnostics_initializes_with_zero_counts() -> None:
     assert summary['fit_executor_tasks'] == 0
     assert summary['n_source_groups'] == 0
     assert summary['n_side_contexts_built'] == 0
+    assert summary['n_side_context_lookup_calls'] == 0
     assert summary['n_gap_contexts_built'] == 0
     assert summary['n_gap_fast_path_calls'] == 0
     assert summary['n_gap_fallback_calls'] == 0
+    assert summary['n_precomputed_fit_key_used'] == 0
+    assert summary['n_fit_key_built_from_indices'] == 0
+    assert summary['n_fit_key_built_after_sampling'] == 0
+    assert summary['n_fit_key_missing_precomputed'] == 0
     assert summary['side_obs_count_p50'] == 0.0
     assert summary['gap_segment_obs_count_p50'] == 0.0
     assert summary['n_unique_fit_contexts'] == 0


### PR DESCRIPTION
Closes #136

## Summary
- Issue 109: Issue 108 side/gap context precompute の follow-up 修正

## Changed files
- `packages/seisai-engine/src/seisai_engine/pipelines/fbpick/physics/physical_center.py`
- `packages/seisai-engine/src/seisai_engine/pipelines/fbpick/physics/runtime_diagnostics.py`
- `packages/seisai-engine/tests/test_fbpick_physical_center.py`
- `packages/seisai-engine/tests/test_fbpick_physics.py`

## Checks
- `.work/codex/checks.log`: 1145 passed, 5 warnings in 96.27s (0:01:36)

## Review
- `.work/codex/review.txt`: accept: yes
- findings: blocker 0, major 0, minor 0
