### PR TITLE
Issue: `fallback_existing_trend` を全SGY trend materializationではなく、失敗traceだけの partial trend fallback にする

### DIFF
--- a/packages/seisai-engine/src/seisai_engine/pipelines/fbpick/common/io.py
+++ b/packages/seisai-engine/src/seisai_engine/pipelines/fbpick/common/io.py
@@ -433,7 +433,9 @@ _ROBUST_RUNTIME_DIAGNOSTIC_STRING_KEYS = frozenset(
         'anchor_selection_mode',
         'fit_executor_backend',
         'observation_sampling_method',
+        'physical_runtime_fallback_existing_trend_mode',
         'physical_runtime_legacy_trend_output',
+        'physical_runtime_partial_trend_fallback_fallback_if_too_many',
         'physical_runtime_trend_result_mode',
         'physical_runtime_trend_result_reason',
     }

--- a/packages/seisai-engine/src/seisai_engine/pipelines/fbpick/physics/config.py
+++ b/packages/seisai-engine/src/seisai_engine/pipelines/fbpick/physics/config.py
@@ -19,6 +19,7 @@ __all__ = [
     'PhysicalAnchorSelectionCfg',
     'PhysicalFitExecutorCfg',
     'PhysicalObservationSamplingCfg',
+    'PhysicalPartialTrendFallbackCfg',
     'PhysicalPrefilterCfg',
     'PhysicalProgressCfg',
     'PhysicalProjectionCfg',
@@ -217,6 +218,18 @@ class PhysicalFitExecutorCfg:
 
 
 @dataclass(frozen=True)
+class PhysicalPartialTrendFallbackCfg:
+    enabled: bool = True
+    max_fraction: float = 0.05
+    max_traces: int = 50_000
+    cluster_consecutive_indices: bool = True
+    use_global_fallback: bool = True
+    fallback_if_too_many: str = 'robust'
+    local_window_from_trend_config: bool = True
+    emit_progress: bool = True
+
+
+@dataclass(frozen=True)
 class PhysicalProgressCfg:
     enabled: bool = False
     level: str = 'sgy'
@@ -242,6 +255,7 @@ class PhysicalRuntimeDiagnosticsCfg:
 class PhysicalRuntimeCfg:
     fit_policy: str = 'full'
     trend_result_mode: str = 'eager'
+    fallback_existing_trend_mode: str = 'full'
     legacy_trend_output: str = 'auto'
     geometry_invalid_fallback: str = 'existing_trend'
     group_invalid_fallback: str = 'existing_trend'
@@ -256,6 +270,9 @@ class PhysicalRuntimeCfg:
         PhysicalObservationSamplingCfg()
     )
     fit_executor: PhysicalFitExecutorCfg = PhysicalFitExecutorCfg()
+    partial_trend_fallback: PhysicalPartialTrendFallbackCfg = (
+        PhysicalPartialTrendFallbackCfg()
+    )
     progress: PhysicalProgressCfg = PhysicalProgressCfg()
 
 
@@ -638,6 +655,34 @@ def _load_physical_fit_executor_cfg(cfg: dict[str, Any]) -> PhysicalFitExecutorC
     )
 
 
+def _load_physical_partial_trend_fallback_cfg(
+    cfg: dict[str, Any],
+) -> PhysicalPartialTrendFallbackCfg:
+    fallback_if_too_many = optional_str(cfg, 'fallback_if_too_many', 'robust')
+    if fallback_if_too_many is None:
+        msg = (
+            'physical_runtime.partial_trend_fallback.fallback_if_too_many '
+            'must not be null'
+        )
+        raise TypeError(msg)
+    return PhysicalPartialTrendFallbackCfg(
+        enabled=bool(optional_bool(cfg, 'enabled', default=True)),
+        max_fraction=float(optional_float(cfg, 'max_fraction', 0.05)),
+        max_traces=int(optional_int(cfg, 'max_traces', 50_000)),
+        cluster_consecutive_indices=bool(
+            optional_bool(cfg, 'cluster_consecutive_indices', default=True)
+        ),
+        use_global_fallback=bool(
+            optional_bool(cfg, 'use_global_fallback', default=True)
+        ),
+        fallback_if_too_many=str(fallback_if_too_many),
+        local_window_from_trend_config=bool(
+            optional_bool(cfg, 'local_window_from_trend_config', default=True)
+        ),
+        emit_progress=bool(optional_bool(cfg, 'emit_progress', default=True)),
+    )
+
+
 def _load_physical_progress_cfg(cfg: dict[str, Any]) -> PhysicalProgressCfg:
     level = optional_str(cfg, 'level', 'sgy')
     stream = optional_str(cfg, 'stream', 'stderr')
@@ -699,6 +744,11 @@ def _load_physical_runtime_cfg(cfg: dict[str, Any]) -> PhysicalRuntimeCfg:
     return PhysicalRuntimeCfg(
         fit_policy=optional_str(cfg, 'fit_policy', 'full'),
         trend_result_mode=optional_str(cfg, 'trend_result_mode', 'eager'),
+        fallback_existing_trend_mode=optional_str(
+            cfg,
+            'fallback_existing_trend_mode',
+            'full',
+        ),
         legacy_trend_output=optional_str(cfg, 'legacy_trend_output', 'auto'),
         geometry_invalid_fallback=optional_str(
             cfg,
@@ -747,6 +797,12 @@ def _load_physical_runtime_cfg(cfg: dict[str, Any]) -> PhysicalRuntimeCfg:
             _require_dict(
                 cfg.get('fit_executor'),
                 key='physical_runtime.fit_executor',
+            )
+        ),
+        partial_trend_fallback=_load_physical_partial_trend_fallback_cfg(
+            _require_dict(
+                cfg.get('partial_trend_fallback'),
+                key='physical_runtime.partial_trend_fallback',
             )
         ),
         progress=_load_physical_progress_cfg(
@@ -859,6 +915,29 @@ def _validate_physical_projection_cfg(cfg: PhysicalProjectionCfg) -> None:
         raise ValueError(msg)
 
 
+def _validate_physical_partial_trend_fallback_cfg(
+    cfg: PhysicalPartialTrendFallbackCfg,
+) -> None:
+    _validate_nonnegative_float(
+        'physical_runtime.partial_trend_fallback.max_fraction',
+        cfg.max_fraction,
+    )
+    if float(cfg.max_fraction) > 1.0:
+        msg = 'physical_runtime.partial_trend_fallback.max_fraction must be <= 1'
+        raise ValueError(msg)
+    _validate_positive_int(
+        'physical_runtime.partial_trend_fallback.max_traces',
+        cfg.max_traces,
+    )
+    if cfg.fallback_if_too_many not in {'robust', 'full', 'error'}:
+        msg = (
+            'physical_runtime.partial_trend_fallback.fallback_if_too_many '
+            "must be 'robust', 'full', or 'error', "
+            f'got {cfg.fallback_if_too_many!r}'
+        )
+        raise ValueError(msg)
+
+
 def _validate_physical_runtime_cfg(cfg: PhysicalRuntimeCfg) -> None:
     if cfg.fit_policy not in {'full', 'anchor_source_xy'}:
         msg = (
@@ -870,6 +949,13 @@ def _validate_physical_runtime_cfg(cfg: PhysicalRuntimeCfg) -> None:
         msg = (
             "physical_runtime.trend_result_mode must be 'eager', 'lazy', "
             f"or 'disabled', got {cfg.trend_result_mode!r}"
+        )
+        raise ValueError(msg)
+    if cfg.fallback_existing_trend_mode not in {'full', 'partial', 'robust'}:
+        msg = (
+            "physical_runtime.fallback_existing_trend_mode must be 'full', "
+            "'partial', or 'robust', "
+            f'got {cfg.fallback_existing_trend_mode!r}'
         )
         raise ValueError(msg)
     if cfg.legacy_trend_output not in {'auto', 'always', 'omit'}:
@@ -914,6 +1000,7 @@ def _validate_physical_runtime_cfg(cfg: PhysicalRuntimeCfg) -> None:
             "with legacy_trend_output='always'"
         )
         raise ValueError(msg)
+    _validate_physical_partial_trend_fallback_cfg(cfg.partial_trend_fallback)
     anchor = cfg.anchor_selection
     if anchor.mode != 'source_xy_stride':
         msg = (

--- a/packages/seisai-engine/src/seisai_engine/pipelines/fbpick/physics/physical_center.py
+++ b/packages/seisai-engine/src/seisai_engine/pipelines/fbpick/physics/physical_center.py
@@ -133,8 +133,8 @@ __all__ = [
     'PHYSICAL_RUNTIME_FIT_SOURCE_FULL_FIT',
     'PHYSICAL_RUNTIME_FIT_SOURCE_LABELS',
     'PHYSICAL_RUNTIME_FIT_SOURCE_NEAREST_ANCHOR_REUSE',
-    'PhysicalCenterResult',
     'PhysicalCenterFallbackPreflight',
+    'PhysicalCenterResult',
     'build_geometry_two_piece_physical_center',
     'preflight_geometry_two_piece_fallback',
 ]
@@ -255,6 +255,32 @@ class _FitCacheEntry:
     fit_failed: bool
     diagnostics_computed: bool = False
     failure_reason: int | None = None
+
+
+@dataclass(frozen=True)
+class _PendingTrendFallbackRecord:
+    failure_reason: int
+    runtime_fit_source: int
+
+
+@dataclass
+class _PendingTrendFallback:
+    records: dict[int, _PendingTrendFallbackRecord] = field(default_factory=dict)
+
+    def add(
+        self,
+        trace_idx: int,
+        *,
+        failure_reason: int,
+        runtime_fit_source: int,
+    ) -> None:
+        self.records[int(trace_idx)] = _PendingTrendFallbackRecord(
+            failure_reason=int(failure_reason),
+            runtime_fit_source=int(runtime_fit_source),
+        )
+
+    def clear(self) -> None:
+        self.records.clear()
 
 
 @dataclass(frozen=True)
@@ -391,29 +417,101 @@ def _existing_fallback_trend(
     return trend_provider.get(reason='fallback_existing_trend')
 
 
-def _fallback_center_for_trace(
+def _use_full_trend_for_fallback_all(
+    trend_provider: object | None,
+    *,
+    n_traces: int,
+) -> bool:
+    if trend_provider is None:
+        return True
+    mode = str(getattr(trend_provider, 'fallback_existing_trend_mode', 'full'))
+    if mode == 'robust':
+        return False
+    if mode != 'partial':
+        return True
+
+    partial_cfg = getattr(trend_provider, '_partial_cfg', None)
+    if partial_cfg is None or not bool(partial_cfg.enabled):
+        return True
+    too_many = int(n_traces) > int(partial_cfg.max_traces)
+    provider_n_traces = getattr(trend_provider, '_n_traces', None)
+    total_traces = int(provider_n_traces) if provider_n_traces is not None else 0
+    if total_traces > 0:
+        too_many = too_many or (
+            float(n_traces) / float(total_traces)
+            > float(partial_cfg.max_fraction)
+        )
+    if not too_many:
+        return True
+    fallback = str(partial_cfg.fallback_if_too_many)
+    if fallback == 'full':
+        return True
+    if fallback == 'error':
+        msg = (
+            'partial trend fallback target count exceeds configured '
+            f'limits: n_targets={int(n_traces)}'
+        )
+        raise RuntimeError(msg)
+    record_too_many = getattr(
+        trend_provider,
+        'record_partial_too_many_robust_fallback',
+        None,
+    )
+    if record_too_many is not None:
+        record_too_many(int(n_traces))
+    return False
+
+
+def _partial_fallback_center_for_trace(
+    trace_idx: int,
+    *,
+    n_samples: int,
+    dt: float,
+    trend_provider: object | None,
+) -> tuple[bool, tuple[int, np.float32, int] | None]:
+    if trend_provider is None:
+        return False, None
+    get_partial = getattr(trend_provider, 'get_partial', None)
+    if get_partial is None:
+        return False, None
+    partial = get_partial(
+        np.asarray([int(trace_idx)], dtype=np.int64),
+        reason='fallback_existing_trend',
+    )
+    if partial is None:
+        return False, None
+
+    valid = np.asarray(partial.valid_mask, dtype=np.bool_).reshape(-1)
+    center_i = np.asarray(partial.center_i, dtype=np.int64).reshape(-1)
+    center_t = np.asarray(partial.center_t_sec, dtype=np.float32).reshape(-1)
+    if valid.size != 1 or center_i.size != 1 or center_t.size != 1:
+        msg = 'partial trend fallback must return one result per requested trace'
+        raise ValueError(msg)
+    sample_i = int(center_i[0])
+    sample_t = float(center_t[0])
+    if (
+        bool(valid[0])
+        and _is_valid_pick_i(sample_i, n_samples_orig=n_samples)
+        and np.isfinite(sample_t)
+    ):
+        return True, (
+            sample_i,
+            np.float32(sample_i * dt),
+            PHYSICAL_MODEL_STATUS_FALLBACK_EXISTING_TREND,
+        )
+    return True, None
+
+
+def _fallback_center_without_existing_trend(
     trace_idx: int,
     *,
     table: CoarsePickTable,
     feasible: FeasibleBandResult,
-    trend: TrendResult,
     merged: MergeResult,
-    trend_provider: object | None = None,
 ) -> tuple[int, np.float32, int]:
     n_samples = int(table.n_samples_orig)
     dt = float(table.dt_scalar_sec)
     idx = int(trace_idx)
-    trend = _existing_fallback_trend(trend, trend_provider)
-
-    trend_i = int(np.asarray(trend.trend_center_i, dtype=np.int64)[idx])
-    trend_t = float(np.asarray(trend.trend_center_sec, dtype=np.float32)[idx])
-    if _is_valid_pick_i(trend_i, n_samples_orig=n_samples) and np.isfinite(trend_t):
-        return (
-            trend_i,
-            np.float32(trend_i * dt),
-            PHYSICAL_MODEL_STATUS_FALLBACK_EXISTING_TREND,
-        )
-
     robust_i = int(np.asarray(merged.robust_pick_i, dtype=np.int64)[idx])
     lo_sec = float(np.asarray(feasible.feasible_lo_sec, dtype=np.float32)[idx])
     hi_sec = float(np.asarray(feasible.feasible_hi_sec, dtype=np.float32)[idx])
@@ -435,6 +533,49 @@ def _fallback_center_for_trace(
         robust_i,
         np.float32(robust_i * dt),
         PHYSICAL_MODEL_STATUS_FALLBACK_ROBUST,
+    )
+
+
+def _fallback_center_for_trace(
+    trace_idx: int,
+    *,
+    table: CoarsePickTable,
+    feasible: FeasibleBandResult,
+    trend: TrendResult,
+    merged: MergeResult,
+    trend_provider: object | None = None,
+) -> tuple[int, np.float32, int]:
+    n_samples = int(table.n_samples_orig)
+    dt = float(table.dt_scalar_sec)
+    idx = int(trace_idx)
+    partial_attempted, partial_center = _partial_fallback_center_for_trace(
+        idx,
+        n_samples=n_samples,
+        dt=dt,
+        trend_provider=trend_provider,
+    )
+    if partial_center is not None:
+        return partial_center
+
+    if not partial_attempted:
+        trend = _existing_fallback_trend(trend, trend_provider)
+
+        trend_i = int(np.asarray(trend.trend_center_i, dtype=np.int64)[idx])
+        trend_t = float(np.asarray(trend.trend_center_sec, dtype=np.float32)[idx])
+        if _is_valid_pick_i(trend_i, n_samples_orig=n_samples) and np.isfinite(
+            trend_t
+        ):
+            return (
+                trend_i,
+                np.float32(trend_i * dt),
+                PHYSICAL_MODEL_STATUS_FALLBACK_EXISTING_TREND,
+            )
+
+    return _fallback_center_without_existing_trend(
+        idx,
+        table=table,
+        feasible=feasible,
+        merged=merged,
     )
 
 
@@ -486,6 +627,67 @@ def _finalize_result(arrays: dict[str, np.ndarray]) -> PhysicalCenterResult:
     return PhysicalCenterResult(**arrays)
 
 
+def _should_defer_partial_existing_trend(
+    trend_provider: object | None,
+) -> bool:
+    if trend_provider is None:
+        return False
+    mode = str(getattr(trend_provider, 'fallback_existing_trend_mode', 'full'))
+    if mode != 'partial':
+        return False
+    if getattr(trend_provider, 'get_partial', None) is None:
+        return False
+    partial_cfg = getattr(trend_provider, '_partial_cfg', None)
+    return partial_cfg is None or bool(partial_cfg.enabled)
+
+
+def _assign_fallback_values(
+    arrays: dict[str, np.ndarray],
+    trace_idx: int,
+    *,
+    center_i: int,
+    center_t: np.float32,
+    fallback_status: int,
+    failure_reason: int,
+    runtime_fit_source: int,
+) -> None:
+    arrays['physical_center_i'][trace_idx] = np.int32(center_i)
+    arrays['physical_center_t_sec'][trace_idx] = np.float32(center_t)
+    arrays['physical_model_status'][trace_idx] = np.uint8(fallback_status)
+    arrays['physical_model_failure_reason'][trace_idx] = np.uint8(failure_reason)
+    source = int(runtime_fit_source)
+    if fallback_status == PHYSICAL_MODEL_STATUS_FALLBACK_ROBUST:
+        source = PHYSICAL_RUNTIME_FIT_SOURCE_FALLBACK_ROBUST
+    arrays['physical_runtime_fit_source'][trace_idx] = np.uint8(source)
+
+
+def _assign_deferred_existing_trend_placeholder(
+    arrays: dict[str, np.ndarray],
+    trace_idx: int,
+    *,
+    failure_reason: int,
+    runtime_fit_source: int,
+    table: CoarsePickTable,
+    feasible: FeasibleBandResult,
+    merged: MergeResult,
+) -> None:
+    center_i, center_t, _fallback_status = _fallback_center_without_existing_trend(
+        trace_idx,
+        table=table,
+        feasible=feasible,
+        merged=merged,
+    )
+    _assign_fallback_values(
+        arrays,
+        trace_idx,
+        center_i=center_i,
+        center_t=center_t,
+        fallback_status=PHYSICAL_MODEL_STATUS_FALLBACK_EXISTING_TREND,
+        failure_reason=failure_reason,
+        runtime_fit_source=runtime_fit_source,
+    )
+
+
 def _assign_fallback(
     arrays: dict[str, np.ndarray],
     trace_idx: int,
@@ -497,7 +699,28 @@ def _assign_fallback(
     trend: TrendResult,
     merged: MergeResult,
     trend_provider: object | None = None,
+    pending_trend_fallback: _PendingTrendFallback | None = None,
 ) -> None:
+    if (
+        pending_trend_fallback is not None
+        and _should_defer_partial_existing_trend(trend_provider)
+    ):
+        pending_trend_fallback.add(
+            trace_idx,
+            failure_reason=failure_reason,
+            runtime_fit_source=runtime_fit_source,
+        )
+        _assign_deferred_existing_trend_placeholder(
+            arrays,
+            trace_idx,
+            failure_reason=failure_reason,
+            runtime_fit_source=runtime_fit_source,
+            table=table,
+            feasible=feasible,
+            merged=merged,
+        )
+        return
+
     center_i, center_t, fallback_status = _fallback_center_for_trace(
         trace_idx,
         table=table,
@@ -506,14 +729,15 @@ def _assign_fallback(
         trend_provider=trend_provider,
         merged=merged,
     )
-    arrays['physical_center_i'][trace_idx] = np.int32(center_i)
-    arrays['physical_center_t_sec'][trace_idx] = np.float32(center_t)
-    arrays['physical_model_status'][trace_idx] = np.uint8(fallback_status)
-    arrays['physical_model_failure_reason'][trace_idx] = np.uint8(failure_reason)
-    source = int(runtime_fit_source)
-    if fallback_status == PHYSICAL_MODEL_STATUS_FALLBACK_ROBUST:
-        source = PHYSICAL_RUNTIME_FIT_SOURCE_FALLBACK_ROBUST
-    arrays['physical_runtime_fit_source'][trace_idx] = np.uint8(source)
+    _assign_fallback_values(
+        arrays,
+        trace_idx,
+        center_i=center_i,
+        center_t=center_t,
+        fallback_status=fallback_status,
+        failure_reason=failure_reason,
+        runtime_fit_source=runtime_fit_source,
+    )
 
 
 def _assign_robust_fallback(
@@ -539,6 +763,148 @@ def _assign_robust_fallback(
     )
 
 
+def _partial_fallback_lookup(
+    partial: object,
+) -> dict[int, tuple[bool, int, float]]:
+    indices = np.asarray(partial.indices, dtype=np.int64).reshape(-1)
+    center_i = np.asarray(partial.center_i, dtype=np.int64).reshape(-1)
+    center_t = np.asarray(
+        partial.center_t_sec,
+        dtype=np.float32,
+    ).reshape(-1)
+    valid = np.asarray(partial.valid_mask, dtype=np.bool_).reshape(-1)
+    if not (
+        indices.shape == center_i.shape == center_t.shape == valid.shape
+    ):
+        msg = 'partial trend fallback arrays must have matching 1D shapes'
+        raise ValueError(msg)
+    return {
+        int(trace_idx): (bool(valid[pos]), int(center_i[pos]), float(center_t[pos]))
+        for pos, trace_idx in enumerate(indices.tolist())
+    }
+
+
+def _apply_pending_trend_fallback(
+    arrays: dict[str, np.ndarray],
+    *,
+    pending_trend_fallback: _PendingTrendFallback | None,
+    table: CoarsePickTable,
+    feasible: FeasibleBandResult,
+    trend: TrendResult,
+    merged: MergeResult,
+    trend_provider: object | None,
+) -> None:
+    if pending_trend_fallback is None or not pending_trend_fallback.records:
+        return
+
+    pending_items = [
+        (trace_idx, record)
+        for trace_idx, record in pending_trend_fallback.records.items()
+        if int(arrays['physical_model_status'][int(trace_idx)])
+        == PHYSICAL_MODEL_STATUS_FALLBACK_EXISTING_TREND
+    ]
+    pending_trend_fallback.clear()
+    if not pending_items:
+        return
+
+    indices = np.asarray(
+        [trace_idx for trace_idx, _record in pending_items],
+        dtype=np.int64,
+    )
+    get_partial = (
+        None
+        if trend_provider is None
+        else getattr(trend_provider, 'get_partial', None)
+    )
+    partial = (
+        get_partial(indices, reason='fallback_existing_trend')
+        if get_partial is not None
+        else None
+    )
+    if partial is None:
+        trend = _existing_fallback_trend(trend, trend_provider)
+        for trace_idx, record in pending_items:
+            center_i, center_t, fallback_status = _fallback_center_for_trace(
+                trace_idx,
+                table=table,
+                feasible=feasible,
+                trend=trend,
+                trend_provider=None,
+                merged=merged,
+            )
+            _assign_fallback_values(
+                arrays,
+                trace_idx,
+                center_i=center_i,
+                center_t=center_t,
+                fallback_status=fallback_status,
+                failure_reason=record.failure_reason,
+                runtime_fit_source=record.runtime_fit_source,
+            )
+        return
+
+    partial_by_trace = _partial_fallback_lookup(partial)
+    n_samples = int(table.n_samples_orig)
+    dt = float(table.dt_scalar_sec)
+    for trace_idx, record in pending_items:
+        partial_value = partial_by_trace.get(int(trace_idx))
+        if partial_value is not None:
+            valid, center_i, center_t_sec = partial_value
+            if (
+                valid
+                and _is_valid_pick_i(center_i, n_samples_orig=n_samples)
+                and np.isfinite(center_t_sec)
+            ):
+                _assign_fallback_values(
+                    arrays,
+                    trace_idx,
+                    center_i=center_i,
+                    center_t=np.float32(center_i * dt),
+                    fallback_status=PHYSICAL_MODEL_STATUS_FALLBACK_EXISTING_TREND,
+                    failure_reason=record.failure_reason,
+                    runtime_fit_source=record.runtime_fit_source,
+                )
+                continue
+
+        center_i, center_t, fallback_status = _fallback_center_without_existing_trend(
+            trace_idx,
+            table=table,
+            feasible=feasible,
+            merged=merged,
+        )
+        _assign_fallback_values(
+            arrays,
+            trace_idx,
+            center_i=center_i,
+            center_t=center_t,
+            fallback_status=fallback_status,
+            failure_reason=record.failure_reason,
+            runtime_fit_source=record.runtime_fit_source,
+        )
+
+
+def _finalize_result_with_pending_trend_fallback(
+    arrays: dict[str, np.ndarray],
+    *,
+    pending_trend_fallback: _PendingTrendFallback | None,
+    table: CoarsePickTable,
+    feasible: FeasibleBandResult,
+    trend: TrendResult,
+    merged: MergeResult,
+    trend_provider: object | None,
+) -> PhysicalCenterResult:
+    _apply_pending_trend_fallback(
+        arrays,
+        pending_trend_fallback=pending_trend_fallback,
+        table=table,
+        feasible=feasible,
+        trend=trend,
+        merged=merged,
+        trend_provider=trend_provider,
+    )
+    return _finalize_result(arrays)
+
+
 def _assign_fallback_all(
     *,
     failure_reason: int,
@@ -548,24 +914,16 @@ def _assign_fallback_all(
     merged: MergeResult,
     trend_provider: object | None = None,
 ) -> PhysicalCenterResult:
-    trend = _existing_fallback_trend(trend, trend_provider)
     arrays = _allocate_result_arrays(table)
     n = int(table.n_traces)
     n_samples = int(table.n_samples_orig)
     dt = float(table.dt_scalar_sec)
-
-    trend_i = _as_vector(
-        'trend.trend_center_i',
-        trend.trend_center_i,
+    use_full_trend = _use_full_trend_for_fallback_all(
+        trend_provider,
         n_traces=n,
-        dtype=np.int64,
     )
-    trend_t = _as_vector(
-        'trend.trend_center_sec',
-        trend.trend_center_sec,
-        n_traces=n,
-        dtype=np.float32,
-    )
+    if use_full_trend:
+        trend = _existing_fallback_trend(trend, trend_provider)
     robust_i = _as_vector(
         'merged.robust_pick_i',
         merged.robust_pick_i,
@@ -623,18 +981,31 @@ def _assign_fallback_all(
                 PHYSICAL_RUNTIME_FIT_SOURCE_FALLBACK_EXISTING_TREND
             )
 
-    valid_trend = (
-        (trend_i >= 0)
-        & (trend_i < n_samples)
-        & np.isfinite(trend_t)
-    )
-    center_i[valid_trend] = trend_i[valid_trend].astype(np.int32)
-    status[valid_trend] = np.uint8(
-        PHYSICAL_MODEL_STATUS_FALLBACK_EXISTING_TREND
-    )
-    fit_source[valid_trend] = np.uint8(
-        PHYSICAL_RUNTIME_FIT_SOURCE_FALLBACK_EXISTING_TREND
-    )
+    if use_full_trend:
+        trend_i = _as_vector(
+            'trend.trend_center_i',
+            trend.trend_center_i,
+            n_traces=n,
+            dtype=np.int64,
+        )
+        trend_t = _as_vector(
+            'trend.trend_center_sec',
+            trend.trend_center_sec,
+            n_traces=n,
+            dtype=np.float32,
+        )
+        valid_trend = (
+            (trend_i >= 0)
+            & (trend_i < n_samples)
+            & np.isfinite(trend_t)
+        )
+        center_i[valid_trend] = trend_i[valid_trend].astype(np.int32)
+        status[valid_trend] = np.uint8(
+            PHYSICAL_MODEL_STATUS_FALLBACK_EXISTING_TREND
+        )
+        fit_source[valid_trend] = np.uint8(
+            PHYSICAL_RUNTIME_FIT_SOURCE_FALLBACK_EXISTING_TREND
+        )
 
     arrays['physical_center_i'][:] = center_i
     arrays['physical_center_t_sec'][:] = (
@@ -2504,6 +2875,7 @@ def _prepare_trace_plan_assignment(
     observation_plan_cache: _ObservationPlanCache,
     min_fit_obs: int,
     runtime_diagnostics: PhysicalRuntimeDiagnostics | None,
+    pending_trend_fallback: _PendingTrendFallback | None = None,
 ) -> _TracePlanAssignment | None:
     arrays['physical_offset_source'][trace_idx] = np.uint8(offset_source)
     if (
@@ -2519,6 +2891,7 @@ def _prepare_trace_plan_assignment(
             trend=trend,
             trend_provider=trend_provider,
             merged=merged,
+            pending_trend_fallback=pending_trend_fallback,
         )
         return None
 
@@ -2543,6 +2916,7 @@ def _prepare_trace_plan_assignment(
             trend=trend,
             trend_provider=trend_provider,
             merged=merged,
+            pending_trend_fallback=pending_trend_fallback,
         )
         return None
 
@@ -2563,6 +2937,7 @@ def _prepare_trace_plan_assignment(
             trend=trend,
             trend_provider=trend_provider,
             merged=merged,
+            pending_trend_fallback=pending_trend_fallback,
         )
         return None
 
@@ -2622,6 +2997,7 @@ def _assign_prepared_model_prediction_batch(
     fit_cache: dict[tuple[int, ...], _FitCacheEntry],
     t0_shift_sec: float | np.ndarray = 0.0,
     runtime_diagnostics: PhysicalRuntimeDiagnostics | None = None,
+    pending_trend_fallback: _PendingTrendFallback | None = None,
 ) -> tuple[np.ndarray, tuple[float, float, float, float, float, float, float] | None]:
     if not items:
         return np.zeros((0,), dtype=np.bool_), None
@@ -2684,6 +3060,7 @@ def _assign_prepared_model_prediction_batch(
             trend=trend,
             trend_provider=trend_provider,
             merged=merged,
+            pending_trend_fallback=pending_trend_fallback,
         )
     return valid, diagnostics
 
@@ -2734,6 +3111,7 @@ def _assign_fit_context_fallback(
     trend: TrendResult,
     trend_provider: object | None = None,
     merged: MergeResult,
+    pending_trend_fallback: _PendingTrendFallback | None = None,
 ) -> None:
     for trace_idx in np.asarray(work_item.trace_indices, dtype=np.int64).tolist():
         _assign_fallback(
@@ -2745,6 +3123,7 @@ def _assign_fit_context_fallback(
             trend=trend,
             trend_provider=trend_provider,
             merged=merged,
+            pending_trend_fallback=pending_trend_fallback,
         )
 
 
@@ -2762,6 +3141,7 @@ def _fit_and_assign_context_work_item(
     strategy: _PhysicalFitStrategy,
     fit_cache: dict[tuple[int, ...], _FitCacheEntry],
     runtime_diagnostics: PhysicalRuntimeDiagnostics | None,
+    pending_trend_fallback: _PendingTrendFallback | None = None,
 ) -> _FitContextWorkResult:
     trend_model, diagnostics, fit_failure_reason = _fit_model_for_plan(
         strategy=strategy,
@@ -2796,6 +3176,7 @@ def _fit_and_assign_context_work_item(
         diagnostics=diagnostics,
         fit_failure_reason=fit_failure_reason,
         runtime_diagnostics=runtime_diagnostics,
+        pending_trend_fallback=pending_trend_fallback,
     )
 
 
@@ -2814,6 +3195,7 @@ def _assign_fit_context_work_item_outcome(
     diagnostics: tuple[float, float, float, float, float, float, float] | None,
     fit_failure_reason: int | None,
     runtime_diagnostics: PhysicalRuntimeDiagnostics | None,
+    pending_trend_fallback: _PendingTrendFallback | None = None,
 ) -> _FitContextWorkResult:
     if fit_failure_reason is not None:
         _assign_fit_context_fallback(
@@ -2825,6 +3207,7 @@ def _assign_fit_context_work_item_outcome(
             trend=trend,
             trend_provider=trend_provider,
             merged=merged,
+            pending_trend_fallback=pending_trend_fallback,
         )
         return _FitContextWorkResult(
             trend_model=None,
@@ -2842,6 +3225,7 @@ def _assign_fit_context_work_item_outcome(
             trend=trend,
             trend_provider=trend_provider,
             merged=merged,
+            pending_trend_fallback=pending_trend_fallback,
         )
         return _FitContextWorkResult(
             trend_model=None,
@@ -2876,6 +3260,7 @@ def _assign_fit_context_work_item_outcome(
         merged=merged,
         fit_cache=fit_cache,
         runtime_diagnostics=runtime_diagnostics,
+        pending_trend_fallback=pending_trend_fallback,
     )
     return _FitContextWorkResult(
         trend_model=trend_model,
@@ -2910,6 +3295,7 @@ def _prepare_fit_context_assignments_for_trace_indices(
     observation_plan_cache: _ObservationPlanCache,
     min_fit_obs: int,
     runtime_diagnostics: PhysicalRuntimeDiagnostics | None,
+    pending_trend_fallback: _PendingTrendFallback | None = None,
 ) -> tuple[
     dict[tuple[int, ...], list[_TracePlanAssignment]],
     list[_TracePlanAssignment],
@@ -2936,6 +3322,7 @@ def _prepare_fit_context_assignments_for_trace_indices(
             observation_plan_cache=observation_plan_cache,
             min_fit_obs=min_fit_obs,
             runtime_diagnostics=runtime_diagnostics,
+            pending_trend_fallback=pending_trend_fallback,
         )
         if assignment is None:
             continue
@@ -2960,6 +3347,7 @@ def _fit_and_assign_context_work_items(
     runtime_diagnostics: PhysicalRuntimeDiagnostics | None,
     progress: object | None = None,
     progress_context: Mapping[str, object] | None = None,
+    pending_trend_fallback: _PendingTrendFallback | None = None,
 ) -> dict[tuple[int, ...], _FitContextWorkResult]:
     reporter = progress if progress is not None else NullProgressReporter()
     context = dict(progress_context or {})
@@ -2980,6 +3368,7 @@ def _fit_and_assign_context_work_items(
             progress=reporter,
             progress_context=context,
             progress_start_sec=fit_start,
+            pending_trend_fallback=pending_trend_fallback,
         )
 
     results: dict[tuple[int, ...], _FitContextWorkResult] = {}
@@ -3004,6 +3393,7 @@ def _fit_and_assign_context_work_items(
             strategy=strategy,
             fit_cache=fit_cache,
             runtime_diagnostics=runtime_diagnostics,
+            pending_trend_fallback=pending_trend_fallback,
         )
         reporter.emit(
             'fit.progress',
@@ -3096,6 +3486,7 @@ def _fit_and_assign_context_work_items_parallel(
     progress: object | None = None,
     progress_context: Mapping[str, object] | None = None,
     progress_start_sec: float | None = None,
+    pending_trend_fallback: _PendingTrendFallback | None = None,
 ) -> dict[tuple[int, ...], _FitContextWorkResult]:
     reporter = progress if progress is not None else NullProgressReporter()
     context = dict(progress_context or {})
@@ -3148,6 +3539,7 @@ def _fit_and_assign_context_work_items_parallel(
             diagnostics=entry.diagnostics,
             fit_failure_reason=fit_failure_reason,
             runtime_diagnostics=runtime_diagnostics,
+            pending_trend_fallback=pending_trend_fallback,
         )
         done += 1
         reporter.emit(
@@ -3221,6 +3613,7 @@ def _fit_and_assign_context_work_items_parallel(
                 diagnostics=task_result.diagnostics,
                 fit_failure_reason=task_result.failure_reason,
                 runtime_diagnostics=runtime_diagnostics,
+                pending_trend_fallback=pending_trend_fallback,
             )
 
     return results
@@ -3258,6 +3651,7 @@ def _fallback_no_compatible_anchor(
     trend_provider: object | None = None,
     merged: MergeResult,
     cfg: PhysicsLiteConfig,
+    pending_trend_fallback: _PendingTrendFallback | None = None,
 ) -> None:
     fallback = str(cfg.physical_runtime.anchor_reuse.fallback_if_no_compatible_segment)
     if fallback == 'robust':
@@ -3279,6 +3673,7 @@ def _fallback_no_compatible_anchor(
         trend=trend,
         trend_provider=trend_provider,
         merged=merged,
+        pending_trend_fallback=pending_trend_fallback,
     )
 
 
@@ -4017,6 +4412,7 @@ def build_geometry_two_piece_physical_center(
     )
 
     arrays = _allocate_result_arrays(table)
+    pending_trend_fallback = _PendingTrendFallback()
     reporter.emit('physical-center.stage_start', **context, stage='anchor_selection')
     stage_start = time.perf_counter()
     with (
@@ -4097,6 +4493,7 @@ def build_geometry_two_piece_physical_center(
                 observation_plan_cache=observation_plan_cache,
                 min_fit_obs=min_fit_obs,
                 runtime_diagnostics=runtime_diagnostics,
+                pending_trend_fallback=pending_trend_fallback,
             )
         )
         anchor_work_items = _build_fit_context_work_items(
@@ -4133,6 +4530,7 @@ def build_geometry_two_piece_physical_center(
             runtime_diagnostics=runtime_diagnostics,
             progress=reporter,
             progress_context=context,
+            pending_trend_fallback=pending_trend_fallback,
         )
         if runtime_diagnostics is not None:
             anchor_fit_call_delta = max(
@@ -4227,6 +4625,7 @@ def build_geometry_two_piece_physical_center(
                         trend=trend,
                         trend_provider=trend_provider,
                         merged=merged,
+                        pending_trend_fallback=pending_trend_fallback,
                     )
                     continue
 
@@ -4293,6 +4692,7 @@ def build_geometry_two_piece_physical_center(
                         trend_provider=trend_provider,
                         merged=merged,
                         cfg=cfg,
+                        pending_trend_fallback=pending_trend_fallback,
                     )
 
             if fallback_full_trace_indices:
@@ -4316,6 +4716,7 @@ def build_geometry_two_piece_physical_center(
                         observation_plan_cache=observation_plan_cache,
                         min_fit_obs=min_fit_obs,
                         runtime_diagnostics=runtime_diagnostics,
+                        pending_trend_fallback=pending_trend_fallback,
                     )
                 )
                 fallback_full_work_items = _build_fit_context_work_items(
@@ -4349,6 +4750,7 @@ def build_geometry_two_piece_physical_center(
                     runtime_diagnostics=runtime_diagnostics,
                     progress=reporter,
                     progress_context=context,
+                    pending_trend_fallback=pending_trend_fallback,
                 )
 
             non_anchor_mode = str(cfg.physical_runtime.anchor_reuse.non_anchor_mode)
@@ -4389,6 +4791,7 @@ def build_geometry_two_piece_physical_center(
                             trend=trend,
                             trend_provider=trend_provider,
                             merged=merged,
+                            pending_trend_fallback=pending_trend_fallback,
                         )
                 continue
 
@@ -4460,6 +4863,7 @@ def build_geometry_two_piece_physical_center(
                         observation_plan_cache=observation_plan_cache,
                         min_fit_obs=min_fit_obs,
                         runtime_diagnostics=runtime_diagnostics,
+                        pending_trend_fallback=pending_trend_fallback,
                     )
                 )
                 refit_work_items = _build_fit_context_work_items(
@@ -4491,6 +4895,7 @@ def build_geometry_two_piece_physical_center(
                     runtime_diagnostics=runtime_diagnostics,
                     progress=reporter,
                     progress_context=context,
+                    pending_trend_fallback=pending_trend_fallback,
                 )
                 assigned_count = sum(
                     len(result.valid_trace_indices)
@@ -4535,6 +4940,7 @@ def build_geometry_two_piece_physical_center(
                             trend=trend,
                             trend_provider=trend_provider,
                             merged=merged,
+                            pending_trend_fallback=pending_trend_fallback,
                         )
                     continue
 
@@ -4579,6 +4985,7 @@ def build_geometry_two_piece_physical_center(
                         trend=trend,
                         trend_provider=trend_provider,
                         merged=merged,
+                        pending_trend_fallback=pending_trend_fallback,
                     )
                 if use_shift:
                     group_shift_ms_values.append(float(stats.t0_shift_sec) * 1000.0)
@@ -4627,6 +5034,15 @@ def build_geometry_two_piece_physical_center(
                 full_fit_call_count_estimate=len(groups)
             )
             runtime_diagnostics.set_unique_fit_contexts(len(fit_cache))
+        result = _finalize_result_with_pending_trend_fallback(
+            arrays,
+            pending_trend_fallback=pending_trend_fallback,
+            table=table,
+            feasible=feasible,
+            trend=trend,
+            merged=merged,
+            trend_provider=trend_provider,
+        )
         reporter.emit(
             'physical-center.done',
             **context,
@@ -4635,7 +5051,7 @@ def build_geometry_two_piece_physical_center(
             n_source_groups=len(groups),
             n_unique_fit_contexts=len(fit_cache),
         )
-        return _finalize_result(arrays)
+        return result
 
     reporter.emit(
         'physical-center.stage_start',
@@ -4664,6 +5080,7 @@ def build_geometry_two_piece_physical_center(
             observation_plan_cache=observation_plan_cache,
             min_fit_obs=min_fit_obs,
             runtime_diagnostics=runtime_diagnostics,
+            pending_trend_fallback=pending_trend_fallback,
         )
         if assignment is not None:
             fit_context_assignments.setdefault(assignment.fit_key, []).append(
@@ -4705,11 +5122,21 @@ def build_geometry_two_piece_physical_center(
         runtime_diagnostics=runtime_diagnostics,
         progress=reporter,
         progress_context=context,
+        pending_trend_fallback=pending_trend_fallback,
     )
 
     if runtime_diagnostics is not None:
         runtime_diagnostics.set_unique_fit_contexts(len(fit_cache))
 
+    result = _finalize_result_with_pending_trend_fallback(
+        arrays,
+        pending_trend_fallback=pending_trend_fallback,
+        table=table,
+        feasible=feasible,
+        trend=trend,
+        merged=merged,
+        trend_provider=trend_provider,
+    )
     reporter.emit(
         'physical-center.done',
         **context,
@@ -4718,4 +5145,4 @@ def build_geometry_two_piece_physical_center(
         n_source_groups=len(groups),
         n_unique_fit_contexts=len(fit_cache),
     )
-    return _finalize_result(arrays)
+    return result

--- a/packages/seisai-engine/src/seisai_engine/pipelines/fbpick/physics/run.py
+++ b/packages/seisai-engine/src/seisai_engine/pipelines/fbpick/physics/run.py
@@ -30,7 +30,12 @@ from .runtime_diagnostics import (
     runtime_summary_from_npz_fields,
     write_physics_runtime_summary,
 )
-from .trend import TrendResult, build_trend_result
+from .trend import (
+    PartialTrendFallbackResult,
+    TrendResult,
+    build_partial_trend_fallback,
+    build_trend_result,
+)
 
 __all__ = [
     'build_robust_payload_from_coarse',
@@ -86,6 +91,34 @@ def _add_trend_runtime_summary_fields(
     mode = _payload_scalar(payload, 'physical_runtime_trend_result_mode')
     reason = _payload_scalar(payload, 'physical_runtime_trend_result_reason')
     legacy_output = _payload_scalar(payload, 'physical_runtime_legacy_trend_output')
+    fallback_existing_trend_mode = _payload_scalar(
+        payload,
+        'physical_runtime_fallback_existing_trend_mode',
+    )
+    partial_enabled = _payload_scalar(
+        payload,
+        'physical_runtime_partial_trend_fallback_enabled',
+    )
+    partial_n_targets = _payload_scalar(
+        payload,
+        'physical_runtime_partial_trend_fallback_n_targets',
+    )
+    partial_n_valid = _payload_scalar(
+        payload,
+        'physical_runtime_partial_trend_fallback_n_valid',
+    )
+    partial_n_robust = _payload_scalar(
+        payload,
+        'physical_runtime_partial_trend_fallback_n_robust',
+    )
+    partial_elapsed = _payload_scalar(
+        payload,
+        'physical_runtime_partial_trend_fallback_elapsed_sec',
+    )
+    partial_too_many = _payload_scalar(
+        payload,
+        'physical_runtime_partial_trend_fallback_too_many',
+    )
 
     if materialized is not None:
         summary['trend_result_materialized'] = bool(int(materialized))
@@ -104,6 +137,22 @@ def _add_trend_runtime_summary_fields(
         summary['trend_result_reason'] = reason_str if reason_str else None
     if legacy_output is not None:
         summary['legacy_trend_output'] = str(legacy_output)
+    if fallback_existing_trend_mode is not None:
+        summary['fallback_existing_trend_mode'] = str(
+            fallback_existing_trend_mode
+        )
+    if partial_enabled is not None:
+        summary['partial_trend_fallback_enabled'] = bool(int(partial_enabled))
+    if partial_n_targets is not None:
+        summary['partial_trend_fallback_n_targets'] = int(partial_n_targets)
+    if partial_n_valid is not None:
+        summary['partial_trend_fallback_n_valid'] = int(partial_n_valid)
+    if partial_n_robust is not None:
+        summary['partial_trend_fallback_n_robust'] = int(partial_n_robust)
+    if partial_elapsed is not None:
+        summary['partial_trend_fallback_elapsed_sec'] = float(partial_elapsed)
+    if partial_too_many is not None:
+        summary['partial_trend_fallback_too_many'] = bool(int(partial_too_many))
 
 
 def _build_unmaterialized_trend(table) -> TrendResult:
@@ -127,17 +176,32 @@ class LazyTrendResultProvider:
         *,
         mode: str,
         build_fn: Callable[[], TrendResult],
+        build_partial_fn: Callable[[np.ndarray], PartialTrendFallbackResult | None]
+        | None = None,
+        fallback_existing_trend_mode: str = 'full',
+        partial_cfg: Any | None = None,
+        n_traces: int | None = None,
         progress: Any,
         progress_context: Mapping[str, object],
     ) -> None:
         self.mode = str(mode)
         self._build_fn = build_fn
+        self._build_partial_fn = build_partial_fn
+        self.fallback_existing_trend_mode = str(fallback_existing_trend_mode)
+        self._partial_cfg = partial_cfg
+        self._n_traces = None if n_traces is None else int(n_traces)
         self._progress = progress
         self._progress_context = dict(progress_context)
         self._trend_result: TrendResult | None = None
+        self._partial_cache: dict[int, tuple[int, np.float32, bool]] = {}
         self.computed = False
         self.reason: str | None = None
         self.elapsed_sec = 0.0
+        self.partial_elapsed_sec = 0.0
+        self.partial_n_targets = 0
+        self.partial_n_valid = 0
+        self.partial_n_robust = 0
+        self.partial_too_many = False
 
     @property
     def trend_result(self) -> TrendResult | None:
@@ -170,6 +234,221 @@ class LazyTrendResultProvider:
                 elapsed=self.elapsed_sec,
             )
         return self._trend_result
+
+    def _partial_too_many(self, n_targets: int) -> bool:
+        partial_cfg = self._partial_cfg
+        if partial_cfg is None:
+            return False
+        if int(n_targets) > int(partial_cfg.max_traces):
+            return True
+        if self._n_traces is None or self._n_traces <= 0:
+            return False
+        return (
+            float(n_targets) / float(self._n_traces)
+            > float(partial_cfg.max_fraction)
+        )
+
+    @staticmethod
+    def _partial_result_from_cache(
+        indices: np.ndarray,
+        cache: Mapping[int, tuple[int, np.float32, bool]],
+    ) -> PartialTrendFallbackResult:
+        requested = np.asarray(indices, dtype=np.int64).reshape(-1)
+        center_i = np.full((requested.size,), -1, dtype=np.int32)
+        center_t_sec = np.full((requested.size,), np.nan, dtype=np.float32)
+        valid = np.zeros((requested.size,), dtype=np.bool_)
+        for pos, trace_idx in enumerate(requested.tolist()):
+            cached_i, cached_t, cached_valid = cache[int(trace_idx)]
+            if bool(cached_valid):
+                center_i[pos] = np.int32(cached_i)
+                center_t_sec[pos] = np.float32(cached_t)
+                valid[pos] = True
+        fallback_to_robust = ~valid
+        return PartialTrendFallbackResult(
+            indices=requested.copy(),
+            center_i=center_i,
+            center_t_sec=center_t_sec,
+            valid_mask=valid,
+            fallback_to_robust_mask=fallback_to_robust.astype(
+                np.bool_,
+                copy=False,
+            ),
+            elapsed_sec=0.0,
+            n_targets=int(requested.size),
+            n_valid=int(np.count_nonzero(valid)),
+            n_robust=int(np.count_nonzero(fallback_to_robust)),
+        )
+
+    def _cache_robust_partial(self, indices: np.ndarray) -> None:
+        for trace_idx in np.asarray(indices, dtype=np.int64).reshape(-1).tolist():
+            self._partial_cache[int(trace_idx)] = (-1, np.float32(np.nan), False)
+
+    def _record_partial_robust_targets(self, n_targets: int) -> None:
+        self.partial_n_targets += int(n_targets)
+        self.partial_n_robust += int(n_targets)
+
+    def record_partial_too_many_robust_fallback(self, n_targets: int) -> None:
+        self.partial_too_many = True
+        self._record_partial_robust_targets(n_targets)
+
+    def get_partial(
+        self,
+        indices: np.ndarray,
+        *,
+        reason: str,
+    ) -> PartialTrendFallbackResult | None:
+        requested = np.asarray(indices, dtype=np.int64).reshape(-1)
+        if requested.size == 0:
+            return self._partial_result_from_cache(requested, self._partial_cache)
+
+        mode = str(self.fallback_existing_trend_mode)
+        if mode == 'full':
+            return None
+        missing = np.asarray(
+            [
+                int(trace_idx)
+                for trace_idx in np.unique(requested)
+                if int(trace_idx) not in self._partial_cache
+            ],
+            dtype=np.int64,
+        )
+        if mode == 'robust':
+            self._cache_robust_partial(missing)
+            return self._partial_result_from_cache(requested, self._partial_cache)
+        if mode != 'partial':
+            return None
+
+        if missing.size > 0:
+            partial_cfg = self._partial_cfg
+            if partial_cfg is not None and not bool(partial_cfg.enabled):
+                return None
+            n_effective_targets = len(self._partial_cache) + int(missing.size)
+            if self._partial_too_many(n_effective_targets):
+                fallback = (
+                    'robust'
+                    if partial_cfg is None
+                    else str(partial_cfg.fallback_if_too_many)
+                )
+                if fallback == 'full':
+                    self.partial_too_many = True
+                    return None
+                if fallback == 'error':
+                    msg = (
+                        'partial trend fallback target count exceeds '
+                        f'configured limits: n_targets={n_effective_targets}'
+                    )
+                    raise RuntimeError(msg)
+                self._cache_robust_partial(missing)
+                self.record_partial_too_many_robust_fallback(int(missing.size))
+                return self._partial_result_from_cache(
+                    requested,
+                    self._partial_cache,
+                )
+
+            if self._build_partial_fn is None:
+                return None
+            emit_progress = (
+                True if partial_cfg is None else bool(partial_cfg.emit_progress)
+            )
+            if emit_progress:
+                self._progress.emit(
+                    'physics.stage_start',
+                    **self._progress_context,
+                    stage='partial_trend_fallback',
+                    lazy=True,
+                    reason=str(reason),
+                    n_targets=int(missing.size),
+                )
+            stage_start = perf_counter()
+            result = self._build_partial_fn(missing)
+            elapsed = perf_counter() - stage_start
+            if result is None:
+                if emit_progress:
+                    self._progress.emit(
+                        'physics.stage_done',
+                        **self._progress_context,
+                        stage='partial_trend_fallback',
+                        lazy=True,
+                        reason=str(reason),
+                        elapsed=elapsed,
+                        n_targets=int(missing.size),
+                        fallback='full',
+                    )
+                return None
+            self.partial_elapsed_sec += float(elapsed)
+            self.partial_n_targets += int(result.n_targets)
+            self.partial_n_valid += int(result.n_valid)
+            self.partial_n_robust += int(result.n_robust)
+            for pos, trace_idx in enumerate(
+                np.asarray(result.indices, dtype=np.int64).reshape(-1).tolist()
+            ):
+                valid = bool(np.asarray(result.valid_mask, dtype=np.bool_)[pos])
+                center_i = int(np.asarray(result.center_i, dtype=np.int64)[pos])
+                center_t = np.float32(
+                    np.asarray(result.center_t_sec, dtype=np.float32)[pos]
+                )
+                self._partial_cache[int(trace_idx)] = (center_i, center_t, valid)
+            if emit_progress:
+                self._progress.emit(
+                    'physics.stage_done',
+                    **self._progress_context,
+                    stage='partial_trend_fallback',
+                    lazy=True,
+                    reason=str(reason),
+                    elapsed=elapsed,
+                    n_targets=int(result.n_targets),
+                    n_valid=int(result.n_valid),
+                    n_robust=int(result.n_robust),
+                )
+        return self._partial_result_from_cache(requested, self._partial_cache)
+
+
+def _partial_trend_fallback_runtime_fields(
+    *,
+    typed_cfg,
+    trend_provider: LazyTrendResultProvider,
+) -> dict[str, np.ndarray]:
+    partial_cfg = typed_cfg.physical_runtime.partial_trend_fallback
+    return {
+        'physical_runtime_fallback_existing_trend_mode': np.asarray(
+            str(typed_cfg.physical_runtime.fallback_existing_trend_mode)
+        ),
+        'physical_runtime_partial_trend_fallback_enabled': np.asarray(
+            int(bool(partial_cfg.enabled)),
+            dtype=np.int64,
+        ),
+        'physical_runtime_partial_trend_fallback_max_fraction': np.asarray(
+            float(partial_cfg.max_fraction),
+            dtype=np.float64,
+        ),
+        'physical_runtime_partial_trend_fallback_max_traces': np.asarray(
+            int(partial_cfg.max_traces),
+            dtype=np.int64,
+        ),
+        'physical_runtime_partial_trend_fallback_fallback_if_too_many': (
+            np.asarray(str(partial_cfg.fallback_if_too_many))
+        ),
+        'physical_runtime_partial_trend_fallback_n_targets': np.asarray(
+            int(trend_provider.partial_n_targets),
+            dtype=np.int64,
+        ),
+        'physical_runtime_partial_trend_fallback_n_valid': np.asarray(
+            int(trend_provider.partial_n_valid),
+            dtype=np.int64,
+        ),
+        'physical_runtime_partial_trend_fallback_n_robust': np.asarray(
+            int(trend_provider.partial_n_robust),
+            dtype=np.int64,
+        ),
+        'physical_runtime_partial_trend_fallback_elapsed_sec': np.asarray(
+            float(trend_provider.partial_elapsed_sec),
+            dtype=np.float64,
+        ),
+        'physical_runtime_partial_trend_fallback_too_many': np.asarray(
+            int(bool(trend_provider.partial_too_many)),
+            dtype=np.int64,
+        ),
+    }
 
 
 def _build_coarse_observed_confidence(table) -> ConfidenceResult:
@@ -317,6 +596,17 @@ def build_robust_payload_from_coarse(
         trend_provider = LazyTrendResultProvider(
             mode=str(typed_cfg.physical_runtime.trend_result_mode),
             build_fn=lambda: build_trend_result(table, feasible, typed_cfg),
+            build_partial_fn=lambda indices: build_partial_trend_fallback(
+                table,
+                feasible,
+                typed_cfg,
+                indices,
+            ),
+            fallback_existing_trend_mode=str(
+                typed_cfg.physical_runtime.fallback_existing_trend_mode
+            ),
+            partial_cfg=typed_cfg.physical_runtime.partial_trend_fallback,
+            n_traces=int(table.n_traces),
             progress=reporter,
             progress_context=progress_fields,
         )
@@ -422,9 +712,26 @@ def build_robust_payload_from_coarse(
                 with runtime_diagnostics.time_block('trend_result_sec'):
                     return build_trend_result(table, feasible, typed_cfg)
 
+            def _build_partial_trend_fallback_for_provider(
+                indices: np.ndarray,
+            ) -> PartialTrendFallbackResult | None:
+                with runtime_diagnostics.time_block('partial_trend_fallback_sec'):
+                    return build_partial_trend_fallback(
+                        table,
+                        feasible,
+                        typed_cfg,
+                        indices,
+                    )
+
             trend_provider = LazyTrendResultProvider(
                 mode=str(typed_cfg.physical_runtime.trend_result_mode),
                 build_fn=_build_trend_result_for_provider,
+                build_partial_fn=_build_partial_trend_fallback_for_provider,
+                fallback_existing_trend_mode=str(
+                    typed_cfg.physical_runtime.fallback_existing_trend_mode
+                ),
+                partial_cfg=typed_cfg.physical_runtime.partial_trend_fallback,
+                n_traces=int(table.n_traces),
                 progress=reporter,
                 progress_context=progress_fields,
             )
@@ -648,6 +955,12 @@ def build_robust_payload_from_coarse(
             iter_id=iter_id,
         ),
     }
+    payload.update(
+        _partial_trend_fallback_runtime_fields(
+            typed_cfg=typed_cfg,
+            trend_provider=trend_provider,
+        )
+    )
     if include_trend_output:
         payload.update(
             {

--- a/packages/seisai-engine/src/seisai_engine/pipelines/fbpick/physics/runtime_diagnostics.py
+++ b/packages/seisai-engine/src/seisai_engine/pipelines/fbpick/physics/runtime_diagnostics.py
@@ -983,6 +983,52 @@ def runtime_summary_from_npz_fields(
         summary['legacy_trend_output'] = str(
             np.asarray(payload['physical_runtime_legacy_trend_output']).item()
         )
+    if 'physical_runtime_fallback_existing_trend_mode' in payload:
+        summary['fallback_existing_trend_mode'] = str(
+            np.asarray(
+                payload['physical_runtime_fallback_existing_trend_mode']
+            ).item()
+        )
+    if 'physical_runtime_partial_trend_fallback_enabled' in payload:
+        summary['partial_trend_fallback_enabled'] = bool(
+            int(
+                np.asarray(
+                    payload['physical_runtime_partial_trend_fallback_enabled']
+                ).item()
+            )
+        )
+    if 'physical_runtime_partial_trend_fallback_n_targets' in payload:
+        summary['partial_trend_fallback_n_targets'] = int(
+            np.asarray(
+                payload['physical_runtime_partial_trend_fallback_n_targets']
+            ).item()
+        )
+    if 'physical_runtime_partial_trend_fallback_n_valid' in payload:
+        summary['partial_trend_fallback_n_valid'] = int(
+            np.asarray(
+                payload['physical_runtime_partial_trend_fallback_n_valid']
+            ).item()
+        )
+    if 'physical_runtime_partial_trend_fallback_n_robust' in payload:
+        summary['partial_trend_fallback_n_robust'] = int(
+            np.asarray(
+                payload['physical_runtime_partial_trend_fallback_n_robust']
+            ).item()
+        )
+    if 'physical_runtime_partial_trend_fallback_elapsed_sec' in payload:
+        summary['partial_trend_fallback_elapsed_sec'] = float(
+            np.asarray(
+                payload['physical_runtime_partial_trend_fallback_elapsed_sec']
+            ).item()
+        )
+    if 'physical_runtime_partial_trend_fallback_too_many' in payload:
+        summary['partial_trend_fallback_too_many'] = bool(
+            int(
+                np.asarray(
+                    payload['physical_runtime_partial_trend_fallback_too_many']
+                ).item()
+            )
+        )
     return summary
 
 

--- a/packages/seisai-engine/src/seisai_engine/pipelines/fbpick/physics/trend.py
+++ b/packages/seisai-engine/src/seisai_engine/pipelines/fbpick/physics/trend.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from time import perf_counter
 
 import numpy as np
 
@@ -8,7 +9,12 @@ from .config import PhysicsLiteConfig
 from .feasible import FeasibleBandResult
 from .pick_table import CoarsePickTable
 
-__all__ = ['TrendResult', 'build_trend_result']
+__all__ = [
+    'PartialTrendFallbackResult',
+    'TrendResult',
+    'build_partial_trend_fallback',
+    'build_trend_result',
+]
 
 
 @dataclass(frozen=True)
@@ -22,6 +28,19 @@ class TrendResult:
     trend_center_sec: np.ndarray
     trend_center_i: np.ndarray
     filled_mask: np.ndarray
+
+
+@dataclass(frozen=True)
+class PartialTrendFallbackResult:
+    indices: np.ndarray
+    center_i: np.ndarray
+    center_t_sec: np.ndarray
+    valid_mask: np.ndarray
+    fallback_to_robust_mask: np.ndarray
+    elapsed_sec: float
+    n_targets: int
+    n_valid: int
+    n_robust: int
 
 
 def _lower_quantile_threshold(values: np.ndarray, frac: float) -> float:
@@ -63,7 +82,10 @@ def _fit_weighted_line(
     yy = np.asarray(y, dtype=np.float64)
     ww = np.asarray(weights, dtype=np.float64)
     if xx.shape != yy.shape or xx.shape != ww.shape or xx.ndim != 1:
-        msg = f'x/y/weights must be 1D and same shape, got {xx.shape}, {yy.shape}, {ww.shape}'
+        msg = (
+            'x/y/weights must be 1D and same shape, '
+            f'got {xx.shape}, {yy.shape}, {ww.shape}'
+        )
         raise ValueError(msg)
 
     valid = np.isfinite(xx) & np.isfinite(yy) & np.isfinite(ww) & (ww > 0.0)
@@ -111,7 +133,8 @@ def _predict_local_center_sec(
     slope, intercept = fit
     slope = float(np.clip(slope, slope_lo, slope_hi))
     intercept = _weighted_median(
-        np.asarray(y_window_sec, dtype=np.float64) - slope * np.asarray(x_window_m, dtype=np.float64),
+        np.asarray(y_window_sec, dtype=np.float64)
+        - slope * np.asarray(x_window_m, dtype=np.float64),
         weight_window,
     )
 
@@ -170,7 +193,10 @@ def _local_inversion_mask(
     center = np.asarray(local_center_i, dtype=np.float32)
     valid = np.asarray(local_valid, dtype=np.bool_)
     if center.shape != valid.shape or center.ndim != 1:
-        msg = f'local_center_i/local_valid must be 1D and same shape, got {center.shape}, {valid.shape}'
+        msg = (
+            'local_center_i/local_valid must be 1D and same shape, '
+            f'got {center.shape}, {valid.shape}'
+        )
         raise ValueError(msg)
     if int(center.shape[0]) < 2:
         return np.zeros(center.shape, dtype=np.bool_)
@@ -253,8 +279,15 @@ def _fill_trend_centers(
     local = np.asarray(local_center_sec, dtype=np.float32)
     valid = np.asarray(local_valid, dtype=np.bool_)
     global_center = np.asarray(global_center_sec, dtype=np.float32)
-    if local.shape != valid.shape or local.shape != global_center.shape or local.ndim != 1:
-        msg = f'local/valid/global must be 1D and same shape, got {local.shape}, {valid.shape}, {global_center.shape}'
+    if (
+        local.shape != valid.shape
+        or local.shape != global_center.shape
+        or local.ndim != 1
+    ):
+        msg = (
+            'local/valid/global must be 1D and same shape, '
+            f'got {local.shape}, {valid.shape}, {global_center.shape}'
+        )
         raise ValueError(msg)
 
     filled = (~valid).astype(np.bool_, copy=False)
@@ -271,6 +304,204 @@ def _fill_trend_centers(
     return global_center.copy(), np.ones(local.shape, dtype=np.bool_)
 
 
+def _empty_partial_trend_fallback(
+    indices: np.ndarray,
+    *,
+    start_sec: float,
+    fallback_to_robust: bool,
+) -> PartialTrendFallbackResult:
+    target = np.asarray(indices, dtype=np.int64)
+    n_targets = int(target.size)
+    valid = np.zeros((n_targets,), dtype=np.bool_)
+    robust = np.full((n_targets,), bool(fallback_to_robust), dtype=np.bool_)
+    return PartialTrendFallbackResult(
+        indices=target.copy(),
+        center_i=np.full((n_targets,), -1, dtype=np.int32),
+        center_t_sec=np.full((n_targets,), np.nan, dtype=np.float32),
+        valid_mask=valid,
+        fallback_to_robust_mask=robust,
+        elapsed_sec=float(perf_counter() - start_sec),
+        n_targets=n_targets,
+        n_valid=0,
+        n_robust=int(np.count_nonzero(robust)),
+    )
+
+
+def build_partial_trend_fallback(
+    table: CoarsePickTable,
+    feasible: FeasibleBandResult,
+    cfg: PhysicsLiteConfig,
+    target_indices: np.ndarray,
+) -> PartialTrendFallbackResult | None:
+    start_sec = perf_counter()
+    targets = np.asarray(target_indices, dtype=np.int64).reshape(-1)
+    if targets.size == 0:
+        return _empty_partial_trend_fallback(
+            targets,
+            start_sec=start_sec,
+            fallback_to_robust=False,
+        )
+    if bool(np.any((targets < 0) | (targets >= int(table.n_traces)))):
+        msg = 'partial trend fallback indices must be within trace bounds'
+        raise IndexError(msg)
+
+    partial_cfg = cfg.physical_runtime.partial_trend_fallback
+    if not bool(partial_cfg.enabled):
+        return None
+
+    n_targets = int(targets.size)
+    too_many = n_targets > int(partial_cfg.max_traces)
+    if int(table.n_traces) > 0:
+        too_many = too_many or (
+            (float(n_targets) / float(table.n_traces))
+            > float(partial_cfg.max_fraction)
+        )
+    if too_many:
+        fallback = str(partial_cfg.fallback_if_too_many)
+        if fallback == 'full':
+            return None
+        if fallback == 'error':
+            msg = (
+                'partial trend fallback target count exceeds configured '
+                f'limits: n_targets={n_targets}'
+            )
+            raise RuntimeError(msg)
+        return _empty_partial_trend_fallback(
+            targets,
+            start_sec=start_sec,
+            fallback_to_robust=True,
+        )
+
+    feasible_mask = np.asarray(feasible.feasible_mask, dtype=np.bool_)
+    if feasible_mask.shape != (table.n_traces,):
+        msg = (
+            f'feasible_mask must have shape {(table.n_traces,)}, '
+            f'got {feasible_mask.shape}'
+        )
+        raise ValueError(msg)
+    pmax = np.clip(np.asarray(table.coarse_pmax, dtype=np.float32), 0.0, 1.0)
+    offset_abs_m = np.abs(np.asarray(table.offset_m, dtype=np.float32)).astype(
+        np.float64,
+        copy=False,
+    )
+    times_sec = np.asarray(table.coarse_pick_t_sec, dtype=np.float32).astype(
+        np.float64,
+        copy=False,
+    )
+    finite_seed = (
+        feasible_mask
+        & np.isfinite(offset_abs_m)
+        & np.isfinite(times_sec)
+        & np.isfinite(pmax)
+    )
+    if not bool(np.any(finite_seed)):
+        return _empty_partial_trend_fallback(
+            targets,
+            start_sec=start_sec,
+            fallback_to_robust=True,
+        )
+    try:
+        seed_threshold = np.float32(
+            _lower_quantile_threshold(
+                pmax[finite_seed],
+                frac=float(cfg.keep_reject.drop_low_frac),
+            )
+        )
+    except ValueError:
+        return _empty_partial_trend_fallback(
+            targets,
+            start_sec=start_sec,
+            fallback_to_robust=True,
+        )
+    seed_mask = finite_seed & (pmax >= seed_threshold)
+    if not bool(np.any(seed_mask)):
+        return _empty_partial_trend_fallback(
+            targets,
+            start_sec=start_sec,
+            fallback_to_robust=True,
+        )
+
+    weights = np.maximum(pmax.astype(np.float64, copy=False), 1.0e-6)
+    slope_lo = 1.0 / float(cfg.trend.trend_local_vmax_mps)
+    slope_hi = 1.0 / float(cfg.trend.trend_local_vmin_mps)
+    local_half_win = int(cfg.trend.trend_local_section_len) * int(
+        cfg.trend.trend_local_stride
+    )
+
+    global_center_sec = np.full((n_targets,), np.nan, dtype=np.float32)
+    if bool(partial_cfg.use_global_fallback):
+        try:
+            global_center_sec = _build_global_center_sec(
+                offset_abs_m=offset_abs_m[seed_mask],
+                seed_times_sec=times_sec[seed_mask],
+                seed_weights=weights[seed_mask],
+                target_offsets_abs_m=offset_abs_m[targets],
+                cfg=cfg,
+            )
+        except (TypeError, ValueError, FloatingPointError):
+            global_center_sec = np.full((n_targets,), np.nan, dtype=np.float32)
+
+    center_i = np.full((n_targets,), -1, dtype=np.int32)
+    center_t_sec = np.full((n_targets,), np.nan, dtype=np.float32)
+    valid = np.zeros((n_targets,), dtype=np.bool_)
+    dt = float(table.dt_scalar_sec)
+    n_samples = int(table.n_samples_orig)
+
+    for pos, trace_idx in enumerate(targets.tolist()):
+        idx = int(trace_idx)
+        pred: float | None = None
+        lo = max(0, idx - local_half_win)
+        hi = min(int(table.n_traces), idx + local_half_win + 1)
+        window_seed = np.flatnonzero(seed_mask[lo:hi]) + lo
+        if int(window_seed.size) >= int(cfg.trend.trend_min_pts):
+            try:
+                pred = _predict_local_center_sec(
+                    x_window_m=offset_abs_m[window_seed],
+                    y_window_sec=times_sec[window_seed],
+                    weight_window=weights[window_seed],
+                    x_target_m=float(offset_abs_m[idx]),
+                    slope_lo=slope_lo,
+                    slope_hi=slope_hi,
+                    huber_c=float(cfg.trend.trend_local_huber_c),
+                    iters=int(cfg.trend.trend_local_iters),
+                )
+            except (TypeError, ValueError, FloatingPointError):
+                pred = None
+
+        global_pred = float(global_center_sec[pos])
+        if pred is not None and np.isfinite(pred) and np.isfinite(global_pred):
+            local_i = float(pred) / dt
+            global_i = global_pred / dt
+            if (
+                abs(local_i - global_i)
+                >= float(cfg.robust_center.local_global_diff_th_samples)
+            ):
+                pred = global_pred
+        if pred is None or not np.isfinite(pred):
+            pred = global_pred if np.isfinite(global_pred) else None
+        if pred is None or not np.isfinite(pred):
+            continue
+
+        sample_i = int(np.rint(float(pred) / dt))
+        sample_i = int(np.clip(sample_i, 0, n_samples - 1))
+        center_i[pos] = np.int32(sample_i)
+        center_t_sec[pos] = np.float32(sample_i * dt)
+        valid[pos] = True
+
+    fallback_to_robust = ~valid
+    return PartialTrendFallbackResult(
+        indices=targets.copy(),
+        center_i=center_i,
+        center_t_sec=center_t_sec,
+        valid_mask=valid,
+        fallback_to_robust_mask=fallback_to_robust.astype(np.bool_, copy=False),
+        elapsed_sec=float(perf_counter() - start_sec),
+        n_targets=n_targets,
+        n_valid=int(np.count_nonzero(valid)),
+        n_robust=int(np.count_nonzero(fallback_to_robust)),
+    )
+
+
 def build_trend_result(
     table: CoarsePickTable,
     feasible: FeasibleBandResult,
@@ -278,7 +509,10 @@ def build_trend_result(
 ) -> TrendResult:
     feasible_mask = np.asarray(feasible.feasible_mask, dtype=np.bool_)
     if feasible_mask.shape != (table.n_traces,):
-        msg = f'feasible_mask must have shape {(table.n_traces,)}, got {feasible_mask.shape}'
+        msg = (
+            f'feasible_mask must have shape {(table.n_traces,)}, '
+            f'got {feasible_mask.shape}'
+        )
         raise ValueError(msg)
 
     pmax = np.clip(np.asarray(table.coarse_pmax, dtype=np.float32), 0.0, 1.0)

--- a/packages/seisai-engine/tests/test_fbpick_physics.py
+++ b/packages/seisai-engine/tests/test_fbpick_physics.py
@@ -65,7 +65,12 @@ from seisai_engine.pipelines.fbpick.physics.runtime_diagnostics import (
     PhysicalRuntimeDiagnostics,
     runtime_summary_from_npz_fields,
 )
-from seisai_engine.pipelines.fbpick.physics.trend import TrendResult, build_trend_result
+from seisai_engine.pipelines.fbpick.physics.trend import (
+    PartialTrendFallbackResult,
+    TrendResult,
+    build_trend_result,
+)
+from seisai_pick.trend.trend_fit_strategy import TwoPieceRansacAutoBreakStrategy
 
 _ANCHOR_OPTIONAL_KEYS = {
     'physical_anchor_group_id',
@@ -455,6 +460,7 @@ def test_load_physics_lite_config_defaults_include_physical_trend_blocks() -> No
     assert cfg.physical_projection.mode == 'model'
     assert cfg.physical_runtime.fit_policy == 'full'
     assert cfg.physical_runtime.trend_result_mode == 'eager'
+    assert cfg.physical_runtime.fallback_existing_trend_mode == 'full'
     assert cfg.physical_runtime.legacy_trend_output == 'auto'
     assert cfg.physical_runtime.geometry_invalid_fallback == 'existing_trend'
     assert cfg.physical_runtime.group_invalid_fallback == 'existing_trend'
@@ -504,6 +510,24 @@ def test_load_physics_lite_config_defaults_include_physical_trend_blocks() -> No
     assert cfg.physical_runtime.fit_executor.max_workers is None
     assert cfg.physical_runtime.fit_executor.torch_num_threads_per_worker == 1
     assert cfg.physical_runtime.fit_executor.chunksize == 1
+    assert cfg.physical_runtime.partial_trend_fallback.enabled is True
+    assert cfg.physical_runtime.partial_trend_fallback.max_fraction == pytest.approx(
+        0.05
+    )
+    assert cfg.physical_runtime.partial_trend_fallback.max_traces == 50_000
+    assert (
+        cfg.physical_runtime.partial_trend_fallback.cluster_consecutive_indices
+        is True
+    )
+    assert cfg.physical_runtime.partial_trend_fallback.use_global_fallback is True
+    assert (
+        cfg.physical_runtime.partial_trend_fallback.fallback_if_too_many == 'robust'
+    )
+    assert (
+        cfg.physical_runtime.partial_trend_fallback.local_window_from_trend_config
+        is True
+    )
+    assert cfg.physical_runtime.partial_trend_fallback.emit_progress is True
     assert cfg.physical_runtime.progress.enabled is False
     assert cfg.physical_runtime.progress.level == 'sgy'
     assert cfg.physical_runtime.progress.interval_sec == 10.0
@@ -592,6 +616,7 @@ def test_load_physics_lite_config_accepts_anchor_selection_runtime_block() -> No
                 'physical_runtime': {
                     'fit_policy': 'anchor_source_xy',
                     'trend_result_mode': 'lazy',
+                    'fallback_existing_trend_mode': 'partial',
                     'geometry_invalid_fallback': 'robust',
                     'group_invalid_fallback': 'robust',
                     'anchor_selection': {
@@ -640,6 +665,13 @@ def test_load_physics_lite_config_accepts_anchor_selection_runtime_block() -> No
                     'torch_num_threads_per_worker': 1,
                     'chunksize': 2,
                 },
+                'partial_trend_fallback': {
+                    'enabled': True,
+                    'max_fraction': 0.2,
+                    'max_traces': 123,
+                    'fallback_if_too_many': 'full',
+                    'emit_progress': False,
+                },
                 'progress': {
                     'enabled': True,
                     'level': 'fit',
@@ -657,6 +689,7 @@ def test_load_physics_lite_config_accepts_anchor_selection_runtime_block() -> No
 
     assert cfg.physical_runtime.fit_policy == 'anchor_source_xy'
     assert cfg.physical_runtime.trend_result_mode == 'lazy'
+    assert cfg.physical_runtime.fallback_existing_trend_mode == 'partial'
     assert cfg.physical_runtime.legacy_trend_output == 'auto'
     assert cfg.physical_runtime.geometry_invalid_fallback == 'robust'
     assert cfg.physical_runtime.group_invalid_fallback == 'robust'
@@ -689,6 +722,12 @@ def test_load_physics_lite_config_accepts_anchor_selection_runtime_block() -> No
     assert cfg.physical_runtime.fit_executor.backend == 'thread'
     assert cfg.physical_runtime.fit_executor.max_workers == 2
     assert cfg.physical_runtime.fit_executor.chunksize == 2
+    assert cfg.physical_runtime.partial_trend_fallback.max_fraction == pytest.approx(
+        0.2
+    )
+    assert cfg.physical_runtime.partial_trend_fallback.max_traces == 123
+    assert cfg.physical_runtime.partial_trend_fallback.fallback_if_too_many == 'full'
+    assert cfg.physical_runtime.partial_trend_fallback.emit_progress is False
     assert cfg.physical_runtime.progress.enabled is True
     assert cfg.physical_runtime.progress.level == 'fit'
     assert cfg.physical_runtime.progress.interval_sec == pytest.approx(0.5)
@@ -783,6 +822,10 @@ def test_physical_center_example_config_enables_physical_trend() -> None:
             'physical_runtime.trend_result_mode',
         ),
         (
+            {'physical_runtime': {'fallback_existing_trend_mode': 'auto'}},
+            'physical_runtime.fallback_existing_trend_mode',
+        ),
+        (
             {'physical_runtime': {'legacy_trend_output': 'compat'}},
             'physical_runtime.legacy_trend_output',
         ),
@@ -831,6 +874,30 @@ def test_physical_center_example_config_enables_physical_trend() -> None:
                 }
             },
             'physical_runtime.anchor_selection.mode',
+        ),
+        (
+            {
+                'physical_runtime': {
+                    'partial_trend_fallback': {'max_fraction': 1.5}
+                }
+            },
+            'physical_runtime.partial_trend_fallback.max_fraction',
+        ),
+        (
+            {
+                'physical_runtime': {
+                    'partial_trend_fallback': {'max_traces': 0}
+                }
+            },
+            'physical_runtime.partial_trend_fallback.max_traces',
+        ),
+        (
+            {
+                'physical_runtime': {
+                    'partial_trend_fallback': {'fallback_if_too_many': 'skip'}
+                }
+            },
+            'physical_runtime.partial_trend_fallback.fallback_if_too_many',
         ),
         (
             {
@@ -1608,7 +1675,15 @@ def test_save_and_load_robust_npz_preserve_prefixed_runtime_scalars(
 ) -> None:
     payload = {
         **_make_robust_payload(),
+        'physical_runtime_fallback_existing_trend_mode': np.asarray('partial'),
         'physical_runtime_n_fit_calls': np.asarray(7, dtype=np.int64),
+        'physical_runtime_partial_trend_fallback_fallback_if_too_many': (
+            np.asarray('robust')
+        ),
+        'physical_runtime_partial_trend_fallback_n_targets': np.asarray(
+            3,
+            dtype=np.int64,
+        ),
         'physical_runtime_ransac_fit_total_sec': np.asarray(1.25, dtype=np.float64),
         'physical_runtime_non_ransac_total_sec': np.asarray(4.5, dtype=np.float64),
     }
@@ -1616,7 +1691,25 @@ def test_save_and_load_robust_npz_preserve_prefixed_runtime_scalars(
     out_path = save_robust_npz(tmp_path / 'runtime_scalars.robust.npz', **payload)
     loaded = load_robust_npz(out_path)
 
+    assert (
+        np.asarray(loaded['physical_runtime_fallback_existing_trend_mode']).item()
+        == 'partial'
+    )
     assert int(np.asarray(loaded['physical_runtime_n_fit_calls']).item()) == 7
+    assert (
+        np.asarray(
+            loaded['physical_runtime_partial_trend_fallback_fallback_if_too_many']
+        ).item()
+        == 'robust'
+    )
+    assert (
+        int(
+            np.asarray(
+                loaded['physical_runtime_partial_trend_fallback_n_targets']
+            ).item()
+        )
+        == 3
+    )
     assert float(
         np.asarray(loaded['physical_runtime_ransac_fit_total_sec']).item()
     ) == pytest.approx(1.25)
@@ -2031,6 +2124,285 @@ def test_run_physics_lite_lazy_existing_trend_fallback_builds_trend_once(
     np.testing.assert_array_equal(robust['trend_center_i'], trend_i)
     np.testing.assert_array_equal(robust['physical_center_i'], trend_i)
     np.testing.assert_array_equal(robust['fine_center_i'], trend_i)
+
+
+def test_run_physics_lite_lazy_partial_existing_trend_fallback_skips_full_trend(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    class NanPredictModel:
+        edges = np.asarray([0.0, 1000.0, 2000.0], dtype=np.float32)
+        coef = np.asarray(
+            [[0.001, 0.02], [0.001, 0.02]],
+            dtype=np.float32,
+        )
+
+        def predict(self, x_abs):
+            return np.full((int(x_abs.numel()),), np.nan, dtype=np.float32)
+
+    def fake_fit(self, *_args, **_kwargs):
+        return NanPredictModel()
+
+    def fail_build_trend(*_args, **_kwargs):
+        raise AssertionError('full trend_result should not be materialized')
+
+    partial_calls: list[np.ndarray] = []
+
+    def fake_build_partial(table, _feasible, _cfg, target_indices):
+        indices = np.asarray(target_indices, dtype=np.int64).reshape(-1)
+        partial_calls.append(indices.copy())
+        center_i = (indices.astype(np.int32) + np.int32(200)).astype(np.int32)
+        center_t = center_i.astype(np.float32) * np.float32(table.dt_scalar_sec)
+        valid = np.ones((indices.size,), dtype=np.bool_)
+        return PartialTrendFallbackResult(
+            indices=indices,
+            center_i=center_i,
+            center_t_sec=center_t,
+            valid_mask=valid,
+            fallback_to_robust_mask=np.zeros((indices.size,), dtype=np.bool_),
+            elapsed_sec=0.0,
+            n_targets=int(indices.size),
+            n_valid=int(indices.size),
+            n_robust=0,
+        )
+
+    monkeypatch.setattr(TwoPieceRansacAutoBreakStrategy, 'fit', fake_fit)
+    monkeypatch.setattr(
+        'seisai_engine.pipelines.fbpick.physics.run.build_trend_result',
+        fail_build_trend,
+    )
+    monkeypatch.setattr(
+        'seisai_engine.pipelines.fbpick.physics.run.build_partial_trend_fallback',
+        fake_build_partial,
+    )
+
+    n_traces = 24
+    offsets_m = np.linspace(50.0, 1200.0, n_traces, dtype=np.float32)
+    coarse_pick_i = np.arange(80, 80 + n_traces, dtype=np.int32)
+    coarse_path = save_coarse_npz(
+        tmp_path / 'lazy_partial_existing_trend_fallback.coarse.npz',
+        **_make_coarse_payload(
+            coarse_pick_i=coarse_pick_i,
+            coarse_pmax=np.full((n_traces,), 0.95, dtype=np.float32),
+            offsets_m=offsets_m,
+        ),
+        **_make_physical_geometry(offsets_m),
+    )
+    progress = _RecordingProgressReporter()
+
+    out_path = run_physics_lite(
+        coarse_path,
+        cfg={
+            'physical_trend': {
+                'enabled': True,
+                'segment_by_offset_sign': False,
+                'split_by_offset_gap': False,
+            },
+            'neighbor_context': {'enabled': False},
+            'physical_prefilter': {'enabled': False},
+            'two_piece_ransac': {'min_pts': 3, 'seed': 7},
+            'physical_runtime': {
+                'trend_result_mode': 'lazy',
+                'fallback_existing_trend_mode': 'partial',
+                'partial_trend_fallback': {
+                    'enabled': True,
+                    'max_fraction': 1.0,
+                    'max_traces': 1000,
+                    'fallback_if_too_many': 'robust',
+                },
+                'progress': {'enabled': True, 'level': 'stage'},
+            },
+        },
+        source_model_id='coarse-model',
+        iter_id='',
+        repo_root=tmp_path,
+        progress=progress,
+    )
+
+    robust = load_robust_npz(out_path)
+    summary = json.loads(
+        derive_physics_runtime_summary_path(out_path).read_text(encoding='utf-8')
+    )
+    stage_starts = [
+        fields.get('stage')
+        for event, fields in progress.events
+        if event == 'physics.stage_start'
+    ]
+
+    assert partial_calls
+    assert len(partial_calls) == 1
+    np.testing.assert_array_equal(partial_calls[0], np.arange(n_traces, dtype=np.int64))
+    assert 'trend_result' not in stage_starts
+    assert 'partial_trend_fallback' in stage_starts
+    assert (
+        int(np.asarray(robust['physical_runtime_trend_result_materialized']).item())
+        == 0
+    )
+    assert (
+        np.asarray(robust['physical_runtime_fallback_existing_trend_mode']).item()
+        == 'partial'
+    )
+    assert (
+        int(
+            np.asarray(
+                robust['physical_runtime_partial_trend_fallback_enabled']
+            ).item()
+        )
+        == 1
+    )
+    assert (
+        int(
+            np.asarray(
+                robust['physical_runtime_partial_trend_fallback_n_targets']
+            ).item()
+        )
+        == n_traces
+    )
+    assert (
+        int(
+            np.asarray(
+                robust['physical_runtime_partial_trend_fallback_n_valid']
+            ).item()
+        )
+        == n_traces
+    )
+    assert (
+        int(
+            np.asarray(
+                robust['physical_runtime_partial_trend_fallback_n_robust']
+            ).item()
+        )
+        == 0
+    )
+    assert (
+        int(
+            np.asarray(
+                robust['physical_runtime_partial_trend_fallback_too_many']
+            ).item()
+        )
+        == 0
+    )
+    assert summary['trend_result_computed'] is False
+    assert summary['fallback_existing_trend_mode'] == 'partial'
+    assert summary['partial_trend_fallback_enabled'] is True
+    assert summary['partial_trend_fallback_n_targets'] == n_traces
+    assert summary['partial_trend_fallback_n_valid'] == n_traces
+    assert summary['partial_trend_fallback_n_robust'] == 0
+    assert summary['partial_trend_fallback_elapsed_sec'] >= 0.0
+    assert summary['partial_trend_fallback_too_many'] is False
+    np.testing.assert_array_equal(
+        robust['trend_center_i'],
+        np.full((n_traces,), -1, dtype=np.int32),
+    )
+    np.testing.assert_array_equal(
+        robust['physical_center_i'],
+        np.arange(200, 200 + n_traces, dtype=np.int32),
+    )
+    assert np.all(
+        robust['physical_model_status']
+        == np.uint8(PHYSICAL_MODEL_STATUS_FALLBACK_EXISTING_TREND)
+    )
+
+
+def test_run_physics_lite_lazy_partial_all_trace_too_many_skips_full_trend(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    n_traces = 12
+    coarse_pick_i = np.arange(70, 70 + n_traces, dtype=np.int32)
+    coarse_path = save_coarse_npz(
+        tmp_path / 'lazy_partial_all_trace_too_many.coarse.npz',
+        **_make_coarse_payload(
+            coarse_pick_i=coarse_pick_i,
+            coarse_pmax=np.full((n_traces,), 0.95, dtype=np.float32),
+            offsets_m=np.linspace(50.0, 400.0, n_traces, dtype=np.float32),
+        ),
+    )
+    progress = _RecordingProgressReporter()
+
+    def fail_build_trend(*_args, **_kwargs):
+        raise AssertionError('trend_result should not be materialized')
+
+    monkeypatch.setattr(
+        'seisai_engine.pipelines.fbpick.physics.run.build_trend_result',
+        fail_build_trend,
+    )
+
+    out_path = run_physics_lite(
+        coarse_path,
+        cfg={
+            'physical_trend': {
+                'enabled': True,
+                'fit_kind': 'two_piece_irls_autobreak',
+                'use_geometry_offset': True,
+            },
+            'physical_runtime': {
+                'trend_result_mode': 'lazy',
+                'fallback_existing_trend_mode': 'partial',
+                'geometry_invalid_fallback': 'existing_trend',
+                'partial_trend_fallback': {
+                    'enabled': True,
+                    'max_fraction': 0.01,
+                    'max_traces': 1,
+                    'fallback_if_too_many': 'robust',
+                },
+                'progress': {'enabled': True, 'level': 'stage'},
+            },
+        },
+        source_model_id='coarse-model',
+        iter_id='',
+        repo_root=tmp_path,
+        progress=progress,
+    )
+
+    robust = load_robust_npz(out_path)
+    summary = json.loads(
+        derive_physics_runtime_summary_path(out_path).read_text(encoding='utf-8')
+    )
+    stage_starts = [
+        fields.get('stage')
+        for event, fields in progress.events
+        if event == 'physics.stage_start'
+    ]
+
+    assert 'trend_result' not in stage_starts
+    assert (
+        int(np.asarray(robust['physical_runtime_trend_result_materialized']).item())
+        == 0
+    )
+    assert (
+        int(
+            np.asarray(
+                robust['physical_runtime_partial_trend_fallback_n_targets']
+            ).item()
+        )
+        == n_traces
+    )
+    assert (
+        int(
+            np.asarray(
+                robust['physical_runtime_partial_trend_fallback_n_robust']
+            ).item()
+        )
+        == n_traces
+    )
+    assert (
+        int(
+            np.asarray(
+                robust['physical_runtime_partial_trend_fallback_too_many']
+            ).item()
+        )
+        == 1
+    )
+    assert summary['fallback_existing_trend_mode'] == 'partial'
+    assert summary['partial_trend_fallback_n_targets'] == n_traces
+    assert summary['partial_trend_fallback_n_robust'] == n_traces
+    assert summary['partial_trend_fallback_too_many'] is True
+    np.testing.assert_array_equal(
+        robust['trend_center_i'],
+        np.full((n_traces,), -1, dtype=np.int32),
+    )
+    np.testing.assert_array_equal(robust['physical_center_i'], coarse_pick_i)
 
 
 def test_run_physics_lite_lazy_geometry_invalid_robust_skips_trend_result(


### PR DESCRIPTION
Closes #142

## Summary
- Issue: `fallback_existing_trend` を全SGY trend materializationではなく、失敗traceだけの partial trend fallback にする

## Changed files
- `packages/seisai-engine/src/seisai_engine/pipelines/fbpick/common/io.py`
- `packages/seisai-engine/src/seisai_engine/pipelines/fbpick/physics/config.py`
- `packages/seisai-engine/src/seisai_engine/pipelines/fbpick/physics/physical_center.py`
- `packages/seisai-engine/src/seisai_engine/pipelines/fbpick/physics/run.py`
- `packages/seisai-engine/src/seisai_engine/pipelines/fbpick/physics/runtime_diagnostics.py`
- `packages/seisai-engine/src/seisai_engine/pipelines/fbpick/physics/trend.py`
- `packages/seisai-engine/tests/test_fbpick_physics.py`

## Checks
- `.work/codex/checks.log`: 1177 passed, 5 warnings in 92.10s (0:01:32)

## Review
- `.work/codex/review.txt`: accept: yes
- findings: blocker 0, major 0, minor 2
