### PR TITLE
Issue: physical trend実行時はIRLS/RANSACを先に回し、trend_resultはfallback時だけlazy生成する

### DIFF
--- a/packages/seisai-engine/src/seisai_engine/pipelines/fbpick/common/io.py
+++ b/packages/seisai-engine/src/seisai_engine/pipelines/fbpick/common/io.py
@@ -433,6 +433,9 @@ _ROBUST_RUNTIME_DIAGNOSTIC_STRING_KEYS = frozenset(
         'anchor_selection_mode',
         'fit_executor_backend',
         'observation_sampling_method',
+        'physical_runtime_legacy_trend_output',
+        'physical_runtime_trend_result_mode',
+        'physical_runtime_trend_result_reason',
     }
 )
 

--- a/packages/seisai-engine/src/seisai_engine/pipelines/fbpick/physics/config.py
+++ b/packages/seisai-engine/src/seisai_engine/pipelines/fbpick/physics/config.py
@@ -242,6 +242,7 @@ class PhysicalRuntimeDiagnosticsCfg:
 class PhysicalRuntimeCfg:
     fit_policy: str = 'full'
     trend_result_mode: str = 'eager'
+    legacy_trend_output: str = 'auto'
     geometry_invalid_fallback: str = 'existing_trend'
     group_invalid_fallback: str = 'existing_trend'
     diagnostics_enabled: bool = True
@@ -698,6 +699,7 @@ def _load_physical_runtime_cfg(cfg: dict[str, Any]) -> PhysicalRuntimeCfg:
     return PhysicalRuntimeCfg(
         fit_policy=optional_str(cfg, 'fit_policy', 'full'),
         trend_result_mode=optional_str(cfg, 'trend_result_mode', 'eager'),
+        legacy_trend_output=optional_str(cfg, 'legacy_trend_output', 'auto'),
         geometry_invalid_fallback=optional_str(
             cfg,
             'geometry_invalid_fallback',
@@ -870,6 +872,12 @@ def _validate_physical_runtime_cfg(cfg: PhysicalRuntimeCfg) -> None:
             f"or 'disabled', got {cfg.trend_result_mode!r}"
         )
         raise ValueError(msg)
+    if cfg.legacy_trend_output not in {'auto', 'always', 'omit'}:
+        msg = (
+            "physical_runtime.legacy_trend_output must be 'auto', 'always', "
+            f"or 'omit', got {cfg.legacy_trend_output!r}"
+        )
+        raise ValueError(msg)
     if cfg.geometry_invalid_fallback not in {'existing_trend', 'robust'}:
         msg = (
             'physical_runtime.geometry_invalid_fallback must be '
@@ -880,6 +888,30 @@ def _validate_physical_runtime_cfg(cfg: PhysicalRuntimeCfg) -> None:
         msg = (
             'physical_runtime.group_invalid_fallback must be '
             f"'existing_trend' or 'robust', got {cfg.group_invalid_fallback!r}"
+        )
+        raise ValueError(msg)
+    if (
+        cfg.trend_result_mode == 'disabled'
+        and cfg.geometry_invalid_fallback == 'existing_trend'
+    ):
+        msg = (
+            "physical_runtime.trend_result_mode='disabled' cannot be combined "
+            "with geometry_invalid_fallback='existing_trend'"
+        )
+        raise ValueError(msg)
+    if (
+        cfg.trend_result_mode == 'disabled'
+        and cfg.group_invalid_fallback == 'existing_trend'
+    ):
+        msg = (
+            "physical_runtime.trend_result_mode='disabled' cannot be combined "
+            "with group_invalid_fallback='existing_trend'"
+        )
+        raise ValueError(msg)
+    if cfg.trend_result_mode == 'disabled' and cfg.legacy_trend_output == 'always':
+        msg = (
+            "physical_runtime.trend_result_mode='disabled' cannot be combined "
+            "with legacy_trend_output='always'"
         )
         raise ValueError(msg)
     anchor = cfg.anchor_selection

--- a/packages/seisai-engine/src/seisai_engine/pipelines/fbpick/physics/physical_center.py
+++ b/packages/seisai-engine/src/seisai_engine/pipelines/fbpick/physics/physical_center.py
@@ -382,6 +382,15 @@ def _is_valid_pick_i(value: int, *, n_samples_orig: int) -> bool:
     return 0 <= int(value) < int(n_samples_orig)
 
 
+def _existing_fallback_trend(
+    trend: TrendResult,
+    trend_provider: object | None = None,
+) -> TrendResult:
+    if trend_provider is None:
+        return trend
+    return trend_provider.get(reason='fallback_existing_trend')
+
+
 def _fallback_center_for_trace(
     trace_idx: int,
     *,
@@ -389,10 +398,12 @@ def _fallback_center_for_trace(
     feasible: FeasibleBandResult,
     trend: TrendResult,
     merged: MergeResult,
+    trend_provider: object | None = None,
 ) -> tuple[int, np.float32, int]:
     n_samples = int(table.n_samples_orig)
     dt = float(table.dt_scalar_sec)
     idx = int(trace_idx)
+    trend = _existing_fallback_trend(trend, trend_provider)
 
     trend_i = int(np.asarray(trend.trend_center_i, dtype=np.int64)[idx])
     trend_t = float(np.asarray(trend.trend_center_sec, dtype=np.float32)[idx])
@@ -485,12 +496,14 @@ def _assign_fallback(
     feasible: FeasibleBandResult,
     trend: TrendResult,
     merged: MergeResult,
+    trend_provider: object | None = None,
 ) -> None:
     center_i, center_t, fallback_status = _fallback_center_for_trace(
         trace_idx,
         table=table,
         feasible=feasible,
         trend=trend,
+        trend_provider=trend_provider,
         merged=merged,
     )
     arrays['physical_center_i'][trace_idx] = np.int32(center_i)
@@ -533,7 +546,9 @@ def _assign_fallback_all(
     feasible: FeasibleBandResult,
     trend: TrendResult,
     merged: MergeResult,
+    trend_provider: object | None = None,
 ) -> PhysicalCenterResult:
+    trend = _existing_fallback_trend(trend, trend_provider)
     arrays = _allocate_result_arrays(table)
     n = int(table.n_traces)
     n_samples = int(table.n_samples_orig)
@@ -701,6 +716,7 @@ def _assign_configured_fallback_all(
     feasible: FeasibleBandResult,
     trend: TrendResult,
     merged: MergeResult,
+    trend_provider: object | None = None,
 ) -> PhysicalCenterResult:
     if str(fallback_mode) == 'robust':
         return _assign_robust_fallback_all(
@@ -713,6 +729,7 @@ def _assign_configured_fallback_all(
         table=table,
         feasible=feasible,
         trend=trend,
+        trend_provider=trend_provider,
         merged=merged,
     )
 
@@ -730,6 +747,7 @@ def _emit_fallback_all_and_done(
     reporter: object,
     context: Mapping[str, object],
     runtime_diagnostics: PhysicalRuntimeDiagnostics | None,
+    trend_provider: object | None = None,
 ) -> PhysicalCenterResult:
     n = int(table.n_traces)
     reporter.emit(
@@ -751,6 +769,7 @@ def _emit_fallback_all_and_done(
             table=table,
             feasible=feasible,
             trend=trend,
+            trend_provider=trend_provider,
             merged=merged,
         )
     reporter.emit(
@@ -2087,7 +2106,11 @@ def _run_fit_tasks_with_executor(
     )
     context = dict(progress_context or {})
     total = len(tasks) if progress_total is None else int(progress_total)
-    start_sec = time.perf_counter() if progress_start_sec is None else progress_start_sec
+    start_sec = (
+        time.perf_counter()
+        if progress_start_sec is None
+        else progress_start_sec
+    )
     fit_calls_done = 0
     fit_total_sec = float(progress_fit_total_sec_base)
     executor_cfg = cfg.physical_runtime.fit_executor
@@ -2475,6 +2498,7 @@ def _prepare_trace_plan_assignment(
     table: CoarsePickTable,
     feasible: FeasibleBandResult,
     trend: TrendResult,
+    trend_provider: object | None = None,
     merged: MergeResult,
     cfg: PhysicsLiteConfig,
     observation_plan_cache: _ObservationPlanCache,
@@ -2493,6 +2517,7 @@ def _prepare_trace_plan_assignment(
             table=table,
             feasible=feasible,
             trend=trend,
+            trend_provider=trend_provider,
             merged=merged,
         )
         return None
@@ -2516,6 +2541,7 @@ def _prepare_trace_plan_assignment(
             table=table,
             feasible=feasible,
             trend=trend,
+            trend_provider=trend_provider,
             merged=merged,
         )
         return None
@@ -2535,6 +2561,7 @@ def _prepare_trace_plan_assignment(
             table=table,
             feasible=feasible,
             trend=trend,
+            trend_provider=trend_provider,
             merged=merged,
         )
         return None
@@ -2590,6 +2617,7 @@ def _assign_prepared_model_prediction_batch(
     table: CoarsePickTable,
     feasible: FeasibleBandResult,
     trend: TrendResult,
+    trend_provider: object | None = None,
     merged: MergeResult,
     fit_cache: dict[tuple[int, ...], _FitCacheEntry],
     t0_shift_sec: float | np.ndarray = 0.0,
@@ -2654,6 +2682,7 @@ def _assign_prepared_model_prediction_batch(
             table=table,
             feasible=feasible,
             trend=trend,
+            trend_provider=trend_provider,
             merged=merged,
         )
     return valid, diagnostics
@@ -2703,6 +2732,7 @@ def _assign_fit_context_fallback(
     table: CoarsePickTable,
     feasible: FeasibleBandResult,
     trend: TrendResult,
+    trend_provider: object | None = None,
     merged: MergeResult,
 ) -> None:
     for trace_idx in np.asarray(work_item.trace_indices, dtype=np.int64).tolist():
@@ -2713,6 +2743,7 @@ def _assign_fit_context_fallback(
             table=table,
             feasible=feasible,
             trend=trend,
+            trend_provider=trend_provider,
             merged=merged,
         )
 
@@ -2725,6 +2756,7 @@ def _fit_and_assign_context_work_item(
     table: CoarsePickTable,
     feasible: FeasibleBandResult,
     trend: TrendResult,
+    trend_provider: object | None = None,
     merged: MergeResult,
     cfg: PhysicsLiteConfig,
     strategy: _PhysicalFitStrategy,
@@ -2757,6 +2789,7 @@ def _fit_and_assign_context_work_item(
         table=table,
         feasible=feasible,
         trend=trend,
+        trend_provider=trend_provider,
         merged=merged,
         fit_cache=fit_cache,
         trend_model=trend_model,
@@ -2774,6 +2807,7 @@ def _assign_fit_context_work_item_outcome(
     table: CoarsePickTable,
     feasible: FeasibleBandResult,
     trend: TrendResult,
+    trend_provider: object | None = None,
     merged: MergeResult,
     fit_cache: dict[tuple[int, ...], _FitCacheEntry],
     trend_model: object | None,
@@ -2789,6 +2823,7 @@ def _assign_fit_context_work_item_outcome(
             table=table,
             feasible=feasible,
             trend=trend,
+            trend_provider=trend_provider,
             merged=merged,
         )
         return _FitContextWorkResult(
@@ -2805,6 +2840,7 @@ def _assign_fit_context_work_item_outcome(
             table=table,
             feasible=feasible,
             trend=trend,
+            trend_provider=trend_provider,
             merged=merged,
         )
         return _FitContextWorkResult(
@@ -2836,6 +2872,7 @@ def _assign_fit_context_work_item_outcome(
         table=table,
         feasible=feasible,
         trend=trend,
+        trend_provider=trend_provider,
         merged=merged,
         fit_cache=fit_cache,
         runtime_diagnostics=runtime_diagnostics,
@@ -2867,6 +2904,7 @@ def _prepare_fit_context_assignments_for_trace_indices(
     table: CoarsePickTable,
     feasible: FeasibleBandResult,
     trend: TrendResult,
+    trend_provider: object | None = None,
     merged: MergeResult,
     cfg: PhysicsLiteConfig,
     observation_plan_cache: _ObservationPlanCache,
@@ -2892,6 +2930,7 @@ def _prepare_fit_context_assignments_for_trace_indices(
             table=table,
             feasible=feasible,
             trend=trend,
+            trend_provider=trend_provider,
             merged=merged,
             cfg=cfg,
             observation_plan_cache=observation_plan_cache,
@@ -2913,6 +2952,7 @@ def _fit_and_assign_context_work_items(
     table: CoarsePickTable,
     feasible: FeasibleBandResult,
     trend: TrendResult,
+    trend_provider: object | None = None,
     merged: MergeResult,
     cfg: PhysicsLiteConfig,
     strategy: _PhysicalFitStrategy,
@@ -2932,6 +2972,7 @@ def _fit_and_assign_context_work_items(
             table=table,
             feasible=feasible,
             trend=trend,
+            trend_provider=trend_provider,
             merged=merged,
             cfg=cfg,
             fit_cache=fit_cache,
@@ -2957,6 +2998,7 @@ def _fit_and_assign_context_work_items(
             table=table,
             feasible=feasible,
             trend=trend,
+            trend_provider=trend_provider,
             merged=merged,
             cfg=cfg,
             strategy=strategy,
@@ -3046,6 +3088,7 @@ def _fit_and_assign_context_work_items_parallel(
     table: CoarsePickTable,
     feasible: FeasibleBandResult,
     trend: TrendResult,
+    trend_provider: object | None = None,
     merged: MergeResult,
     cfg: PhysicsLiteConfig,
     fit_cache: dict[tuple[int, ...], _FitCacheEntry],
@@ -3056,7 +3099,11 @@ def _fit_and_assign_context_work_items_parallel(
 ) -> dict[tuple[int, ...], _FitContextWorkResult]:
     reporter = progress if progress is not None else NullProgressReporter()
     context = dict(progress_context or {})
-    fit_start = time.perf_counter() if progress_start_sec is None else progress_start_sec
+    fit_start = (
+        time.perf_counter()
+        if progress_start_sec is None
+        else progress_start_sec
+    )
     total = len(work_items)
     done = 0
     reporter.emit(
@@ -3094,6 +3141,7 @@ def _fit_and_assign_context_work_items_parallel(
             table=table,
             feasible=feasible,
             trend=trend,
+            trend_provider=trend_provider,
             merged=merged,
             fit_cache=fit_cache,
             trend_model=entry.model,
@@ -3166,6 +3214,7 @@ def _fit_and_assign_context_work_items_parallel(
                 table=table,
                 feasible=feasible,
                 trend=trend,
+                trend_provider=trend_provider,
                 merged=merged,
                 fit_cache=fit_cache,
                 trend_model=task_result.trend_model,
@@ -3206,6 +3255,7 @@ def _fallback_no_compatible_anchor(
     table: CoarsePickTable,
     feasible: FeasibleBandResult,
     trend: TrendResult,
+    trend_provider: object | None = None,
     merged: MergeResult,
     cfg: PhysicsLiteConfig,
 ) -> None:
@@ -3227,6 +3277,7 @@ def _fallback_no_compatible_anchor(
         table=table,
         feasible=feasible,
         trend=trend,
+        trend_provider=trend_provider,
         merged=merged,
     )
 
@@ -3643,6 +3694,7 @@ def build_geometry_two_piece_physical_center(
     trend: TrendResult,
     merged: MergeResult,
     cfg: PhysicsLiteConfig,
+    trend_provider: object | None = None,
     runtime_diagnostics: PhysicalRuntimeDiagnostics | None = None,
     progress: object | None = None,
     progress_context: Mapping[str, object] | None = None,
@@ -3759,6 +3811,7 @@ def build_geometry_two_piece_physical_center(
             table=table,
             feasible=feasible,
             trend=trend,
+            trend_provider=trend_provider,
             merged=merged,
             reporter=reporter,
             context=context,
@@ -3852,6 +3905,7 @@ def build_geometry_two_piece_physical_center(
             table=table,
             feasible=feasible,
             trend=trend,
+            trend_provider=trend_provider,
             merged=merged,
             reporter=reporter,
             context=context,
@@ -3867,6 +3921,7 @@ def build_geometry_two_piece_physical_center(
             table=table,
             feasible=feasible,
             trend=trend,
+            trend_provider=trend_provider,
             merged=merged,
             reporter=reporter,
             context=context,
@@ -3876,7 +3931,11 @@ def build_geometry_two_piece_physical_center(
     if runtime_diagnostics is not None:
         runtime_diagnostics.set_source_groups(len(groups))
 
-    reporter.emit('physical-center.stage_start', **context, stage='source_group_ordering')
+    reporter.emit(
+        'physical-center.stage_start',
+        **context,
+        stage='source_group_ordering',
+    )
     stage_start = time.perf_counter()
     with (
         runtime_diagnostics.time_block('source_group_ordering_sec')
@@ -4032,6 +4091,7 @@ def build_geometry_two_piece_physical_center(
                 table=table,
                 feasible=feasible,
                 trend=trend,
+                trend_provider=trend_provider,
                 merged=merged,
                 cfg=cfg,
                 observation_plan_cache=observation_plan_cache,
@@ -4065,6 +4125,7 @@ def build_geometry_two_piece_physical_center(
             table=table,
             feasible=feasible,
             trend=trend,
+            trend_provider=trend_provider,
             merged=merged,
             cfg=cfg,
             strategy=strategy,
@@ -4164,6 +4225,7 @@ def build_geometry_two_piece_physical_center(
                         table=table,
                         feasible=feasible,
                         trend=trend,
+                        trend_provider=trend_provider,
                         merged=merged,
                     )
                     continue
@@ -4228,6 +4290,7 @@ def build_geometry_two_piece_physical_center(
                         table=table,
                         feasible=feasible,
                         trend=trend,
+                        trend_provider=trend_provider,
                         merged=merged,
                         cfg=cfg,
                     )
@@ -4247,6 +4310,7 @@ def build_geometry_two_piece_physical_center(
                         table=table,
                         feasible=feasible,
                         trend=trend,
+                        trend_provider=trend_provider,
                         merged=merged,
                         cfg=cfg,
                         observation_plan_cache=observation_plan_cache,
@@ -4277,6 +4341,7 @@ def build_geometry_two_piece_physical_center(
                     table=table,
                     feasible=feasible,
                     trend=trend,
+                    trend_provider=trend_provider,
                     merged=merged,
                     cfg=cfg,
                     strategy=strategy,
@@ -4322,6 +4387,7 @@ def build_geometry_two_piece_physical_center(
                             table=table,
                             feasible=feasible,
                             trend=trend,
+                            trend_provider=trend_provider,
                             merged=merged,
                         )
                 continue
@@ -4388,6 +4454,7 @@ def build_geometry_two_piece_physical_center(
                         table=table,
                         feasible=feasible,
                         trend=trend,
+                        trend_provider=trend_provider,
                         merged=merged,
                         cfg=cfg,
                         observation_plan_cache=observation_plan_cache,
@@ -4416,6 +4483,7 @@ def build_geometry_two_piece_physical_center(
                     table=table,
                     feasible=feasible,
                     trend=trend,
+                    trend_provider=trend_provider,
                     merged=merged,
                     cfg=cfg,
                     strategy=strategy,
@@ -4465,6 +4533,7 @@ def build_geometry_two_piece_physical_center(
                             table=table,
                             feasible=feasible,
                             trend=trend,
+                            trend_provider=trend_provider,
                             merged=merged,
                         )
                     continue
@@ -4508,6 +4577,7 @@ def build_geometry_two_piece_physical_center(
                         table=table,
                         feasible=feasible,
                         trend=trend,
+                        trend_provider=trend_provider,
                         merged=merged,
                     )
                 if use_shift:
@@ -4588,6 +4658,7 @@ def build_geometry_two_piece_physical_center(
             table=table,
             feasible=feasible,
             trend=trend,
+            trend_provider=trend_provider,
             merged=merged,
             cfg=cfg,
             observation_plan_cache=observation_plan_cache,
@@ -4626,6 +4697,7 @@ def build_geometry_two_piece_physical_center(
         table=table,
         feasible=feasible,
         trend=trend,
+        trend_provider=trend_provider,
         merged=merged,
         cfg=cfg,
         strategy=strategy,

--- a/packages/seisai-engine/src/seisai_engine/pipelines/fbpick/physics/run.py
+++ b/packages/seisai-engine/src/seisai_engine/pipelines/fbpick/physics/run.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from collections.abc import Mapping
+from collections.abc import Callable, Mapping
 from pathlib import Path
 from time import perf_counter
 from typing import Any
@@ -60,6 +60,52 @@ def _status_counts_line(values: np.ndarray) -> str:
     )
 
 
+def _payload_scalar(payload: Mapping[str, np.ndarray], key: str) -> object | None:
+    if key not in payload:
+        return None
+    return np.asarray(payload[key]).item()
+
+
+def _add_trend_runtime_summary_fields(
+    summary: dict[str, object],
+    payload: Mapping[str, np.ndarray],
+) -> None:
+    materialized = _payload_scalar(
+        payload,
+        'physical_runtime_trend_result_materialized',
+    )
+    computed = _payload_scalar(payload, 'physical_runtime_trend_result_computed')
+    elapsed = _payload_scalar(
+        payload,
+        'physical_runtime_trend_result_elapsed_sec',
+    )
+    started_before = _payload_scalar(
+        payload,
+        'physical_runtime_physical_center_started_before_trend_result',
+    )
+    mode = _payload_scalar(payload, 'physical_runtime_trend_result_mode')
+    reason = _payload_scalar(payload, 'physical_runtime_trend_result_reason')
+    legacy_output = _payload_scalar(payload, 'physical_runtime_legacy_trend_output')
+
+    if materialized is not None:
+        summary['trend_result_materialized'] = bool(int(materialized))
+    if computed is not None:
+        summary['trend_result_computed'] = bool(int(computed))
+    if elapsed is not None:
+        summary['trend_result_elapsed_sec'] = float(elapsed)
+    if started_before is not None:
+        summary['physical_center_started_before_trend_result'] = bool(
+            int(started_before)
+        )
+    if mode is not None:
+        summary['trend_result_mode'] = str(mode)
+    if reason is not None:
+        reason_str = str(reason)
+        summary['trend_result_reason'] = reason_str if reason_str else None
+    if legacy_output is not None:
+        summary['legacy_trend_output'] = str(legacy_output)
+
+
 def _build_unmaterialized_trend(table) -> TrendResult:
     n = int(table.n_traces)
     return TrendResult(
@@ -73,6 +119,57 @@ def _build_unmaterialized_trend(table) -> TrendResult:
         trend_center_i=np.full((n,), -1, dtype=np.int32),
         filled_mask=np.zeros((n,), dtype=np.bool_),
     )
+
+
+class LazyTrendResultProvider:
+    def __init__(
+        self,
+        *,
+        mode: str,
+        build_fn: Callable[[], TrendResult],
+        progress: Any,
+        progress_context: Mapping[str, object],
+    ) -> None:
+        self.mode = str(mode)
+        self._build_fn = build_fn
+        self._progress = progress
+        self._progress_context = dict(progress_context)
+        self._trend_result: TrendResult | None = None
+        self.computed = False
+        self.reason: str | None = None
+        self.elapsed_sec = 0.0
+
+    @property
+    def trend_result(self) -> TrendResult | None:
+        return self._trend_result
+
+    def get(self, reason: str) -> TrendResult:
+        if self.mode == 'disabled':
+            msg = 'trend_result is disabled but was requested'
+            raise RuntimeError(msg)
+        if self._trend_result is None:
+            self.reason = str(reason)
+            lazy = self.mode != 'eager'
+            self._progress.emit(
+                'physics.stage_start',
+                **self._progress_context,
+                stage='trend_result',
+                lazy=lazy,
+                reason=self.reason,
+            )
+            stage_start = perf_counter()
+            self._trend_result = self._build_fn()
+            self.elapsed_sec = perf_counter() - stage_start
+            self.computed = True
+            self._progress.emit(
+                'physics.stage_done',
+                **self._progress_context,
+                stage='trend_result',
+                lazy=lazy,
+                reason=self.reason,
+                elapsed=self.elapsed_sec,
+            )
+        return self._trend_result
 
 
 def _build_coarse_observed_confidence(table) -> ConfidenceResult:
@@ -109,6 +206,12 @@ def _build_coarse_observed_merge(table, confidence: ConfidenceResult) -> MergeRe
         used_theoretical_mask=np.zeros((n,), dtype=np.bool_),
         reason_mask=np.zeros((n,), dtype=np.uint8),
     )
+
+
+def _physical_center_first_enabled(typed_cfg) -> bool:
+    return bool(typed_cfg.physical_trend.enabled) and str(
+        typed_cfg.physical_runtime.trend_result_mode
+    ) in {'lazy', 'disabled'}
 
 
 def _should_use_lazy_robust_fallback_path(
@@ -211,33 +314,27 @@ def build_robust_payload_from_coarse(
             stage='feasible_band',
             elapsed=perf_counter() - stage_start,
         )
-        trend_materialized = True
-        if _should_use_lazy_robust_fallback_path(
-            coarse_npz,
-            table=table,
-            typed_cfg=typed_cfg,
-            reporter=reporter,
-            progress_fields=progress_fields,
-        ):
-            trend_materialized = False
+        trend_provider = LazyTrendResultProvider(
+            mode=str(typed_cfg.physical_runtime.trend_result_mode),
+            build_fn=lambda: build_trend_result(table, feasible, typed_cfg),
+            progress=reporter,
+            progress_context=progress_fields,
+        )
+        physical_center_first = _physical_center_first_enabled(typed_cfg)
+        if physical_center_first:
+            _should_use_lazy_robust_fallback_path(
+                coarse_npz,
+                table=table,
+                typed_cfg=typed_cfg,
+                reporter=reporter,
+                progress_fields=progress_fields,
+            )
             trend = _build_unmaterialized_trend(table)
             confidence = _build_coarse_observed_confidence(table)
             merged = _build_coarse_observed_merge(table, confidence)
         else:
             _raise_if_trend_materialization_disabled(typed_cfg)
-            reporter.emit(
-                'physics.stage_start',
-                **progress_fields,
-                stage='trend_result',
-            )
-            stage_start = perf_counter()
-            trend = build_trend_result(table, feasible, typed_cfg)
-            reporter.emit(
-                'physics.stage_done',
-                **progress_fields,
-                stage='trend_result',
-                elapsed=perf_counter() - stage_start,
-            )
+            trend = trend_provider.get(reason='eager')
             reporter.emit('physics.stage_start', **progress_fields, stage='confidence')
             stage_start = perf_counter()
             confidence = compute_confidence_terms(table, feasible, trend, typed_cfg)
@@ -271,6 +368,7 @@ def build_robust_payload_from_coarse(
             trend=trend,
             merged=merged,
             cfg=typed_cfg,
+            trend_provider=trend_provider if physical_center_first else None,
             progress=reporter,
             progress_context=progress_fields,
         )
@@ -280,9 +378,21 @@ def build_robust_payload_from_coarse(
             stage='physical_center',
             elapsed=perf_counter() - stage_start,
         )
+        if (
+            physical_center_first
+            and str(typed_cfg.physical_runtime.legacy_trend_output) == 'always'
+        ):
+            trend = trend_provider.get(reason='legacy_trend_output')
+        elif physical_center_first and trend_provider.trend_result is not None:
+            trend = trend_provider.trend_result
+        trend_materialized = bool(trend_provider.computed)
     else:
         with runtime_diagnostics.time_physics():
-            reporter.emit('physics.stage_start', **progress_fields, stage='normalize_table')
+            reporter.emit(
+                'physics.stage_start',
+                **progress_fields,
+                stage='normalize_table',
+            )
             stage_start = perf_counter()
             with runtime_diagnostics.time_block('normalize_table_sec'):
                 table = normalize_coarse_pick_table(coarse_npz)
@@ -294,7 +404,11 @@ def build_robust_payload_from_coarse(
                 elapsed=perf_counter() - stage_start,
                 n_traces=int(table.n_traces),
             )
-            reporter.emit('physics.stage_start', **progress_fields, stage='feasible_band')
+            reporter.emit(
+                'physics.stage_start',
+                **progress_fields,
+                stage='feasible_band',
+            )
             stage_start = perf_counter()
             with runtime_diagnostics.time_block('feasible_band_sec'):
                 feasible = compute_feasible_band(table, typed_cfg.feasible_band)
@@ -304,34 +418,31 @@ def build_robust_payload_from_coarse(
                 stage='feasible_band',
                 elapsed=perf_counter() - stage_start,
             )
-            trend_materialized = True
-            if _should_use_lazy_robust_fallback_path(
-                coarse_npz,
-                table=table,
-                typed_cfg=typed_cfg,
-                reporter=reporter,
-                progress_fields=progress_fields,
-            ):
-                trend_materialized = False
+            def _build_trend_result_for_provider() -> TrendResult:
+                with runtime_diagnostics.time_block('trend_result_sec'):
+                    return build_trend_result(table, feasible, typed_cfg)
+
+            trend_provider = LazyTrendResultProvider(
+                mode=str(typed_cfg.physical_runtime.trend_result_mode),
+                build_fn=_build_trend_result_for_provider,
+                progress=reporter,
+                progress_context=progress_fields,
+            )
+            physical_center_first = _physical_center_first_enabled(typed_cfg)
+            if physical_center_first:
+                _should_use_lazy_robust_fallback_path(
+                    coarse_npz,
+                    table=table,
+                    typed_cfg=typed_cfg,
+                    reporter=reporter,
+                    progress_fields=progress_fields,
+                )
                 trend = _build_unmaterialized_trend(table)
                 confidence = _build_coarse_observed_confidence(table)
                 merged = _build_coarse_observed_merge(table, confidence)
             else:
                 _raise_if_trend_materialization_disabled(typed_cfg)
-                reporter.emit(
-                    'physics.stage_start',
-                    **progress_fields,
-                    stage='trend_result',
-                )
-                stage_start = perf_counter()
-                with runtime_diagnostics.time_block('trend_result_sec'):
-                    trend = build_trend_result(table, feasible, typed_cfg)
-                reporter.emit(
-                    'physics.stage_done',
-                    **progress_fields,
-                    stage='trend_result',
-                    elapsed=perf_counter() - stage_start,
-                )
+                trend = trend_provider.get(reason='eager')
                 reporter.emit(
                     'physics.stage_start',
                     **progress_fields,
@@ -367,7 +478,11 @@ def build_robust_payload_from_coarse(
                     stage='merge',
                     elapsed=perf_counter() - stage_start,
                 )
-            reporter.emit('physics.stage_start', **progress_fields, stage='physical_center')
+            reporter.emit(
+                'physics.stage_start',
+                **progress_fields,
+                stage='physical_center',
+            )
             stage_start = perf_counter()
             with runtime_diagnostics.time_physical_center():
                 physical = build_geometry_two_piece_physical_center(
@@ -377,6 +492,7 @@ def build_robust_payload_from_coarse(
                     trend=trend,
                     merged=merged,
                     cfg=typed_cfg,
+                    trend_provider=trend_provider if physical_center_first else None,
                     runtime_diagnostics=runtime_diagnostics,
                     progress=reporter,
                     progress_context=progress_fields,
@@ -387,7 +503,17 @@ def build_robust_payload_from_coarse(
                 stage='physical_center',
                 elapsed=perf_counter() - stage_start,
             )
+            if (
+                physical_center_first
+                and str(typed_cfg.physical_runtime.legacy_trend_output) == 'always'
+            ):
+                trend = trend_provider.get(reason='legacy_trend_output')
+            elif physical_center_first and trend_provider.trend_result is not None:
+                trend = trend_provider.trend_result
+            trend_materialized = bool(trend_provider.computed)
 
+    legacy_trend_output = str(typed_cfg.physical_runtime.legacy_trend_output)
+    include_trend_output = legacy_trend_output != 'omit' or bool(trend_materialized)
     payload = {
         'dt_sec': np.asarray(table.dt_scalar_sec, dtype=np.float32),
         'n_samples_orig': np.asarray(table.n_samples_orig, dtype=np.int32),
@@ -408,8 +534,6 @@ def build_robust_payload_from_coarse(
         'conf_prob1': np.asarray(confidence.conf_prob1, dtype=np.float32),
         'conf_trend1': np.asarray(confidence.conf_trend1, dtype=np.float32),
         'conf_rs1': np.asarray(confidence.conf_rs1, dtype=np.float32),
-        'trend_center_i': np.asarray(trend.trend_center_i, dtype=np.int32),
-        'trend_center_t_sec': np.asarray(trend.trend_center_sec, dtype=np.float32),
         'physical_center_i': np.asarray(physical.physical_center_i, dtype=np.int32),
         'physical_center_t_sec': np.asarray(
             physical.physical_center_t_sec,
@@ -498,6 +622,25 @@ def build_robust_payload_from_coarse(
             int(bool(trend_materialized)),
             dtype=np.int64,
         ),
+        'physical_runtime_trend_result_computed': np.asarray(
+            int(bool(trend_materialized)),
+            dtype=np.int64,
+        ),
+        'physical_runtime_trend_result_elapsed_sec': np.asarray(
+            float(trend_provider.elapsed_sec),
+            dtype=np.float64,
+        ),
+        'physical_runtime_physical_center_started_before_trend_result': np.asarray(
+            int(bool(physical_center_first)),
+            dtype=np.int64,
+        ),
+        'physical_runtime_trend_result_mode': np.asarray(
+            str(typed_cfg.physical_runtime.trend_result_mode)
+        ),
+        'physical_runtime_trend_result_reason': np.asarray(
+            '' if trend_provider.reason is None else str(trend_provider.reason)
+        ),
+        'physical_runtime_legacy_trend_output': np.asarray(legacy_trend_output),
         'lineage': build_lineage_payload(
             canonical_cfg,
             repo_root=repo_root,
@@ -505,6 +648,16 @@ def build_robust_payload_from_coarse(
             iter_id=iter_id,
         ),
     }
+    if include_trend_output:
+        payload.update(
+            {
+                'trend_center_i': np.asarray(trend.trend_center_i, dtype=np.int32),
+                'trend_center_t_sec': np.asarray(
+                    trend.trend_center_sec,
+                    dtype=np.float32,
+                ),
+            }
+        )
     if (
         bool(typed_cfg.physical_runtime.anchor_selection.enabled)
         or typed_cfg.physical_runtime.fit_policy == 'anchor_source_xy'
@@ -629,17 +782,8 @@ def run_physics_lite(
         if runtime_diagnostics is not None
         else runtime_summary_from_npz_fields(payload)
     )
-    if (
-        summary is not None
-        and 'physical_runtime_trend_result_materialized' in payload
-    ):
-        summary['trend_result_materialized'] = bool(
-            int(
-                np.asarray(
-                    payload['physical_runtime_trend_result_materialized']
-                ).item()
-            )
-        )
+    if summary is not None:
+        _add_trend_runtime_summary_fields(summary, payload)
     summary_path = None
     if summary is not None and bool(typed_cfg.physical_runtime.write_runtime_summary):
         reporter.emit('physics.stage_start', **progress_fields, stage='runtime_summary')

--- a/packages/seisai-engine/src/seisai_engine/pipelines/fbpick/physics/runtime_diagnostics.py
+++ b/packages/seisai-engine/src/seisai_engine/pipelines/fbpick/physics/runtime_diagnostics.py
@@ -862,13 +862,13 @@ class PhysicalRuntimeDiagnostics:
 
 def runtime_summary_from_npz_fields(
     payload: dict[str, np.ndarray],
-) -> dict[str, float | int | str] | None:
+) -> dict[str, object] | None:
     if (
         'physics_total_sec' not in payload
         and 'physical_runtime_physics_total_sec' not in payload
     ):
         return None
-    summary: dict[str, float | int | str] = {}
+    summary: dict[str, object] = {}
     int_keys = {
         'n_traces',
         'n_fit_contexts',
@@ -946,6 +946,43 @@ def runtime_summary_from_npz_fields(
                 summary[key] = str(value)
             else:
                 summary[key] = int(value) if key in int_keys else float(value)
+    if 'physical_runtime_trend_result_materialized' in payload:
+        materialized = np.asarray(
+            payload['physical_runtime_trend_result_materialized']
+        ).item()
+        summary['trend_result_materialized'] = bool(int(materialized))
+    if 'physical_runtime_trend_result_computed' in payload:
+        computed = np.asarray(
+            payload['physical_runtime_trend_result_computed']
+        ).item()
+        summary['trend_result_computed'] = bool(int(computed))
+    if 'physical_runtime_trend_result_elapsed_sec' in payload:
+        summary['trend_result_elapsed_sec'] = float(
+            np.asarray(payload['physical_runtime_trend_result_elapsed_sec']).item()
+        )
+    if 'physical_runtime_physical_center_started_before_trend_result' in payload:
+        summary['physical_center_started_before_trend_result'] = bool(
+            int(
+                np.asarray(
+                    payload[
+                        'physical_runtime_physical_center_started_before_trend_result'
+                    ]
+                ).item()
+            )
+        )
+    if 'physical_runtime_trend_result_mode' in payload:
+        summary['trend_result_mode'] = str(
+            np.asarray(payload['physical_runtime_trend_result_mode']).item()
+        )
+    if 'physical_runtime_trend_result_reason' in payload:
+        reason = str(
+            np.asarray(payload['physical_runtime_trend_result_reason']).item()
+        )
+        summary['trend_result_reason'] = reason if reason else None
+    if 'physical_runtime_legacy_trend_output' in payload:
+        summary['legacy_trend_output'] = str(
+            np.asarray(payload['physical_runtime_legacy_trend_output']).item()
+        )
     return summary
 
 

--- a/packages/seisai-engine/tests/test_fbpick_physics.py
+++ b/packages/seisai-engine/tests/test_fbpick_physics.py
@@ -455,6 +455,7 @@ def test_load_physics_lite_config_defaults_include_physical_trend_blocks() -> No
     assert cfg.physical_projection.mode == 'model'
     assert cfg.physical_runtime.fit_policy == 'full'
     assert cfg.physical_runtime.trend_result_mode == 'eager'
+    assert cfg.physical_runtime.legacy_trend_output == 'auto'
     assert cfg.physical_runtime.geometry_invalid_fallback == 'existing_trend'
     assert cfg.physical_runtime.group_invalid_fallback == 'existing_trend'
     assert cfg.physical_runtime.diagnostics_enabled is True
@@ -656,6 +657,7 @@ def test_load_physics_lite_config_accepts_anchor_selection_runtime_block() -> No
 
     assert cfg.physical_runtime.fit_policy == 'anchor_source_xy'
     assert cfg.physical_runtime.trend_result_mode == 'lazy'
+    assert cfg.physical_runtime.legacy_trend_output == 'auto'
     assert cfg.physical_runtime.geometry_invalid_fallback == 'robust'
     assert cfg.physical_runtime.group_invalid_fallback == 'robust'
     assert cfg.physical_runtime.anchor_selection.enabled is True
@@ -781,12 +783,46 @@ def test_physical_center_example_config_enables_physical_trend() -> None:
             'physical_runtime.trend_result_mode',
         ),
         (
+            {'physical_runtime': {'legacy_trend_output': 'compat'}},
+            'physical_runtime.legacy_trend_output',
+        ),
+        (
             {'physical_runtime': {'geometry_invalid_fallback': 'clip'}},
             'physical_runtime.geometry_invalid_fallback',
         ),
         (
             {'physical_runtime': {'group_invalid_fallback': 'skip'}},
             'physical_runtime.group_invalid_fallback',
+        ),
+        (
+            {
+                'physical_runtime': {
+                    'trend_result_mode': 'disabled',
+                    'geometry_invalid_fallback': 'existing_trend',
+                },
+            },
+            'geometry_invalid_fallback',
+        ),
+        (
+            {
+                'physical_runtime': {
+                    'trend_result_mode': 'disabled',
+                    'geometry_invalid_fallback': 'robust',
+                    'group_invalid_fallback': 'existing_trend',
+                },
+            },
+            'group_invalid_fallback',
+        ),
+        (
+            {
+                'physical_runtime': {
+                    'trend_result_mode': 'disabled',
+                    'geometry_invalid_fallback': 'robust',
+                    'group_invalid_fallback': 'robust',
+                    'legacy_trend_output': 'always',
+                },
+            },
+            'legacy_trend_output',
         ),
         (
             {
@@ -1834,6 +1870,167 @@ def test_run_physics_lite_end_to_end_outputs_full_covering_robust_picks(
     assert np.any(robust['robust_source'][18:24] == np.uint8(ROBUST_SOURCE_TREND_FILL))
     assert np.any(robust['reason_mask'][18:24] & np.uint8(REASON_MASK_FILLED_FROM_TREND))
     assert np.all(np.isfinite(robust['robust_pick_t_sec']))
+
+
+def test_run_physics_lite_lazy_valid_geometry_skips_trend_result(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    n_traces = 24
+    offsets_m = np.linspace(50.0, 1200.0, n_traces, dtype=np.float32)
+    pick_t_sec = np.float32(0.02) + offsets_m / np.float32(3000.0)
+    coarse_pick_i = np.rint(pick_t_sec / np.float32(0.004)).astype(np.int32)
+    coarse_path = save_coarse_npz(
+        tmp_path / 'lazy_valid_geometry.coarse.npz',
+        **_make_coarse_payload(
+            coarse_pick_i=coarse_pick_i,
+            coarse_pmax=np.full((n_traces,), 0.95, dtype=np.float32),
+            offsets_m=offsets_m,
+        ),
+        **_make_physical_geometry(offsets_m),
+    )
+    progress = _RecordingProgressReporter()
+
+    def fail_build_trend(*_args, **_kwargs):
+        raise AssertionError('trend_result should not be materialized')
+
+    monkeypatch.setattr(
+        'seisai_engine.pipelines.fbpick.physics.run.build_trend_result',
+        fail_build_trend,
+    )
+
+    out_path = run_physics_lite(
+        coarse_path,
+        cfg={
+            'physical_trend': {
+                'enabled': True,
+                'segment_by_offset_sign': False,
+                'split_by_offset_gap': False,
+            },
+            'neighbor_context': {'enabled': False},
+            'physical_prefilter': {'enabled': False},
+            'two_piece_ransac': {'min_pts': 3, 'seed': 7},
+            'physical_runtime': {
+                'trend_result_mode': 'lazy',
+                'progress': {'enabled': True, 'level': 'stage'},
+            },
+        },
+        source_model_id='coarse-model',
+        iter_id='',
+        repo_root=tmp_path,
+        progress=progress,
+    )
+    robust = load_robust_npz(out_path)
+    summary = json.loads(
+        derive_physics_runtime_summary_path(out_path).read_text(encoding='utf-8')
+    )
+    stage_starts = [
+        fields.get('stage')
+        for event, fields in progress.events
+        if event == 'physics.stage_start'
+    ]
+
+    assert 'trend_result' not in stage_starts
+    assert stage_starts.index('physical_center') < stage_starts.index(
+        'save_robust_npz'
+    )
+    assert int(np.asarray(robust['n_fit_calls']).item()) > 0
+    assert (
+        int(np.asarray(robust['physical_runtime_trend_result_materialized']).item())
+        == 0
+    )
+    assert summary['trend_result_mode'] == 'lazy'
+    assert summary['trend_result_computed'] is False
+    assert summary['trend_result_reason'] is None
+    assert summary['physical_center_started_before_trend_result'] is True
+    np.testing.assert_array_equal(
+        robust['trend_center_i'],
+        np.full((n_traces,), -1, dtype=np.int32),
+    )
+    assert np.any(
+        robust['physical_model_status']
+        == np.uint8(PHYSICAL_MODEL_STATUS_TWO_PIECE_OK)
+    )
+    np.testing.assert_array_equal(robust['fine_center_i'], robust['physical_center_i'])
+
+
+def test_run_physics_lite_lazy_existing_trend_fallback_builds_trend_once(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    n_traces = 10
+    coarse_pick_i = np.arange(80, 80 + n_traces, dtype=np.int32)
+    trend_i = coarse_pick_i + np.int32(7)
+    coarse_path = save_coarse_npz(
+        tmp_path / 'lazy_existing_trend_fallback.coarse.npz',
+        **_make_coarse_payload(
+            coarse_pick_i=coarse_pick_i,
+            coarse_pmax=np.full((n_traces,), 0.95, dtype=np.float32),
+            offsets_m=np.linspace(50.0, 400.0, n_traces, dtype=np.float32),
+        ),
+    )
+    progress = _RecordingProgressReporter()
+    calls: list[str] = []
+
+    def fake_build_trend(table, _feasible, _cfg):
+        calls.append('trend')
+        dt = np.float32(table.dt_scalar_sec)
+        trend_t_sec = trend_i.astype(np.float32) * dt
+        return TrendResult(
+            seed_mask=np.ones((n_traces,), dtype=np.bool_),
+            seed_threshold=np.float32(0.5),
+            local_center_sec=trend_t_sec,
+            local_center_valid=np.ones((n_traces,), dtype=np.bool_),
+            local_discard_mask=np.zeros((n_traces,), dtype=np.bool_),
+            global_center_sec=trend_t_sec,
+            trend_center_sec=trend_t_sec,
+            trend_center_i=trend_i.astype(np.int32),
+            filled_mask=np.zeros((n_traces,), dtype=np.bool_),
+        )
+
+    monkeypatch.setattr(
+        'seisai_engine.pipelines.fbpick.physics.run.build_trend_result',
+        fake_build_trend,
+    )
+
+    out_path = run_physics_lite(
+        coarse_path,
+        cfg={
+            'physical_trend': {'enabled': True, 'use_geometry_offset': True},
+            'physical_runtime': {
+                'trend_result_mode': 'lazy',
+                'geometry_invalid_fallback': 'existing_trend',
+                'progress': {'enabled': True, 'level': 'stage'},
+            },
+        },
+        source_model_id='coarse-model',
+        iter_id='',
+        repo_root=tmp_path,
+        progress=progress,
+    )
+    robust = load_robust_npz(out_path)
+    summary = json.loads(
+        derive_physics_runtime_summary_path(out_path).read_text(encoding='utf-8')
+    )
+    trend_starts = [
+        fields
+        for event, fields in progress.events
+        if event == 'physics.stage_start' and fields.get('stage') == 'trend_result'
+    ]
+
+    assert calls == ['trend']
+    assert trend_starts == [
+        {'stage': 'trend_result', 'lazy': True, 'reason': 'fallback_existing_trend'}
+    ]
+    assert (
+        int(np.asarray(robust['physical_runtime_trend_result_materialized']).item())
+        == 1
+    )
+    assert summary['trend_result_computed'] is True
+    assert summary['trend_result_reason'] == 'fallback_existing_trend'
+    np.testing.assert_array_equal(robust['trend_center_i'], trend_i)
+    np.testing.assert_array_equal(robust['physical_center_i'], trend_i)
+    np.testing.assert_array_equal(robust['fine_center_i'], trend_i)
 
 
 def test_run_physics_lite_lazy_geometry_invalid_robust_skips_trend_result(


### PR DESCRIPTION
Closes #140

## Summary
- Issue: physical trend実行時はIRLS/RANSACを先に回し、trend_resultはfallback時だけlazy生成する

## Changed files
- `packages/seisai-engine/src/seisai_engine/pipelines/fbpick/common/io.py`
- `packages/seisai-engine/src/seisai_engine/pipelines/fbpick/physics/config.py`
- `packages/seisai-engine/src/seisai_engine/pipelines/fbpick/physics/physical_center.py`
- `packages/seisai-engine/src/seisai_engine/pipelines/fbpick/physics/run.py`
- `packages/seisai-engine/src/seisai_engine/pipelines/fbpick/physics/runtime_diagnostics.py`
- `packages/seisai-engine/tests/test_fbpick_physics.py`

## Checks
- `.work/codex/checks.log`: 1171 passed, 5 warnings in 90.83s (0:01:30)

## Review
- `.work/codex/review.txt`: accept: yes
- findings: blocker 0, major 0, minor 0
