### PR TITLE
# Issue: fbpick physics の geometry invalid fallback を高速化し、physical trend 時は trend_result を lazy 化する

### DIFF
--- a/packages/seisai-engine/src/seisai_engine/pipelines/fbpick/common/io.py
+++ b/packages/seisai-engine/src/seisai_engine/pipelines/fbpick/common/io.py
@@ -287,14 +287,22 @@ def _validate_pick_time_pair(
     dt_sec: float,
     n_samples_orig: int,
 ) -> None:
-    if np.any(pick_i < 0) or np.any(pick_i >= int(n_samples_orig)):
+    valid_mask = np.ones(pick_i.shape, dtype=np.bool_)
+    if pick_key == 'trend_center_i':
+        sentinel_mask = (pick_i == np.int32(-1)) & np.isnan(pick_t_sec)
+        valid_mask = ~sentinel_mask
+        if not bool(np.any(valid_mask)):
+            return
+    pick_valid = pick_i[valid_mask]
+    time_valid = pick_t_sec[valid_mask]
+    if np.any(pick_valid < 0) or np.any(pick_valid >= int(n_samples_orig)):
         msg = f'{pick_key} must lie in [0, n_samples_orig)'
         raise ValueError(msg)
-    if not np.all(np.isfinite(pick_t_sec)):
+    if not np.all(np.isfinite(time_valid)):
         msg = f'{time_key} must be finite'
         raise ValueError(msg)
-    expected_t_sec = pick_i.astype(np.float32) * np.float32(dt_sec)
-    if not np.array_equal(pick_t_sec, expected_t_sec):
+    expected_t_sec = pick_valid.astype(np.float32) * np.float32(dt_sec)
+    if not np.array_equal(time_valid, expected_t_sec):
         msg = f'{time_key} must equal {pick_key} * dt_sec'
         raise ValueError(msg)
 

--- a/packages/seisai-engine/src/seisai_engine/pipelines/fbpick/physics/config.py
+++ b/packages/seisai-engine/src/seisai_engine/pipelines/fbpick/physics/config.py
@@ -241,6 +241,9 @@ class PhysicalRuntimeDiagnosticsCfg:
 @dataclass(frozen=True)
 class PhysicalRuntimeCfg:
     fit_policy: str = 'full'
+    trend_result_mode: str = 'eager'
+    geometry_invalid_fallback: str = 'existing_trend'
+    group_invalid_fallback: str = 'existing_trend'
     diagnostics_enabled: bool = True
     write_runtime_summary: bool = True
     diagnostics: PhysicalRuntimeDiagnosticsCfg = PhysicalRuntimeDiagnosticsCfg()
@@ -694,6 +697,17 @@ def _load_physical_runtime_cfg(cfg: dict[str, Any]) -> PhysicalRuntimeCfg:
     )
     return PhysicalRuntimeCfg(
         fit_policy=optional_str(cfg, 'fit_policy', 'full'),
+        trend_result_mode=optional_str(cfg, 'trend_result_mode', 'eager'),
+        geometry_invalid_fallback=optional_str(
+            cfg,
+            'geometry_invalid_fallback',
+            'existing_trend',
+        ),
+        group_invalid_fallback=optional_str(
+            cfg,
+            'group_invalid_fallback',
+            'existing_trend',
+        ),
         diagnostics_enabled=bool(diagnostics.enabled),
         write_runtime_summary=bool(diagnostics.save_json),
         diagnostics=diagnostics,
@@ -848,6 +862,24 @@ def _validate_physical_runtime_cfg(cfg: PhysicalRuntimeCfg) -> None:
         msg = (
             "physical_runtime.fit_policy must be 'full' or 'anchor_source_xy', "
             f'got {cfg.fit_policy!r}'
+        )
+        raise ValueError(msg)
+    if cfg.trend_result_mode not in {'eager', 'lazy', 'disabled'}:
+        msg = (
+            "physical_runtime.trend_result_mode must be 'eager', 'lazy', "
+            f"or 'disabled', got {cfg.trend_result_mode!r}"
+        )
+        raise ValueError(msg)
+    if cfg.geometry_invalid_fallback not in {'existing_trend', 'robust'}:
+        msg = (
+            'physical_runtime.geometry_invalid_fallback must be '
+            f"'existing_trend' or 'robust', got {cfg.geometry_invalid_fallback!r}"
+        )
+        raise ValueError(msg)
+    if cfg.group_invalid_fallback not in {'existing_trend', 'robust'}:
+        msg = (
+            'physical_runtime.group_invalid_fallback must be '
+            f"'existing_trend' or 'robust', got {cfg.group_invalid_fallback!r}"
         )
         raise ValueError(msg)
     anchor = cfg.anchor_selection

--- a/packages/seisai-engine/src/seisai_engine/pipelines/fbpick/physics/physical_center.py
+++ b/packages/seisai-engine/src/seisai_engine/pipelines/fbpick/physics/physical_center.py
@@ -134,8 +134,19 @@ __all__ = [
     'PHYSICAL_RUNTIME_FIT_SOURCE_LABELS',
     'PHYSICAL_RUNTIME_FIT_SOURCE_NEAREST_ANCHOR_REUSE',
     'PhysicalCenterResult',
+    'PhysicalCenterFallbackPreflight',
     'build_geometry_two_piece_physical_center',
+    'preflight_geometry_two_piece_fallback',
 ]
+
+
+@dataclass(frozen=True)
+class PhysicalCenterFallbackPreflight:
+    status: str | None
+    reason: str | None
+    fallback_mode: str | None
+    geometry_loaded: bool
+    groups: int | None
 
 
 @dataclass(frozen=True)
@@ -524,17 +535,130 @@ def _assign_fallback_all(
     merged: MergeResult,
 ) -> PhysicalCenterResult:
     arrays = _allocate_result_arrays(table)
-    for trace_idx in range(int(table.n_traces)):
-        _assign_fallback(
-            arrays,
-            trace_idx,
-            failure_reason=failure_reason,
-            runtime_fit_source=PHYSICAL_RUNTIME_FIT_SOURCE_FALLBACK_EXISTING_TREND,
-            table=table,
-            feasible=feasible,
-            trend=trend,
-            merged=merged,
-        )
+    n = int(table.n_traces)
+    n_samples = int(table.n_samples_orig)
+    dt = float(table.dt_scalar_sec)
+
+    trend_i = _as_vector(
+        'trend.trend_center_i',
+        trend.trend_center_i,
+        n_traces=n,
+        dtype=np.int64,
+    )
+    trend_t = _as_vector(
+        'trend.trend_center_sec',
+        trend.trend_center_sec,
+        n_traces=n,
+        dtype=np.float32,
+    )
+    robust_i = _as_vector(
+        'merged.robust_pick_i',
+        merged.robust_pick_i,
+        n_traces=n,
+        dtype=np.int64,
+    )
+    lo_sec = _as_vector(
+        'feasible.feasible_lo_sec',
+        feasible.feasible_lo_sec,
+        n_traces=n,
+        dtype=np.float32,
+    )
+    hi_sec = _as_vector(
+        'feasible.feasible_hi_sec',
+        feasible.feasible_hi_sec,
+        n_traces=n,
+        dtype=np.float32,
+    )
+
+    center_i = np.clip(robust_i, 0, n_samples - 1).astype(np.int32)
+    status = np.full(
+        (n,),
+        np.uint8(PHYSICAL_MODEL_STATUS_FALLBACK_ROBUST),
+        dtype=np.uint8,
+    )
+    fit_source = np.full(
+        (n,),
+        np.uint8(PHYSICAL_RUNTIME_FIT_SOURCE_FALLBACK_ROBUST),
+        dtype=np.uint8,
+    )
+
+    valid_band = np.isfinite(lo_sec) & np.isfinite(hi_sec) & (lo_sec <= hi_sec)
+    if bool(np.any(valid_band)):
+        lo_i = np.zeros((n,), dtype=np.int64)
+        hi_i = np.full((n,), n_samples - 1, dtype=np.int64)
+        with np.errstate(invalid='ignore'):
+            lo_i[valid_band] = np.clip(
+                np.ceil(lo_sec[valid_band] / np.float32(dt)),
+                0,
+                n_samples - 1,
+            ).astype(np.int64)
+            hi_i[valid_band] = np.clip(
+                np.floor(hi_sec[valid_band] / np.float32(dt)),
+                0,
+                n_samples - 1,
+            ).astype(np.int64)
+        valid_band &= lo_i <= hi_i
+        if bool(np.any(valid_band)):
+            clipped_i = np.clip(robust_i, lo_i, hi_i).astype(np.int32)
+            center_i[valid_band] = clipped_i[valid_band]
+            status[valid_band] = np.uint8(
+                PHYSICAL_MODEL_STATUS_FALLBACK_FEASIBLE_CLIP
+            )
+            fit_source[valid_band] = np.uint8(
+                PHYSICAL_RUNTIME_FIT_SOURCE_FALLBACK_EXISTING_TREND
+            )
+
+    valid_trend = (
+        (trend_i >= 0)
+        & (trend_i < n_samples)
+        & np.isfinite(trend_t)
+    )
+    center_i[valid_trend] = trend_i[valid_trend].astype(np.int32)
+    status[valid_trend] = np.uint8(
+        PHYSICAL_MODEL_STATUS_FALLBACK_EXISTING_TREND
+    )
+    fit_source[valid_trend] = np.uint8(
+        PHYSICAL_RUNTIME_FIT_SOURCE_FALLBACK_EXISTING_TREND
+    )
+
+    arrays['physical_center_i'][:] = center_i
+    arrays['physical_center_t_sec'][:] = (
+        center_i.astype(np.float64) * dt
+    )
+    arrays['physical_model_status'][:] = status
+    arrays['physical_model_failure_reason'][:] = np.uint8(failure_reason)
+    arrays['physical_runtime_fit_source'][:] = fit_source
+    return _finalize_result(arrays)
+
+
+def _assign_robust_fallback_all(
+    *,
+    failure_reason: int,
+    table: CoarsePickTable,
+    merged: MergeResult,
+) -> PhysicalCenterResult:
+    arrays = _allocate_result_arrays(table)
+    n = int(table.n_traces)
+    n_samples = int(table.n_samples_orig)
+    dt = float(table.dt_scalar_sec)
+    robust_i = _as_vector(
+        'merged.robust_pick_i',
+        merged.robust_pick_i,
+        n_traces=n,
+        dtype=np.int64,
+    )
+    center_i = np.clip(robust_i, 0, n_samples - 1).astype(np.int32)
+    arrays['physical_center_i'][:] = center_i
+    arrays['physical_center_t_sec'][:] = (
+        center_i.astype(np.float64) * dt
+    )
+    arrays['physical_model_status'][:] = np.uint8(
+        PHYSICAL_MODEL_STATUS_FALLBACK_ROBUST
+    )
+    arrays['physical_model_failure_reason'][:] = np.uint8(failure_reason)
+    arrays['physical_runtime_fit_source'][:] = np.uint8(
+        PHYSICAL_RUNTIME_FIT_SOURCE_FALLBACK_ROBUST
+    )
     return _finalize_result(arrays)
 
 
@@ -567,6 +691,84 @@ def _build_disabled_result(
         PHYSICAL_RUNTIME_FIT_SOURCE_FALLBACK_EXISTING_TREND
     )
     return _finalize_result(arrays)
+
+
+def _assign_configured_fallback_all(
+    *,
+    fallback_mode: str,
+    failure_reason: int,
+    table: CoarsePickTable,
+    feasible: FeasibleBandResult,
+    trend: TrendResult,
+    merged: MergeResult,
+) -> PhysicalCenterResult:
+    if str(fallback_mode) == 'robust':
+        return _assign_robust_fallback_all(
+            failure_reason=failure_reason,
+            table=table,
+            merged=merged,
+        )
+    return _assign_fallback_all(
+        failure_reason=failure_reason,
+        table=table,
+        feasible=feasible,
+        trend=trend,
+        merged=merged,
+    )
+
+
+def _emit_fallback_all_and_done(
+    *,
+    status: str,
+    reason: str,
+    fallback_mode: str,
+    failure_reason: int,
+    table: CoarsePickTable,
+    feasible: FeasibleBandResult,
+    trend: TrendResult,
+    merged: MergeResult,
+    reporter: object,
+    context: Mapping[str, object],
+    runtime_diagnostics: PhysicalRuntimeDiagnostics | None,
+) -> PhysicalCenterResult:
+    n = int(table.n_traces)
+    reporter.emit(
+        'physical-center.stage_start',
+        **context,
+        stage='fallback_assign_all',
+        reason=reason,
+        fallback=fallback_mode,
+    )
+    stage_start = time.perf_counter()
+    with (
+        runtime_diagnostics.time_block('fallback_sec')
+        if runtime_diagnostics is not None
+        else nullcontext()
+    ):
+        result = _assign_configured_fallback_all(
+            fallback_mode=fallback_mode,
+            failure_reason=failure_reason,
+            table=table,
+            feasible=feasible,
+            trend=trend,
+            merged=merged,
+        )
+    reporter.emit(
+        'physical-center.stage_done',
+        **context,
+        stage='fallback_assign_all',
+        reason=reason,
+        fallback=fallback_mode,
+        elapsed=time.perf_counter() - stage_start,
+        n_traces=n,
+    )
+    reporter.emit(
+        'physical-center.done',
+        **context,
+        status=status,
+        n_traces=n,
+    )
+    return result
 
 
 def _apply_anchor_selection_diagnostics(
@@ -3361,6 +3563,78 @@ def _load_source_group_geometry_from_npz(
     )
 
 
+def preflight_geometry_two_piece_fallback(
+    *,
+    coarse_npz: Mapping[str, np.ndarray],
+    table: CoarsePickTable,
+    cfg: PhysicsLiteConfig,
+) -> PhysicalCenterFallbackPreflight:
+    n = int(table.n_traces)
+    use_geometry_offset = bool(cfg.physical_trend.use_geometry_offset)
+    try:
+        geometry = load_coarse_geometry_from_npz(coarse_npz, n_traces=n)
+    except (KeyError, TypeError, ValueError):
+        geometry = None
+
+    if use_geometry_offset and geometry is None:
+        return PhysicalCenterFallbackPreflight(
+            status='geometry_invalid',
+            reason='geometry_invalid',
+            fallback_mode=str(cfg.physical_runtime.geometry_invalid_fallback),
+            geometry_loaded=False,
+            groups=None,
+        )
+
+    source_grouping_invalid = False
+    groups: tuple[SourceGroup, ...] = ()
+    source_group_geometry = geometry
+    if source_group_geometry is None and not use_geometry_offset:
+        source_group_geometry = _load_source_group_geometry_from_npz(
+            coarse_npz,
+            n_traces=n,
+        )
+    if source_group_geometry is not None:
+        coord_group_tol_m = float(cfg.physical_trend.coord_group_tol_m)
+        source_xy_degenerate = is_source_xy_degenerate(
+            source_group_geometry,
+            table=table,
+            coord_group_tol_m=coord_group_tol_m,
+        )
+        if source_xy_degenerate and use_geometry_offset:
+            source_grouping_invalid = True
+        if not source_xy_degenerate:
+            groups = build_source_groups(
+                source_group_geometry,
+                coord_group_tol_m=coord_group_tol_m,
+            )
+    if len(groups) == 0 and not use_geometry_offset:
+        groups = _build_table_source_groups(table, n_traces=n)
+
+    if source_grouping_invalid:
+        return PhysicalCenterFallbackPreflight(
+            status='geometry_invalid',
+            reason='source_xy_degenerate',
+            fallback_mode=str(cfg.physical_runtime.geometry_invalid_fallback),
+            geometry_loaded=geometry is not None,
+            groups=len(groups),
+        )
+    if len(groups) == 0:
+        return PhysicalCenterFallbackPreflight(
+            status='geometry_invalid',
+            reason='source_group_empty',
+            fallback_mode=str(cfg.physical_runtime.group_invalid_fallback),
+            geometry_loaded=geometry is not None,
+            groups=0,
+        )
+    return PhysicalCenterFallbackPreflight(
+        status=None,
+        reason=None,
+        fallback_mode=None,
+        geometry_loaded=geometry is not None,
+        groups=len(groups),
+    )
+
+
 def build_geometry_two_piece_physical_center(
     *,
     coarse_npz: Mapping[str, np.ndarray],
@@ -3447,13 +3721,14 @@ def build_geometry_two_piece_physical_center(
     )
 
     if not bool(cfg.physical_trend.enabled):
+        result = _build_disabled_result(table, trend)
         reporter.emit(
             'physical-center.done',
             **context,
             status='disabled',
             n_traces=n,
         )
-        return _build_disabled_result(table, trend)
+        return result
 
     reporter.emit('physical-center.stage_start', **context, stage='geometry_load')
     stage_start = time.perf_counter()
@@ -3476,18 +3751,18 @@ def build_geometry_two_piece_physical_center(
 
     use_geometry_offset = bool(cfg.physical_trend.use_geometry_offset)
     if use_geometry_offset and geometry is None:
-        reporter.emit(
-            'physical-center.done',
-            **context,
+        return _emit_fallback_all_and_done(
             status='geometry_invalid',
-            n_traces=n,
-        )
-        return _assign_fallback_all(
+            reason='geometry_invalid',
+            fallback_mode=str(cfg.physical_runtime.geometry_invalid_fallback),
             failure_reason=PHYSICAL_MODEL_FAILURE_GEOMETRY_INVALID,
             table=table,
             feasible=feasible,
             trend=trend,
             merged=merged,
+            reporter=reporter,
+            context=context,
+            runtime_diagnostics=runtime_diagnostics,
         )
 
     segment_by_offset_sign = bool(cfg.physical_trend.segment_by_offset_sign)
@@ -3534,6 +3809,7 @@ def build_geometry_two_piece_physical_center(
         if runtime_diagnostics is not None
         else nullcontext()
     ):
+        source_grouping_invalid = False
         source_groups_from_geometry = False
         groups: tuple[SourceGroup, ...] = ()
         source_group_geometry = geometry
@@ -3550,19 +3826,7 @@ def build_geometry_two_piece_physical_center(
                 coord_group_tol_m=coord_group_tol_m,
             )
             if source_xy_degenerate and use_geometry_offset:
-                reporter.emit(
-                    'physical-center.done',
-                    **context,
-                    status='geometry_invalid',
-                    n_traces=n,
-                )
-                return _assign_fallback_all(
-                    failure_reason=PHYSICAL_MODEL_FAILURE_GEOMETRY_INVALID,
-                    table=table,
-                    feasible=feasible,
-                    trend=trend,
-                    merged=merged,
-                )
+                source_grouping_invalid = True
             if not source_xy_degenerate:
                 groups = build_source_groups(
                     source_group_geometry,
@@ -3579,19 +3843,34 @@ def build_geometry_two_piece_physical_center(
         groups=len(groups),
     )
 
-    if len(groups) == 0:
-        reporter.emit(
-            'physical-center.done',
-            **context,
+    if source_grouping_invalid:
+        return _emit_fallback_all_and_done(
             status='geometry_invalid',
-            n_traces=n,
-        )
-        return _assign_fallback_all(
+            reason='source_xy_degenerate',
+            fallback_mode=str(cfg.physical_runtime.geometry_invalid_fallback),
             failure_reason=PHYSICAL_MODEL_FAILURE_GEOMETRY_INVALID,
             table=table,
             feasible=feasible,
             trend=trend,
             merged=merged,
+            reporter=reporter,
+            context=context,
+            runtime_diagnostics=runtime_diagnostics,
+        )
+
+    if len(groups) == 0:
+        return _emit_fallback_all_and_done(
+            status='geometry_invalid',
+            reason='source_group_empty',
+            fallback_mode=str(cfg.physical_runtime.group_invalid_fallback),
+            failure_reason=PHYSICAL_MODEL_FAILURE_GEOMETRY_INVALID,
+            table=table,
+            feasible=feasible,
+            trend=trend,
+            merged=merged,
+            reporter=reporter,
+            context=context,
+            runtime_diagnostics=runtime_diagnostics,
         )
 
     if runtime_diagnostics is not None:

--- a/packages/seisai-engine/src/seisai_engine/pipelines/fbpick/physics/run.py
+++ b/packages/seisai-engine/src/seisai_engine/pipelines/fbpick/physics/run.py
@@ -8,16 +8,20 @@ from typing import Any
 import numpy as np
 
 from seisai_engine.pipelines.fbpick.common import (
+    ROBUST_SOURCE_COARSE_OBSERVED,
     build_lineage_payload,
     load_coarse_npz,
     save_robust_npz,
 )
 
-from .confidence import compute_confidence_terms
+from .confidence import ConfidenceResult, compute_confidence_terms
 from .config import load_physics_lite_config, physics_lite_config_to_dict
 from .feasible import compute_feasible_band
-from .merge import apply_keep_reject_fill
-from .physical_center import build_geometry_two_piece_physical_center
+from .merge import MergeResult, apply_keep_reject_fill
+from .physical_center import (
+    build_geometry_two_piece_physical_center,
+    preflight_geometry_two_piece_fallback,
+)
 from .pick_table import normalize_coarse_pick_table
 from .progress import build_progress_reporter
 from .runtime_diagnostics import (
@@ -26,7 +30,7 @@ from .runtime_diagnostics import (
     runtime_summary_from_npz_fields,
     write_physics_runtime_summary,
 )
-from .trend import build_trend_result
+from .trend import TrendResult, build_trend_result
 
 __all__ = [
     'build_robust_payload_from_coarse',
@@ -54,6 +58,109 @@ def _status_counts_line(values: np.ndarray) -> str:
         f'{int(status)}:{int(count)}'
         for status, count in zip(unique.tolist(), counts.tolist(), strict=True)
     )
+
+
+def _build_unmaterialized_trend(table) -> TrendResult:
+    n = int(table.n_traces)
+    return TrendResult(
+        seed_mask=np.zeros((n,), dtype=np.bool_),
+        seed_threshold=np.float32(np.nan),
+        local_center_sec=np.full((n,), np.nan, dtype=np.float32),
+        local_center_valid=np.zeros((n,), dtype=np.bool_),
+        local_discard_mask=np.zeros((n,), dtype=np.bool_),
+        global_center_sec=np.full((n,), np.nan, dtype=np.float32),
+        trend_center_sec=np.full((n,), np.nan, dtype=np.float32),
+        trend_center_i=np.full((n,), -1, dtype=np.int32),
+        filled_mask=np.zeros((n,), dtype=np.bool_),
+    )
+
+
+def _build_coarse_observed_confidence(table) -> ConfidenceResult:
+    n = int(table.n_traces)
+    conf_prob1 = np.clip(
+        np.asarray(table.coarse_pmax, dtype=np.float32),
+        0.0,
+        1.0,
+    ).astype(np.float32, copy=False)
+    conf_trend1 = np.ones((n,), dtype=np.float32)
+    conf_rs1 = np.ones((n,), dtype=np.float32)
+    return ConfidenceResult(
+        conf_prob1=conf_prob1,
+        conf_trend1=conf_trend1,
+        conf_rs1=conf_rs1,
+        total_score=conf_prob1.copy(),
+    )
+
+
+def _build_coarse_observed_merge(table, confidence: ConfidenceResult) -> MergeResult:
+    n = int(table.n_traces)
+    return MergeResult(
+        keep_mask=np.ones((n,), dtype=np.bool_),
+        reject_mask=np.zeros((n,), dtype=np.bool_),
+        score_threshold=np.float32(0.0),
+        robust_pick_i=np.asarray(table.coarse_pick_i, dtype=np.int32).copy(),
+        robust_pick_t_sec=np.asarray(table.coarse_pick_t_sec, dtype=np.float32).copy(),
+        robust_conf=np.asarray(confidence.total_score, dtype=np.float32).copy(),
+        robust_source=np.full(
+            (n,),
+            np.uint8(ROBUST_SOURCE_COARSE_OBSERVED),
+            dtype=np.uint8,
+        ),
+        used_theoretical_mask=np.zeros((n,), dtype=np.bool_),
+        reason_mask=np.zeros((n,), dtype=np.uint8),
+    )
+
+
+def _should_use_lazy_robust_fallback_path(
+    coarse_npz: Mapping[str, np.ndarray],
+    *,
+    table,
+    typed_cfg,
+    reporter: Any,
+    progress_fields: Mapping[str, object],
+) -> bool:
+    runtime = typed_cfg.physical_runtime
+    if str(runtime.trend_result_mode) not in {'lazy', 'disabled'}:
+        return False
+    if not bool(typed_cfg.physical_trend.enabled):
+        return False
+
+    reporter.emit(
+        'physics.stage_start',
+        **progress_fields,
+        stage='geometry_preflight',
+    )
+    stage_start = perf_counter()
+    preflight = preflight_geometry_two_piece_fallback(
+        coarse_npz=coarse_npz,
+        table=table,
+        cfg=typed_cfg,
+    )
+    use_lazy_robust = (
+        preflight.status is not None and str(preflight.fallback_mode) == 'robust'
+    )
+    reporter.emit(
+        'physics.stage_done',
+        **progress_fields,
+        stage='geometry_preflight',
+        elapsed=perf_counter() - stage_start,
+        geometry_loaded=preflight.geometry_loaded,
+        groups=preflight.groups,
+        fallback_detected=preflight.status is not None,
+        fallback_reason=preflight.reason,
+        fallback=preflight.fallback_mode,
+        lazy_robust_fallback=use_lazy_robust,
+    )
+    return use_lazy_robust
+
+
+def _raise_if_trend_materialization_disabled(typed_cfg) -> None:
+    if str(typed_cfg.physical_runtime.trend_result_mode) == 'disabled':
+        msg = (
+            "physical_runtime.trend_result_mode='disabled' cannot materialize "
+            'trend_result for this input'
+        )
+        raise ValueError(msg)
 
 
 def build_robust_payload_from_coarse(
@@ -104,33 +211,57 @@ def build_robust_payload_from_coarse(
             stage='feasible_band',
             elapsed=perf_counter() - stage_start,
         )
-        reporter.emit('physics.stage_start', **progress_fields, stage='trend_result')
-        stage_start = perf_counter()
-        trend = build_trend_result(table, feasible, typed_cfg)
-        reporter.emit(
-            'physics.stage_done',
-            **progress_fields,
-            stage='trend_result',
-            elapsed=perf_counter() - stage_start,
-        )
-        reporter.emit('physics.stage_start', **progress_fields, stage='confidence')
-        stage_start = perf_counter()
-        confidence = compute_confidence_terms(table, feasible, trend, typed_cfg)
-        reporter.emit(
-            'physics.stage_done',
-            **progress_fields,
-            stage='confidence',
-            elapsed=perf_counter() - stage_start,
-        )
-        reporter.emit('physics.stage_start', **progress_fields, stage='merge')
-        stage_start = perf_counter()
-        merged = apply_keep_reject_fill(table, feasible, trend, confidence, typed_cfg)
-        reporter.emit(
-            'physics.stage_done',
-            **progress_fields,
-            stage='merge',
-            elapsed=perf_counter() - stage_start,
-        )
+        trend_materialized = True
+        if _should_use_lazy_robust_fallback_path(
+            coarse_npz,
+            table=table,
+            typed_cfg=typed_cfg,
+            reporter=reporter,
+            progress_fields=progress_fields,
+        ):
+            trend_materialized = False
+            trend = _build_unmaterialized_trend(table)
+            confidence = _build_coarse_observed_confidence(table)
+            merged = _build_coarse_observed_merge(table, confidence)
+        else:
+            _raise_if_trend_materialization_disabled(typed_cfg)
+            reporter.emit(
+                'physics.stage_start',
+                **progress_fields,
+                stage='trend_result',
+            )
+            stage_start = perf_counter()
+            trend = build_trend_result(table, feasible, typed_cfg)
+            reporter.emit(
+                'physics.stage_done',
+                **progress_fields,
+                stage='trend_result',
+                elapsed=perf_counter() - stage_start,
+            )
+            reporter.emit('physics.stage_start', **progress_fields, stage='confidence')
+            stage_start = perf_counter()
+            confidence = compute_confidence_terms(table, feasible, trend, typed_cfg)
+            reporter.emit(
+                'physics.stage_done',
+                **progress_fields,
+                stage='confidence',
+                elapsed=perf_counter() - stage_start,
+            )
+            reporter.emit('physics.stage_start', **progress_fields, stage='merge')
+            stage_start = perf_counter()
+            merged = apply_keep_reject_fill(
+                table,
+                feasible,
+                trend,
+                confidence,
+                typed_cfg,
+            )
+            reporter.emit(
+                'physics.stage_done',
+                **progress_fields,
+                stage='merge',
+                elapsed=perf_counter() - stage_start,
+            )
         reporter.emit('physics.stage_start', **progress_fields, stage='physical_center')
         stage_start = perf_counter()
         physical = build_geometry_two_piece_physical_center(
@@ -173,47 +304,69 @@ def build_robust_payload_from_coarse(
                 stage='feasible_band',
                 elapsed=perf_counter() - stage_start,
             )
-            reporter.emit('physics.stage_start', **progress_fields, stage='trend_result')
-            stage_start = perf_counter()
-            with runtime_diagnostics.time_block('trend_result_sec'):
-                trend = build_trend_result(table, feasible, typed_cfg)
-            reporter.emit(
-                'physics.stage_done',
-                **progress_fields,
-                stage='trend_result',
-                elapsed=perf_counter() - stage_start,
-            )
-            reporter.emit('physics.stage_start', **progress_fields, stage='confidence')
-            stage_start = perf_counter()
-            with runtime_diagnostics.time_block('confidence_sec'):
-                confidence = compute_confidence_terms(
-                    table,
-                    feasible,
-                    trend,
-                    typed_cfg,
+            trend_materialized = True
+            if _should_use_lazy_robust_fallback_path(
+                coarse_npz,
+                table=table,
+                typed_cfg=typed_cfg,
+                reporter=reporter,
+                progress_fields=progress_fields,
+            ):
+                trend_materialized = False
+                trend = _build_unmaterialized_trend(table)
+                confidence = _build_coarse_observed_confidence(table)
+                merged = _build_coarse_observed_merge(table, confidence)
+            else:
+                _raise_if_trend_materialization_disabled(typed_cfg)
+                reporter.emit(
+                    'physics.stage_start',
+                    **progress_fields,
+                    stage='trend_result',
                 )
-            reporter.emit(
-                'physics.stage_done',
-                **progress_fields,
-                stage='confidence',
-                elapsed=perf_counter() - stage_start,
-            )
-            reporter.emit('physics.stage_start', **progress_fields, stage='merge')
-            stage_start = perf_counter()
-            with runtime_diagnostics.time_block('merge_sec'):
-                merged = apply_keep_reject_fill(
-                    table,
-                    feasible,
-                    trend,
-                    confidence,
-                    typed_cfg,
+                stage_start = perf_counter()
+                with runtime_diagnostics.time_block('trend_result_sec'):
+                    trend = build_trend_result(table, feasible, typed_cfg)
+                reporter.emit(
+                    'physics.stage_done',
+                    **progress_fields,
+                    stage='trend_result',
+                    elapsed=perf_counter() - stage_start,
                 )
-            reporter.emit(
-                'physics.stage_done',
-                **progress_fields,
-                stage='merge',
-                elapsed=perf_counter() - stage_start,
-            )
+                reporter.emit(
+                    'physics.stage_start',
+                    **progress_fields,
+                    stage='confidence',
+                )
+                stage_start = perf_counter()
+                with runtime_diagnostics.time_block('confidence_sec'):
+                    confidence = compute_confidence_terms(
+                        table,
+                        feasible,
+                        trend,
+                        typed_cfg,
+                    )
+                reporter.emit(
+                    'physics.stage_done',
+                    **progress_fields,
+                    stage='confidence',
+                    elapsed=perf_counter() - stage_start,
+                )
+                reporter.emit('physics.stage_start', **progress_fields, stage='merge')
+                stage_start = perf_counter()
+                with runtime_diagnostics.time_block('merge_sec'):
+                    merged = apply_keep_reject_fill(
+                        table,
+                        feasible,
+                        trend,
+                        confidence,
+                        typed_cfg,
+                    )
+                reporter.emit(
+                    'physics.stage_done',
+                    **progress_fields,
+                    stage='merge',
+                    elapsed=perf_counter() - stage_start,
+                )
             reporter.emit('physics.stage_start', **progress_fields, stage='physical_center')
             stage_start = perf_counter()
             with runtime_diagnostics.time_physical_center():
@@ -340,6 +493,10 @@ def build_robust_payload_from_coarse(
         'physical_runtime_fit_source': np.asarray(
             physical.physical_runtime_fit_source,
             dtype=np.uint8,
+        ),
+        'physical_runtime_trend_result_materialized': np.asarray(
+            int(bool(trend_materialized)),
+            dtype=np.int64,
         ),
         'lineage': build_lineage_payload(
             canonical_cfg,
@@ -472,6 +629,17 @@ def run_physics_lite(
         if runtime_diagnostics is not None
         else runtime_summary_from_npz_fields(payload)
     )
+    if (
+        summary is not None
+        and 'physical_runtime_trend_result_materialized' in payload
+    ):
+        summary['trend_result_materialized'] = bool(
+            int(
+                np.asarray(
+                    payload['physical_runtime_trend_result_materialized']
+                ).item()
+            )
+        )
     summary_path = None
     if summary is not None and bool(typed_cfg.physical_runtime.write_runtime_summary):
         reporter.emit('physics.stage_start', **progress_fields, stage='runtime_summary')

--- a/packages/seisai-engine/tests/test_fbpick_physical_center.py
+++ b/packages/seisai-engine/tests/test_fbpick_physical_center.py
@@ -27,7 +27,9 @@ from seisai_engine.pipelines.fbpick.physics.physical_center import (
     PHYSICAL_OFFSET_SOURCE_HEADER,
     PHYSICAL_RUNTIME_FIT_SOURCE_ADAPTIVE_REFIT,
     PHYSICAL_RUNTIME_FIT_SOURCE_ANCHOR_FIT,
+    PHYSICAL_RUNTIME_FIT_SOURCE_FALLBACK_EXISTING_TREND,
     PHYSICAL_RUNTIME_FIT_SOURCE_FALLBACK_FULL_FIT_NO_COMPATIBLE_ANCHOR,
+    PHYSICAL_RUNTIME_FIT_SOURCE_FALLBACK_ROBUST,
     PHYSICAL_RUNTIME_FIT_SOURCE_NEAREST_ANCHOR_REUSE,
     build_geometry_two_piece_physical_center,
 )
@@ -2339,6 +2341,182 @@ def test_geometry_missing_falls_back_to_existing_trend_without_crashing() -> Non
     assert np.all(
         result.physical_model_failure_reason
         == np.uint8(PHYSICAL_MODEL_FAILURE_GEOMETRY_INVALID)
+    )
+
+
+def test_assign_fallback_all_vectorized_matches_scalar_fallback() -> None:
+    _coarse_npz, table, feasible, trend, merged = _make_inputs(
+        offsets_m=np.linspace(50.0, 1200.0, 4, dtype=np.float32),
+        with_geometry=False,
+    )
+    trend = replace(
+        trend,
+        trend_center_i=np.asarray([10, -1, -1, table.n_samples_orig], dtype=np.int32),
+        trend_center_sec=np.asarray([0.010, np.nan, np.nan, 1.0], dtype=np.float32),
+    )
+    feasible = replace(
+        feasible,
+        feasible_lo_sec=np.asarray([np.nan, 0.100, np.nan, 0.300], dtype=np.float32),
+        feasible_hi_sec=np.asarray([np.nan, 0.120, np.nan, 0.200], dtype=np.float32),
+    )
+    merged = replace(
+        merged,
+        robust_pick_i=np.asarray(
+            [300, 300, -5, table.n_samples_orig + 20],
+            dtype=np.int32,
+        ),
+    )
+
+    result = physical_center_mod._assign_fallback_all(
+        failure_reason=PHYSICAL_MODEL_FAILURE_GEOMETRY_INVALID,
+        table=table,
+        feasible=feasible,
+        trend=trend,
+        merged=merged,
+    )
+    expected = [
+        physical_center_mod._fallback_center_for_trace(
+            idx,
+            table=table,
+            feasible=feasible,
+            trend=trend,
+            merged=merged,
+        )
+        for idx in range(int(table.n_traces))
+    ]
+
+    np.testing.assert_array_equal(
+        result.physical_center_i,
+        np.asarray(
+            [center_i for center_i, _center_t, _status in expected],
+            dtype=np.int32,
+        ),
+    )
+    np.testing.assert_allclose(
+        result.physical_center_t_sec,
+        np.asarray([center_t for _center_i, center_t, _status in expected]),
+        rtol=0.0,
+        atol=0.0,
+    )
+    np.testing.assert_array_equal(
+        result.physical_model_status,
+        np.asarray(
+            [status for _center_i, _center_t, status in expected],
+            dtype=np.uint8,
+        ),
+    )
+    np.testing.assert_array_equal(
+        result.physical_runtime_fit_source,
+        np.asarray(
+            [
+                PHYSICAL_RUNTIME_FIT_SOURCE_FALLBACK_EXISTING_TREND,
+                PHYSICAL_RUNTIME_FIT_SOURCE_FALLBACK_EXISTING_TREND,
+                PHYSICAL_RUNTIME_FIT_SOURCE_FALLBACK_ROBUST,
+                PHYSICAL_RUNTIME_FIT_SOURCE_FALLBACK_ROBUST,
+            ],
+            dtype=np.uint8,
+        ),
+    )
+
+
+def test_geometry_invalid_fallback_large_trace_count_completes() -> None:
+    n_traces = 100_000
+    coarse_npz, table, feasible, trend, merged = _make_inputs(
+        offsets_m=np.linspace(50.0, 1200.0, n_traces, dtype=np.float32),
+        with_geometry=False,
+    )
+    trend = _with_invalid_trend_centers(trend)
+    feasible = replace(
+        feasible,
+        feasible_lo_sec=np.full((n_traces,), np.nan, dtype=np.float32),
+        feasible_hi_sec=np.full((n_traces,), np.nan, dtype=np.float32),
+    )
+    diagnostics = PhysicalRuntimeDiagnostics()
+
+    result = build_geometry_two_piece_physical_center(
+        coarse_npz=coarse_npz,
+        table=table,
+        feasible=feasible,
+        trend=trend,
+        merged=merged,
+        cfg=_physical_cfg(),
+        runtime_diagnostics=diagnostics,
+    )
+
+    assert diagnostics.n_fit_calls == 0
+    assert result.physical_center_i.shape == (n_traces,)
+    assert np.all(
+        result.physical_model_status
+        == np.uint8(PHYSICAL_MODEL_STATUS_FALLBACK_ROBUST)
+    )
+
+
+def test_geometry_invalid_done_logged_after_fallback_assign_all() -> None:
+    coarse_npz, table, feasible, trend, merged = _make_inputs(
+        offsets_m=np.linspace(50.0, 1200.0, 12, dtype=np.float32),
+        with_geometry=False,
+    )
+    progress = _RecordingProgressReporter()
+
+    build_geometry_two_piece_physical_center(
+        coarse_npz=coarse_npz,
+        table=table,
+        feasible=feasible,
+        trend=trend,
+        merged=merged,
+        cfg=_physical_cfg(),
+        progress=progress,
+    )
+
+    fallback_start = next(
+        idx
+        for idx, (event, fields) in enumerate(progress.events)
+        if event == 'physical-center.stage_start'
+        and fields.get('stage') == 'fallback_assign_all'
+    )
+    fallback_done = next(
+        idx
+        for idx, (event, fields) in enumerate(progress.events)
+        if event == 'physical-center.stage_done'
+        and fields.get('stage') == 'fallback_assign_all'
+    )
+    physical_done = next(
+        idx
+        for idx, (event, fields) in enumerate(progress.events)
+        if event == 'physical-center.done'
+        and fields.get('status') == 'geometry_invalid'
+    )
+
+    assert fallback_start < fallback_done < physical_done
+
+
+def test_geometry_invalid_can_use_robust_fallback() -> None:
+    coarse_npz, table, feasible, trend, merged = _make_inputs(
+        offsets_m=np.linspace(50.0, 1200.0, 12, dtype=np.float32),
+        with_geometry=False,
+    )
+    trend = _with_invalid_trend_centers(trend)
+    merged = replace(merged, robust_pick_i=(table.coarse_pick_i + 3).astype(np.int32))
+
+    result = build_geometry_two_piece_physical_center(
+        coarse_npz=coarse_npz,
+        table=table,
+        feasible=feasible,
+        trend=trend,
+        merged=merged,
+        cfg=_physical_cfg(
+            {'physical_runtime': {'geometry_invalid_fallback': 'robust'}}
+        ),
+    )
+
+    np.testing.assert_array_equal(result.fine_center_i, merged.robust_pick_i)
+    assert np.all(
+        result.physical_model_status
+        == np.uint8(PHYSICAL_MODEL_STATUS_FALLBACK_ROBUST)
+    )
+    assert np.all(
+        result.physical_runtime_fit_source
+        == np.uint8(PHYSICAL_RUNTIME_FIT_SOURCE_FALLBACK_ROBUST)
     )
 
 

--- a/packages/seisai-engine/tests/test_fbpick_physics.py
+++ b/packages/seisai-engine/tests/test_fbpick_physics.py
@@ -44,20 +44,22 @@ from seisai_engine.pipelines.fbpick.physics.physical_center import (
     PHYSICAL_MODEL_FAILURE_GEOMETRY_INVALID,
     PHYSICAL_MODEL_FAILURE_PHYSICAL_DISABLED,
     PHYSICAL_MODEL_STATUS_FALLBACK_EXISTING_TREND,
+    PHYSICAL_MODEL_STATUS_FALLBACK_ROBUST,
     PHYSICAL_MODEL_STATUS_PHYSICAL_DISABLED,
     PHYSICAL_MODEL_STATUS_TWO_PIECE_OK,
     PHYSICAL_OFFSET_SOURCE_HEADER,
+    PHYSICAL_RUNTIME_FIT_SOURCE_FALLBACK_ROBUST,
 )
 from seisai_engine.pipelines.fbpick.physics.pick_table import (
     normalize_coarse_pick_table,
+)
+from seisai_engine.pipelines.fbpick.physics.progress import (
+    ConsoleProgressReporter,
 )
 from seisai_engine.pipelines.fbpick.physics.run import (
     build_robust_payload_from_coarse,
     derive_physics_runtime_summary_path,
     run_physics_lite,
-)
-from seisai_engine.pipelines.fbpick.physics.progress import (
-    ConsoleProgressReporter,
 )
 from seisai_engine.pipelines.fbpick.physics.runtime_diagnostics import (
     PhysicalRuntimeDiagnostics,
@@ -77,6 +79,14 @@ _ANCHOR_OPTIONAL_KEYS = {
     'anchor_source_distance_p90_m',
     'anchor_source_distance_max_m',
 }
+
+
+class _RecordingProgressReporter:
+    def __init__(self) -> None:
+        self.events: list[tuple[str, dict[str, object]]] = []
+
+    def emit(self, event: str, **fields: object) -> None:
+        self.events.append((event, fields))
 
 
 def _make_coarse_payload(
@@ -444,6 +454,9 @@ def test_load_physics_lite_config_defaults_include_physical_trend_blocks() -> No
     assert cfg.two_piece_irls.q_hi == 0.85
     assert cfg.physical_projection.mode == 'model'
     assert cfg.physical_runtime.fit_policy == 'full'
+    assert cfg.physical_runtime.trend_result_mode == 'eager'
+    assert cfg.physical_runtime.geometry_invalid_fallback == 'existing_trend'
+    assert cfg.physical_runtime.group_invalid_fallback == 'existing_trend'
     assert cfg.physical_runtime.diagnostics_enabled is True
     assert cfg.physical_runtime.write_runtime_summary is True
     assert cfg.physical_runtime.diagnostics.enabled is True
@@ -575,10 +588,13 @@ def test_load_physics_lite_config_accepts_two_piece_irls_fit_kind() -> None:
 def test_load_physics_lite_config_accepts_anchor_selection_runtime_block() -> None:
     cfg = load_physics_lite_config(
         {
-            'physical_runtime': {
-                'fit_policy': 'anchor_source_xy',
-                'anchor_selection': {
-                    'enabled': True,
+                'physical_runtime': {
+                    'fit_policy': 'anchor_source_xy',
+                    'trend_result_mode': 'lazy',
+                    'geometry_invalid_fallback': 'robust',
+                    'group_invalid_fallback': 'robust',
+                    'anchor_selection': {
+                        'enabled': True,
                     'mode': 'source_xy_stride',
                     'anchor_stride_source_groups': 3,
                     'anchor_spacing_m': None,
@@ -639,6 +655,9 @@ def test_load_physics_lite_config_accepts_anchor_selection_runtime_block() -> No
     )
 
     assert cfg.physical_runtime.fit_policy == 'anchor_source_xy'
+    assert cfg.physical_runtime.trend_result_mode == 'lazy'
+    assert cfg.physical_runtime.geometry_invalid_fallback == 'robust'
+    assert cfg.physical_runtime.group_invalid_fallback == 'robust'
     assert cfg.physical_runtime.anchor_selection.enabled is True
     assert cfg.physical_runtime.anchor_selection.anchor_stride_source_groups == 3
     assert cfg.physical_runtime.anchor_selection.include_first is False
@@ -756,6 +775,18 @@ def test_physical_center_example_config_enables_physical_trend() -> None:
         (
             {'physical_runtime': {'fit_policy': 'cached'}},
             'physical_runtime.fit_policy',
+        ),
+        (
+            {'physical_runtime': {'trend_result_mode': 'always'}},
+            'physical_runtime.trend_result_mode',
+        ),
+        (
+            {'physical_runtime': {'geometry_invalid_fallback': 'clip'}},
+            'physical_runtime.geometry_invalid_fallback',
+        ),
+        (
+            {'physical_runtime': {'group_invalid_fallback': 'skip'}},
+            'physical_runtime.group_invalid_fallback',
         ),
         (
             {
@@ -1803,6 +1834,202 @@ def test_run_physics_lite_end_to_end_outputs_full_covering_robust_picks(
     assert np.any(robust['robust_source'][18:24] == np.uint8(ROBUST_SOURCE_TREND_FILL))
     assert np.any(robust['reason_mask'][18:24] & np.uint8(REASON_MASK_FILLED_FROM_TREND))
     assert np.all(np.isfinite(robust['robust_pick_t_sec']))
+
+
+def test_run_physics_lite_lazy_geometry_invalid_robust_skips_trend_result(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    n_traces = 12
+    coarse_pick_i = np.arange(80, 80 + n_traces, dtype=np.int32)
+    coarse_path = save_coarse_npz(
+        tmp_path / 'lazy_missing_geometry.coarse.npz',
+        **_make_coarse_payload(
+            coarse_pick_i=coarse_pick_i,
+            coarse_pmax=np.full((n_traces,), 0.95, dtype=np.float32),
+            offsets_m=np.linspace(50.0, 400.0, n_traces, dtype=np.float32),
+        ),
+    )
+    progress = _RecordingProgressReporter()
+
+    def fail_build_trend(*_args, **_kwargs):
+        raise AssertionError('trend_result should not be materialized')
+
+    monkeypatch.setattr(
+        'seisai_engine.pipelines.fbpick.physics.run.build_trend_result',
+        fail_build_trend,
+    )
+
+    out_path = run_physics_lite(
+        coarse_path,
+        cfg={
+            'physical_trend': {
+                'enabled': True,
+                'fit_kind': 'two_piece_irls_autobreak',
+                'use_geometry_offset': True,
+            },
+            'physical_runtime': {
+                'trend_result_mode': 'lazy',
+                'geometry_invalid_fallback': 'robust',
+                'progress': {'enabled': True, 'level': 'stage'},
+            },
+        },
+        source_model_id='coarse-model',
+        iter_id='',
+        repo_root=tmp_path,
+        progress=progress,
+    )
+    robust = load_robust_npz(out_path)
+    summary = json.loads(
+        derive_physics_runtime_summary_path(out_path).read_text(encoding='utf-8')
+    )
+    stage_starts = [
+        fields.get('stage')
+        for event, fields in progress.events
+        if event == 'physics.stage_start'
+    ]
+    fallback_done_idx = next(
+        idx
+        for idx, (event, fields) in enumerate(progress.events)
+        if event == 'physical-center.stage_done'
+        and fields.get('stage') == 'fallback_assign_all'
+    )
+    physical_done_idx = next(
+        idx
+        for idx, (event, fields) in enumerate(progress.events)
+        if event == 'physical-center.done'
+        and fields.get('status') == 'geometry_invalid'
+    )
+
+    assert 'geometry_preflight' in stage_starts
+    assert 'trend_result' not in stage_starts
+    assert fallback_done_idx < physical_done_idx
+    assert (
+        int(np.asarray(robust['physical_runtime_trend_result_materialized']).item())
+        == 0
+    )
+    assert summary['trend_result_materialized'] is False
+    assert int(np.asarray(robust['n_fit_calls']).item()) == 0
+    np.testing.assert_array_equal(
+        robust['trend_center_i'],
+        np.full((n_traces,), -1, dtype=np.int32),
+    )
+    assert np.all(np.isnan(robust['trend_center_t_sec']))
+    np.testing.assert_array_equal(robust['physical_center_i'], coarse_pick_i)
+    np.testing.assert_array_equal(robust['fine_center_i'], coarse_pick_i)
+    assert np.all(
+        robust['physical_model_status']
+        == np.uint8(PHYSICAL_MODEL_STATUS_FALLBACK_ROBUST)
+    )
+    assert np.all(
+        robust['physical_model_failure_reason']
+        == np.uint8(PHYSICAL_MODEL_FAILURE_GEOMETRY_INVALID)
+    )
+    assert np.all(
+        robust['physical_runtime_fit_source']
+        == np.uint8(PHYSICAL_RUNTIME_FIT_SOURCE_FALLBACK_ROBUST)
+    )
+
+
+def test_run_physics_lite_lazy_group_invalid_robust_skips_trend_result(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    n_traces = 12
+    coarse_pick_i = np.arange(90, 90 + n_traces, dtype=np.int32)
+    offsets_m = np.linspace(50.0, 400.0, n_traces, dtype=np.float32)
+    geometry = _make_physical_geometry(offsets_m)
+    geometry['geometry_valid_mask'] = np.zeros((n_traces,), dtype=np.bool_)
+    coarse_path = save_coarse_npz(
+        tmp_path / 'lazy_empty_source_groups.coarse.npz',
+        **_make_coarse_payload(
+            coarse_pick_i=coarse_pick_i,
+            coarse_pmax=np.full((n_traces,), 0.95, dtype=np.float32),
+            offsets_m=offsets_m,
+        ),
+        **geometry,
+    )
+    progress = _RecordingProgressReporter()
+
+    def fail_build_trend(*_args, **_kwargs):
+        raise AssertionError('trend_result should not be materialized')
+
+    monkeypatch.setattr(
+        'seisai_engine.pipelines.fbpick.physics.run.build_trend_result',
+        fail_build_trend,
+    )
+
+    out_path = run_physics_lite(
+        coarse_path,
+        cfg={
+            'physical_trend': {
+                'enabled': True,
+                'fit_kind': 'two_piece_irls_autobreak',
+                'use_geometry_offset': True,
+            },
+            'physical_runtime': {
+                'trend_result_mode': 'lazy',
+                'group_invalid_fallback': 'robust',
+                'progress': {'enabled': True, 'level': 'stage'},
+            },
+        },
+        source_model_id='coarse-model',
+        iter_id='',
+        repo_root=tmp_path,
+        progress=progress,
+    )
+    robust = load_robust_npz(out_path)
+    summary = json.loads(
+        derive_physics_runtime_summary_path(out_path).read_text(encoding='utf-8')
+    )
+    stage_starts = [
+        fields.get('stage')
+        for event, fields in progress.events
+        if event == 'physics.stage_start'
+    ]
+    preflight_done = next(
+        fields
+        for event, fields in progress.events
+        if event == 'physics.stage_done'
+        and fields.get('stage') == 'geometry_preflight'
+    )
+    fallback_done = next(
+        fields
+        for event, fields in progress.events
+        if event == 'physical-center.stage_done'
+        and fields.get('stage') == 'fallback_assign_all'
+    )
+
+    assert 'geometry_preflight' in stage_starts
+    assert 'trend_result' not in stage_starts
+    assert preflight_done['geometry_loaded'] is True
+    assert preflight_done['groups'] == 0
+    assert preflight_done['fallback_reason'] == 'source_group_empty'
+    assert preflight_done['fallback'] == 'robust'
+    assert preflight_done['lazy_robust_fallback'] is True
+    assert fallback_done['reason'] == 'source_group_empty'
+    assert fallback_done['fallback'] == 'robust'
+    assert (
+        int(np.asarray(robust['physical_runtime_trend_result_materialized']).item())
+        == 0
+    )
+    assert summary['trend_result_materialized'] is False
+    assert int(np.asarray(robust['n_fit_calls']).item()) == 0
+    np.testing.assert_array_equal(
+        robust['trend_center_i'],
+        np.full((n_traces,), -1, dtype=np.int32),
+    )
+    assert np.all(np.isnan(robust['trend_center_t_sec']))
+    np.testing.assert_array_equal(robust['physical_center_i'], coarse_pick_i)
+    np.testing.assert_array_equal(robust['fine_center_i'], coarse_pick_i)
+    assert np.all(
+        robust['physical_model_status']
+        == np.uint8(PHYSICAL_MODEL_STATUS_FALLBACK_ROBUST)
+    )
+    assert np.all(
+        robust['physical_runtime_fit_source']
+        == np.uint8(PHYSICAL_RUNTIME_FIT_SOURCE_FALLBACK_ROBUST)
+    )
 
 
 def test_run_physics_lite_allows_disabling_runtime_diagnostics(

--- a/packages/seisai-engine/tests/test_proc_arakawa_layout.py
+++ b/packages/seisai-engine/tests/test_proc_arakawa_layout.py
@@ -77,6 +77,7 @@ def test_runtime_speedup_configs_live_in_expected_directory() -> None:
         "B202_side_on_gap_off.yaml",
         "B203_side_off_gap_on.yaml",
         "B204_side_off_gap_off.yaml",
+        "C301_side_gap_context_precompute_control.yaml",
     }
     assert not (CONFIG_DIR / "runtime_speedup").exists()
 

--- a/tests/test_arakawa_runtime_speedup_layout.py
+++ b/tests/test_arakawa_runtime_speedup_layout.py
@@ -35,6 +35,7 @@ def test_runtime_speedup_source_configs_live_only_under_experiments() -> None:
         'B202_side_on_gap_off',
         'B203_side_off_gap_on',
         'B204_side_off_gap_off',
+        'C301_side_gap_context_precompute_control',
     }
     assert not list(LEGACY_CONFIG_DIR.glob('*.yaml'))
 


### PR DESCRIPTION
Closes #138

## Summary
- # Issue: fbpick physics の geometry invalid fallback を高速化し、physical trend 時は trend_result を lazy 化する

## Changed files
- `packages/seisai-engine/src/seisai_engine/pipelines/fbpick/common/io.py`
- `packages/seisai-engine/src/seisai_engine/pipelines/fbpick/physics/config.py`
- `packages/seisai-engine/src/seisai_engine/pipelines/fbpick/physics/physical_center.py`
- `packages/seisai-engine/src/seisai_engine/pipelines/fbpick/physics/run.py`
- `packages/seisai-engine/tests/test_fbpick_physical_center.py`
- `packages/seisai-engine/tests/test_fbpick_physics.py`
- `packages/seisai-engine/tests/test_proc_arakawa_layout.py`
- `tests/test_arakawa_runtime_speedup_layout.py`

## Checks
- `.work/codex/checks.log`: 1165 passed, 5 warnings in 91.62s (0:01:31)

## Review
- `.work/codex/review.txt`: accept: yes
- findings: blocker 0, major 0, minor 0
