### PR TITLE
Batch: address issues #150-#154

### DIFF
--- a/packages/seisai-engine/src/seisai_engine/pipelines/fbpick/physics/physical_center.py
+++ b/packages/seisai-engine/src/seisai_engine/pipelines/fbpick/physics/physical_center.py
@@ -6,7 +6,6 @@ from contextlib import nullcontext
 from dataclasses import dataclass
 
 import numpy as np
-import torch
 
 from .config import PhysicsLiteConfig
 from .feasible import FeasibleBandResult, compute_velocity_t0_band_from_arrays
@@ -47,7 +46,6 @@ from .physical_center_fit import (
     _FitTaskResult,
     _limit_selected_positions,
     _median_time_position,
-    _model_diagnostics,
     _offset_spread_failure_reason,
     _PhysicalFitStrategy,
     _run_fit_task,
@@ -56,7 +54,6 @@ from .physical_center_fit import (
     _set_fit_worker_torch_num_threads,
     _stable_observation_seed,
     _strategy_from_fit_task_cfg,
-    _tensor_to_numpy,
 )
 from .physical_center_geometry import (
     _signed_offset_side_labels,
@@ -94,6 +91,20 @@ from .physical_center_observation import (
 )
 from .physical_center_observation import (
     _build_observation_plan as _build_observation_plan_with_min_obs,
+)
+from .physical_center_prediction import (
+    _assign_model_diagnostics,
+    _assign_model_diagnostics_batch,
+    _assign_model_prediction,
+    _assign_model_prediction_batch,
+    _assign_prepared_model_prediction_batch,
+    _diagnostics_for_plan,
+    _predict_model_array_sec,
+    _predict_model_sec,
+    _shift_for_trace_indices,
+    _status_for_plan_batch,
+    _TraceFitResult,
+    _TracePlanAssignment,
 )
 from .physical_center_types import (
     PHYSICAL_MODEL_FAILURE_FIT_FAILED,
@@ -139,12 +150,19 @@ from .trend import TrendResult
 
 _PHYSICAL_CENTER_PRIVATE_COMPAT = (
     _append_index,
+    _assign_model_diagnostics,
+    _assign_model_diagnostics_batch,
+    _assign_model_prediction,
+    _assign_model_prediction_batch,
+    _assign_prepared_model_prediction_batch,
     _bin_representative_position,
     _build_gap_segment_context,
     _build_side_observation_context,
     _concat_group_traces,
+    _diagnostics_for_plan,
     _evenly_spaced_positions,
     _filtered_obs_key,
+    _fit_cache_key,
     _fit_strategy_model,
     _FitTaskCfgValues,
     _GapSegmentContext,
@@ -159,6 +177,8 @@ _PHYSICAL_CENTER_PRIVATE_COMPAT = (
     _obs_with_target_side,
     _obs_with_target_signed_offset_side,
     _offset_spread_failure_reason,
+    _predict_model_array_sec,
+    _predict_model_sec,
     _run_fit_task,
     _select_group_ids,
     _set_fit_worker_torch_num_threads,
@@ -169,7 +189,11 @@ _PHYSICAL_CENTER_PRIVATE_COMPAT = (
     _stable_unique,
     _stable_observation_seed,
     _strategy_from_fit_task_cfg,
+    _shift_for_trace_indices,
+    _status_for_plan_batch,
     _trace_position_map,
+    _TraceFitResult,
+    _TracePlanAssignment,
     signed_offset_side_from_geometry,
     split_offset_gap_segments,
 )
@@ -209,23 +233,6 @@ __all__ = [
     'build_geometry_two_piece_physical_center',
     'preflight_geometry_two_piece_fallback',
 ]
-
-@dataclass(frozen=True)
-class _TraceFitResult:
-    plan: _ObservationPlan | None
-    trend_model: object | None
-    diagnostics: tuple[float, float, float, float, float, float, float] | None
-    x_obs: np.ndarray | None = None
-    y_obs: np.ndarray | None = None
-
-
-@dataclass(frozen=True)
-class _TracePlanAssignment:
-    trace_idx: int
-    plan: _ObservationPlan
-    fit_key: tuple[int, ...]
-    obs_count_before_sampling: int
-
 
 @dataclass(frozen=True)
 class _FitContextWorkItem:
@@ -348,259 +355,6 @@ def _build_observation_plan(
         runtime_diagnostics=runtime_diagnostics,
         plan_cache=plan_cache,
     )
-
-
-def _predict_model_sec(trend_model, offset_m: float) -> float:
-    pred = trend_model.predict(torch.tensor([float(offset_m)], dtype=torch.float32))
-    pred_np = _tensor_to_numpy(pred).astype(np.float64, copy=False)
-    if pred_np.shape != (1,):
-        msg = f'trend model prediction must have shape (1,), got {pred_np.shape}'
-        raise ValueError(msg)
-    return float(pred_np[0])
-
-
-def _predict_model_array_sec(trend_model, offset_m: np.ndarray) -> np.ndarray:
-    offsets = np.asarray(offset_m, dtype=np.float32)
-    if offsets.ndim != 1:
-        msg = 'offset_m must be 1D'
-        raise ValueError(msg)
-    if offsets.size == 0:
-        return np.zeros((0,), dtype=np.float64)
-    pred = trend_model.predict(torch.as_tensor(offsets, dtype=torch.float32))
-    pred_np = _tensor_to_numpy(pred).astype(np.float64, copy=False)
-    if pred_np.shape != offsets.shape:
-        msg = (
-            'trend model prediction must have shape '
-            f'{offsets.shape}, got {pred_np.shape}'
-        )
-        raise ValueError(msg)
-    return pred_np
-
-
-def _diagnostics_for_plan(
-    *,
-    plan: _ObservationPlan,
-    x_obs: np.ndarray,
-    y_obs: np.ndarray,
-    cache: dict[tuple[int, ...], _FitCacheEntry],
-) -> tuple[float, float, float, float, float, float, float] | None:
-    cache_key = _fit_cache_key(plan)
-    entry = cache[cache_key]
-    if bool(entry.fit_failed) or entry.model is None:
-        return None
-    if bool(entry.diagnostics_computed):
-        return entry.diagnostics
-
-    try:
-        diagnostics = _model_diagnostics(
-            entry.model,
-            obs_offsets_m=x_obs,
-            obs_times_sec=y_obs,
-        )
-    except (TypeError, ValueError, RuntimeError):
-        diagnostics = None
-    cache[cache_key] = _FitCacheEntry(
-        model=entry.model,
-        diagnostics=diagnostics,
-        fit_failed=False,
-        diagnostics_computed=True,
-        failure_reason=entry.failure_reason,
-    )
-    return diagnostics
-
-
-def _assign_model_diagnostics(
-    arrays: dict[str, np.ndarray],
-    trace_idx: int,
-    diagnostics: tuple[float, float, float, float, float, float, float] | None,
-) -> None:
-    _assign_model_diagnostics_batch(
-        arrays,
-        np.asarray([int(trace_idx)], dtype=np.int64),
-        diagnostics,
-    )
-
-
-def _assign_model_diagnostics_batch(
-    arrays: dict[str, np.ndarray],
-    trace_indices: np.ndarray,
-    diagnostics: tuple[float, float, float, float, float, float, float] | None,
-) -> None:
-    if diagnostics is None:
-        return
-    indices = np.asarray(trace_indices, dtype=np.int64)
-    if indices.size == 0:
-        return
-    (
-        break_offset,
-        slope_near,
-        slope_far,
-        velocity_near,
-        velocity_far,
-        resid_p50,
-        resid_p90,
-    ) = diagnostics
-    arrays['physical_model_break_offset_m'][indices] = np.float32(break_offset)
-    arrays['physical_model_slope_near_s_per_m'][indices] = np.float32(slope_near)
-    arrays['physical_model_slope_far_s_per_m'][indices] = np.float32(slope_far)
-    arrays['physical_model_velocity_near_m_s'][indices] = np.float32(velocity_near)
-    arrays['physical_model_velocity_far_m_s'][indices] = np.float32(velocity_far)
-    arrays['physical_model_resid_p50_ms'][indices] = np.float32(resid_p50)
-    arrays['physical_model_resid_p90_ms'][indices] = np.float32(resid_p90)
-
-
-def _shift_for_trace_indices(
-    t0_shift_sec: float | np.ndarray,
-    *,
-    trace_indices: np.ndarray,
-    n_traces: int,
-) -> float | np.ndarray:
-    shift = np.asarray(t0_shift_sec, dtype=np.float64)
-    if shift.ndim == 0:
-        return float(shift)
-    if shift.ndim != 1:
-        msg = 't0_shift_sec must be scalar or 1D'
-        raise ValueError(msg)
-    indices = np.asarray(trace_indices, dtype=np.int64)
-    if shift.shape == indices.shape:
-        return shift
-    if int(shift.shape[0]) == int(n_traces):
-        return shift[indices]
-    msg = (
-        't0_shift_sec vector must match trace_indices or full trace count, '
-        f'got {shift.shape[0]} for {indices.size} indices and {n_traces} traces'
-    )
-    raise ValueError(msg)
-
-
-def _status_for_plan_batch(
-    trace_indices: np.ndarray,
-    plan_by_trace: Mapping[int, _ObservationPlan] | _ObservationPlan,
-) -> np.ndarray:
-    indices = np.asarray(trace_indices, dtype=np.int64)
-    if isinstance(plan_by_trace, _ObservationPlan):
-        status = (
-            PHYSICAL_MODEL_STATUS_FALLBACK_RELAXED_SEGMENT
-            if bool(plan_by_trace.relaxed)
-            else PHYSICAL_MODEL_STATUS_TWO_PIECE_OK
-        )
-        return np.full((indices.size,), np.uint8(status), dtype=np.uint8)
-
-    out = np.empty((indices.size,), dtype=np.uint8)
-    for pos, trace_idx in enumerate(indices.tolist()):
-        plan = plan_by_trace[int(trace_idx)]
-        out[pos] = np.uint8(
-            PHYSICAL_MODEL_STATUS_FALLBACK_RELAXED_SEGMENT
-            if bool(plan.relaxed)
-            else PHYSICAL_MODEL_STATUS_TWO_PIECE_OK
-        )
-    return out
-
-
-def _assign_model_prediction_batch(
-    arrays: dict[str, np.ndarray],
-    trace_indices: np.ndarray,
-    *,
-    trend_model,
-    diagnostics: tuple[float, float, float, float, float, float, float] | None,
-    plan_by_trace: Mapping[int, _ObservationPlan] | _ObservationPlan,
-    offset_abs_m: np.ndarray,
-    dt: float,
-    n_samples: int,
-    runtime_fit_source: int,
-    t0_shift_sec: float | np.ndarray = 0.0,
-    runtime_diagnostics: PhysicalRuntimeDiagnostics | None = None,
-) -> np.ndarray:
-    indices = np.asarray(trace_indices, dtype=np.int64)
-    if indices.ndim != 1:
-        msg = 'trace_indices must be 1D'
-        raise ValueError(msg)
-    if indices.size == 0:
-        return np.zeros((0,), dtype=np.bool_)
-
-    if runtime_diagnostics is not None:
-        runtime_diagnostics.inc('n_prediction_calls', int(indices.size))
-        runtime_diagnostics.inc('n_prediction_batches')
-
-    offset_arr = np.asarray(offset_abs_m, dtype=np.float32)
-    with (
-        runtime_diagnostics.time_block('prediction_sec')
-        if runtime_diagnostics is not None
-        else nullcontext()
-    ):
-        try:
-            physical_t_sec = _predict_model_array_sec(
-                trend_model,
-                offset_arr[indices],
-            )
-            shift = _shift_for_trace_indices(
-                t0_shift_sec,
-                trace_indices=indices,
-                n_traces=int(offset_arr.shape[0]),
-            )
-            physical_t_sec = physical_t_sec + shift
-        except (TypeError, ValueError, RuntimeError):
-            physical_t_sec = np.full((indices.size,), np.nan, dtype=np.float64)
-
-    valid = np.isfinite(physical_t_sec)
-    if not bool(np.any(valid)):
-        return valid.astype(np.bool_, copy=False)
-
-    with (
-        runtime_diagnostics.time_block('assignment_sec')
-        if runtime_diagnostics is not None
-        else nullcontext()
-    ):
-        valid_indices = indices[valid]
-        center_i = np.rint(physical_t_sec[valid] / float(dt)).astype(np.int64)
-        center_i = np.clip(center_i, 0, int(n_samples) - 1).astype(np.int32)
-        arrays['physical_center_i'][valid_indices] = center_i
-        arrays['physical_center_t_sec'][valid_indices] = (
-            center_i.astype(np.float64) * float(dt)
-        ).astype(np.float32)
-        arrays['physical_model_status'][valid_indices] = _status_for_plan_batch(
-            valid_indices,
-            plan_by_trace,
-        )
-        arrays['physical_model_failure_reason'][valid_indices] = np.uint8(
-            PHYSICAL_MODEL_FAILURE_NONE
-        )
-        arrays['physical_runtime_fit_source'][valid_indices] = np.uint8(
-            runtime_fit_source
-        )
-        _assign_model_diagnostics_batch(arrays, valid_indices, diagnostics)
-    return valid.astype(np.bool_, copy=False)
-
-
-def _assign_model_prediction(
-    arrays: dict[str, np.ndarray],
-    trace_idx: int,
-    *,
-    trend_model,
-    diagnostics: tuple[float, float, float, float, float, float, float] | None,
-    plan: _ObservationPlan,
-    offset_abs_m: np.ndarray,
-    dt: float,
-    n_samples: int,
-    runtime_fit_source: int,
-    t0_shift_sec: float = 0.0,
-    runtime_diagnostics: PhysicalRuntimeDiagnostics | None = None,
-) -> bool:
-    valid = _assign_model_prediction_batch(
-        arrays,
-        np.asarray([int(trace_idx)], dtype=np.int64),
-        trend_model=trend_model,
-        diagnostics=diagnostics,
-        plan_by_trace=plan,
-        offset_abs_m=offset_abs_m,
-        dt=dt,
-        n_samples=n_samples,
-        runtime_fit_source=runtime_fit_source,
-        t0_shift_sec=t0_shift_sec,
-        runtime_diagnostics=runtime_diagnostics,
-    )
-    return bool(valid[0])
-
 
 def _prepare_trace_plan_assignment(
     *,
@@ -726,91 +480,6 @@ def _prepare_trace_plan_assignment(
         fit_key=fit_key,
         obs_count_before_sampling=obs_count_before_sampling,
     )
-
-
-def _assign_prepared_model_prediction_batch(
-    *,
-    arrays: dict[str, np.ndarray],
-    items: list[tuple[int, _TraceFitResult]],
-    offset_abs_m: np.ndarray,
-    dt: float,
-    n_samples: int,
-    runtime_fit_source: int,
-    table: CoarsePickTable,
-    feasible: FeasibleBandResult,
-    trend: TrendResult,
-    trend_provider: object | None = None,
-    merged: MergeResult,
-    fit_cache: dict[tuple[int, ...], _FitCacheEntry],
-    t0_shift_sec: float | np.ndarray = 0.0,
-    runtime_diagnostics: PhysicalRuntimeDiagnostics | None = None,
-    pending_trend_fallback: _PendingTrendFallback | None = None,
-) -> tuple[np.ndarray, tuple[float, float, float, float, float, float, float] | None]:
-    if not items:
-        return np.zeros((0,), dtype=np.bool_), None
-
-    trace_indices = np.asarray(
-        [trace_idx for trace_idx, _result in items], dtype=np.int64
-    )
-    first_result = items[0][1]
-    if first_result.plan is None or first_result.trend_model is None:
-        msg = 'prepared model assignment requires plan and trend_model'
-        raise ValueError(msg)
-
-    plan_by_trace = {
-        int(trace_idx): result.plan
-        for trace_idx, result in items
-        if result.plan is not None
-    }
-    diagnostics = first_result.diagnostics
-    valid = _assign_model_prediction_batch(
-        arrays,
-        trace_indices,
-        trend_model=first_result.trend_model,
-        diagnostics=diagnostics,
-        plan_by_trace=plan_by_trace,
-        offset_abs_m=offset_abs_m,
-        dt=dt,
-        n_samples=n_samples,
-        runtime_fit_source=runtime_fit_source,
-        t0_shift_sec=t0_shift_sec,
-        runtime_diagnostics=runtime_diagnostics,
-    )
-
-    if bool(np.any(valid)) and diagnostics is None:
-        first_valid_pos = int(np.flatnonzero(valid)[0])
-        first_valid_result = items[first_valid_pos][1]
-        if (
-            first_valid_result.plan is not None
-            and first_valid_result.x_obs is not None
-            and first_valid_result.y_obs is not None
-        ):
-            diagnostics = _diagnostics_for_plan(
-                plan=first_valid_result.plan,
-                x_obs=first_valid_result.x_obs,
-                y_obs=first_valid_result.y_obs,
-                cache=fit_cache,
-            )
-            _assign_model_diagnostics_batch(
-                arrays,
-                trace_indices[valid],
-                diagnostics,
-            )
-
-    for trace_idx in trace_indices[~valid].tolist():
-        _assign_fallback(
-            arrays,
-            int(trace_idx),
-            failure_reason=PHYSICAL_MODEL_FAILURE_PREDICTION_INVALID,
-            table=table,
-            feasible=feasible,
-            trend=trend,
-            trend_provider=trend_provider,
-            merged=merged,
-            pending_trend_fallback=pending_trend_fallback,
-        )
-    return valid, diagnostics
-
 
 def _build_fit_context_work_items(
     grouped_assignments: Mapping[tuple[int, ...], list[_TracePlanAssignment]],

--- a/packages/seisai-engine/src/seisai_engine/pipelines/fbpick/physics/physical_center.py
+++ b/packages/seisai-engine/src/seisai_engine/pipelines/fbpick/physics/physical_center.py
@@ -16,6 +16,11 @@ from .geometry import (
     split_offset_gap_segments,
 )
 from .merge import MergeResult
+from .physical_center_context import (
+    PhysicalCenterBuildContext,
+    PhysicalCenterInputs,
+    PhysicalCenterWorkspace,
+)
 from .physical_center_context_fit import (
     _assign_fit_context_fallback,
     _assign_fit_context_work_item_outcome,
@@ -70,6 +75,7 @@ from .physical_center_fit import (
     _strategy_from_fit_task_cfg,
 )
 from .physical_center_geometry import (
+    PhysicalCenterGeometryContext,
     _signed_offset_side_labels,
     _SignedOffsetSideLabels,
     build_physical_center_geometry_context,
@@ -371,24 +377,20 @@ def _selection_group_maps(
 
 def _fallback_no_compatible_anchor(
     *,
-    arrays: dict[str, np.ndarray],
+    inputs: PhysicalCenterInputs,
+    workspace: PhysicalCenterWorkspace,
     trace_idx: int,
-    table: CoarsePickTable,
-    feasible: FeasibleBandResult,
-    trend: TrendResult,
-    trend_provider: object | None = None,
-    merged: MergeResult,
-    cfg: PhysicsLiteConfig,
-    pending_trend_fallback: _PendingTrendFallback | None = None,
 ) -> None:
+    arrays = workspace.arrays
+    cfg = inputs.cfg
     fallback = str(cfg.physical_runtime.anchor_reuse.fallback_if_no_compatible_segment)
     if fallback == 'robust':
         _assign_robust_fallback(
             arrays,
             trace_idx,
             failure_reason=PHYSICAL_MODEL_FAILURE_PREDICTION_INVALID,
-            table=table,
-            merged=merged,
+            table=inputs.table,
+            merged=inputs.merged,
         )
         return
     _assign_fallback(
@@ -396,12 +398,12 @@ def _fallback_no_compatible_anchor(
         trace_idx,
         failure_reason=PHYSICAL_MODEL_FAILURE_PREDICTION_INVALID,
         runtime_fit_source=PHYSICAL_RUNTIME_FIT_SOURCE_FALLBACK_EXISTING_TREND,
-        table=table,
-        feasible=feasible,
-        trend=trend,
-        trend_provider=trend_provider,
-        merged=merged,
-        pending_trend_fallback=pending_trend_fallback,
+        table=inputs.table,
+        feasible=inputs.feasible,
+        trend=inputs.trend,
+        trend_provider=inputs.trend_provider,
+        merged=inputs.merged,
+        pending_trend_fallback=workspace.pending_trend_fallback,
     )
 
 
@@ -702,6 +704,15 @@ def build_geometry_two_piece_physical_center(
     progress: object | None = None,
     progress_context: Mapping[str, object] | None = None,
 ) -> PhysicalCenterResult:
+    inputs = PhysicalCenterInputs(
+        coarse_npz=coarse_npz,
+        table=table,
+        feasible=feasible,
+        trend=trend,
+        merged=merged,
+        cfg=cfg,
+        trend_provider=trend_provider,
+    )
     reporter = (
         progress
         if progress is not None
@@ -808,11 +819,7 @@ def build_geometry_two_piece_physical_center(
             reason='geometry_invalid',
             fallback_mode=str(cfg.physical_runtime.geometry_invalid_fallback),
             failure_reason=PHYSICAL_MODEL_FAILURE_GEOMETRY_INVALID,
-            table=table,
-            feasible=feasible,
-            trend=trend,
-            trend_provider=trend_provider,
-            merged=merged,
+            inputs=inputs,
             reporter=reporter,
             context=context,
             runtime_diagnostics=runtime_diagnostics,
@@ -856,11 +863,7 @@ def build_geometry_two_piece_physical_center(
             reason='source_xy_degenerate',
             fallback_mode=str(cfg.physical_runtime.geometry_invalid_fallback),
             failure_reason=PHYSICAL_MODEL_FAILURE_GEOMETRY_INVALID,
-            table=table,
-            feasible=feasible,
-            trend=trend,
-            trend_provider=trend_provider,
-            merged=merged,
+            inputs=inputs,
             reporter=reporter,
             context=context,
             runtime_diagnostics=runtime_diagnostics,
@@ -872,11 +875,7 @@ def build_geometry_two_piece_physical_center(
             reason='source_group_empty',
             fallback_mode=str(cfg.physical_runtime.group_invalid_fallback),
             failure_reason=PHYSICAL_MODEL_FAILURE_GEOMETRY_INVALID,
-            table=table,
-            feasible=feasible,
-            trend=trend,
-            trend_provider=trend_provider,
-            merged=merged,
+            inputs=inputs,
             reporter=reporter,
             context=context,
             runtime_diagnostics=runtime_diagnostics,
@@ -910,6 +909,19 @@ def build_geometry_two_piece_physical_center(
         **context,
         stage='source_group_ordering',
         elapsed=time.perf_counter() - stage_start,
+    )
+    geometry_context = PhysicalCenterGeometryContext(
+        geometry=geometry,
+        offset_abs_m=offset_abs_m,
+        offset_signed_m=offset_signed_m,
+        offset_signed_labels=offset_signed_labels,
+        offset_source=offset_source,
+        groups=groups,
+        groups_by_id=groups_by_id,
+        group_id_by_trace=group_id_by_trace,
+        source_grouping_invalid=source_group_build.source_grouping_invalid,
+        source_groups_from_geometry=source_groups_from_geometry,
+        geometry_required_missing=False,
     )
 
     pick_t_sec = _as_vector(
@@ -973,8 +985,23 @@ def build_geometry_two_piece_physical_center(
         contexts=len(group_context_by_id),
     )
 
+    min_fit_obs = 2 * _fit_min_pts(cfg)
+    build_context = PhysicalCenterBuildContext(
+        geometry_context=geometry_context,
+        pick_t_sec=pick_t_sec,
+        valid_for_fit=valid_for_fit,
+        group_context_by_id=group_context_by_id,
+        observation_plan_cache=observation_plan_cache,
+        min_fit_obs=min_fit_obs,
+    )
     arrays = _allocate_result_arrays(table)
     pending_trend_fallback = _PendingTrendFallback()
+    workspace = PhysicalCenterWorkspace(
+        arrays=arrays,
+        fit_cache={},
+        runtime_diagnostics=runtime_diagnostics,
+        pending_trend_fallback=pending_trend_fallback,
+    )
     reporter.emit('physical-center.stage_start', **context, stage='anchor_selection')
     stage_start = time.perf_counter()
     with (
@@ -996,8 +1023,7 @@ def build_geometry_two_piece_physical_center(
         enabled=anchor_selection is not None,
     )
     strategy = _fit_strategy(cfg)
-    fit_cache: dict[tuple[int, ...], _FitCacheEntry] = {}
-    min_fit_obs = 2 * _fit_min_pts(cfg)
+    fit_cache = workspace.fit_cache
 
     if cfg.physical_runtime.fit_policy == 'anchor_source_xy':
         if anchor_selection is None:
@@ -1038,24 +1064,9 @@ def build_geometry_two_piece_physical_center(
         anchor_assignments_by_fit, anchor_assignments = (
             _prepare_fit_context_assignments_for_trace_indices(
                 anchor_trace_indices,
-                arrays=arrays,
-                group_id_by_trace=group_id_by_trace,
-                group_context_by_id=group_context_by_id,
-                geometry=geometry,
-                offset_abs_m=offset_abs_m,
-                offset_signed_m=offset_signed_m,
-                offset_source=offset_source,
-                pick_t_sec=pick_t_sec,
-                table=table,
-                feasible=feasible,
-                trend=trend,
-                trend_provider=trend_provider,
-                merged=merged,
-                cfg=cfg,
-                observation_plan_cache=observation_plan_cache,
-                min_fit_obs=min_fit_obs,
-                runtime_diagnostics=runtime_diagnostics,
-                pending_trend_fallback=pending_trend_fallback,
+                inputs=inputs,
+                build_context=build_context,
+                workspace=workspace,
             )
         )
         anchor_work_items = _build_fit_context_work_items(
@@ -1079,21 +1090,13 @@ def build_geometry_two_piece_physical_center(
         )
         anchor_results = _fit_and_assign_context_work_items(
             anchor_work_items,
-            arrays=arrays,
-            offset_abs_m=offset_abs_m,
-            table=table,
-            feasible=feasible,
-            trend=trend,
-            trend_provider=trend_provider,
-            merged=merged,
-            cfg=cfg,
+            inputs=inputs,
+            build_context=build_context,
+            workspace=workspace,
             strategy=strategy,
-            fit_cache=fit_cache,
-            runtime_diagnostics=runtime_diagnostics,
             progress=reporter,
             progress_context=context,
             fit_model_for_plan=_fit_model_for_plan,
-            pending_trend_fallback=pending_trend_fallback,
         )
         if runtime_diagnostics is not None:
             anchor_fit_call_delta = max(
@@ -1247,39 +1250,18 @@ def build_geometry_two_piece_physical_center(
                     fallback_full_trace_indices.append(trace_idx)
                 else:
                     _fallback_no_compatible_anchor(
-                        arrays=arrays,
+                        inputs=inputs,
+                        workspace=workspace,
                         trace_idx=trace_idx,
-                        table=table,
-                        feasible=feasible,
-                        trend=trend,
-                        trend_provider=trend_provider,
-                        merged=merged,
-                        cfg=cfg,
-                        pending_trend_fallback=pending_trend_fallback,
                     )
 
             if fallback_full_trace_indices:
                 fallback_full_assignments_by_fit, _fallback_full_assignments = (
                     _prepare_fit_context_assignments_for_trace_indices(
                         np.asarray(fallback_full_trace_indices, dtype=np.int64),
-                        arrays=arrays,
-                        group_id_by_trace=group_id_by_trace,
-                        group_context_by_id=group_context_by_id,
-                        geometry=geometry,
-                        offset_abs_m=offset_abs_m,
-                        offset_signed_m=offset_signed_m,
-                        offset_source=offset_source,
-                        pick_t_sec=pick_t_sec,
-                        table=table,
-                        feasible=feasible,
-                        trend=trend,
-                        trend_provider=trend_provider,
-                        merged=merged,
-                        cfg=cfg,
-                        observation_plan_cache=observation_plan_cache,
-                        min_fit_obs=min_fit_obs,
-                        runtime_diagnostics=runtime_diagnostics,
-                        pending_trend_fallback=pending_trend_fallback,
+                        inputs=inputs,
+                        build_context=build_context,
+                        workspace=workspace,
                     )
                 )
                 fallback_full_work_items = _build_fit_context_work_items(
@@ -1300,21 +1282,13 @@ def build_geometry_two_piece_physical_center(
                 )
                 _fit_and_assign_context_work_items(
                     fallback_full_work_items,
-                    arrays=arrays,
-                    offset_abs_m=offset_abs_m,
-                    table=table,
-                    feasible=feasible,
-                    trend=trend,
-                    trend_provider=trend_provider,
-                    merged=merged,
-                    cfg=cfg,
+                    inputs=inputs,
+                    build_context=build_context,
+                    workspace=workspace,
                     strategy=strategy,
-                    fit_cache=fit_cache,
-                    runtime_diagnostics=runtime_diagnostics,
                     progress=reporter,
                     progress_context=context,
                     fit_model_for_plan=_fit_model_for_plan,
-                    pending_trend_fallback=pending_trend_fallback,
                 )
 
             non_anchor_mode = str(cfg.physical_runtime.anchor_reuse.non_anchor_mode)
@@ -1410,24 +1384,9 @@ def build_geometry_two_piece_physical_center(
                 refit_assignments_by_fit, _refit_assignments = (
                     _prepare_fit_context_assignments_for_trace_indices(
                         group_trace_indices,
-                        arrays=arrays,
-                        group_id_by_trace=group_id_by_trace,
-                        group_context_by_id=group_context_by_id,
-                        geometry=geometry,
-                        offset_abs_m=offset_abs_m,
-                        offset_signed_m=offset_signed_m,
-                        offset_source=offset_source,
-                        pick_t_sec=pick_t_sec,
-                        table=table,
-                        feasible=feasible,
-                        trend=trend,
-                        trend_provider=trend_provider,
-                        merged=merged,
-                        cfg=cfg,
-                        observation_plan_cache=observation_plan_cache,
-                        min_fit_obs=min_fit_obs,
-                        runtime_diagnostics=runtime_diagnostics,
-                        pending_trend_fallback=pending_trend_fallback,
+                        inputs=inputs,
+                        build_context=build_context,
+                        workspace=workspace,
                     )
                 )
                 refit_work_items = _build_fit_context_work_items(
@@ -1446,21 +1405,13 @@ def build_geometry_two_piece_physical_center(
                 )
                 refit_results = _fit_and_assign_context_work_items(
                     refit_work_items,
-                    arrays=arrays,
-                    offset_abs_m=offset_abs_m,
-                    table=table,
-                    feasible=feasible,
-                    trend=trend,
-                    trend_provider=trend_provider,
-                    merged=merged,
-                    cfg=cfg,
+                    inputs=inputs,
+                    build_context=build_context,
+                    workspace=workspace,
                     strategy=strategy,
-                    fit_cache=fit_cache,
-                    runtime_diagnostics=runtime_diagnostics,
                     progress=reporter,
                     progress_context=context,
                     fit_model_for_plan=_fit_model_for_plan,
-                    pending_trend_fallback=pending_trend_fallback,
                 )
                 assigned_count = sum(
                     len(result.valid_trace_indices)
@@ -1627,24 +1578,9 @@ def build_geometry_two_piece_physical_center(
     fit_context_assignments, _fit_context_ordered_assignments = (
         _prepare_fit_context_assignments_for_trace_indices(
             np.arange(n, dtype=np.int64),
-            arrays=arrays,
-            group_id_by_trace=group_id_by_trace,
-            group_context_by_id=group_context_by_id,
-            geometry=geometry,
-            offset_abs_m=offset_abs_m,
-            offset_signed_m=offset_signed_m,
-            offset_source=offset_source,
-            pick_t_sec=pick_t_sec,
-            table=table,
-            feasible=feasible,
-            trend=trend,
-            trend_provider=trend_provider,
-            merged=merged,
-            cfg=cfg,
-            observation_plan_cache=observation_plan_cache,
-            min_fit_obs=min_fit_obs,
-            runtime_diagnostics=runtime_diagnostics,
-            pending_trend_fallback=pending_trend_fallback,
+            inputs=inputs,
+            build_context=build_context,
+            workspace=workspace,
         )
     )
     reporter.emit(
@@ -1670,21 +1606,13 @@ def build_geometry_two_piece_physical_center(
     )
     _fit_and_assign_context_work_items(
         work_items,
-        arrays=arrays,
-        offset_abs_m=offset_abs_m,
-        table=table,
-        feasible=feasible,
-        trend=trend,
-        trend_provider=trend_provider,
-        merged=merged,
-        cfg=cfg,
+        inputs=inputs,
+        build_context=build_context,
+        workspace=workspace,
         strategy=strategy,
-        fit_cache=fit_cache,
-        runtime_diagnostics=runtime_diagnostics,
         progress=reporter,
         progress_context=context,
         fit_model_for_plan=_fit_model_for_plan,
-        pending_trend_fallback=pending_trend_fallback,
     )
 
     if runtime_diagnostics is not None:

--- a/packages/seisai-engine/src/seisai_engine/pipelines/fbpick/physics/physical_center.py
+++ b/packages/seisai-engine/src/seisai_engine/pipelines/fbpick/physics/physical_center.py
@@ -2,16 +2,11 @@ from __future__ import annotations
 
 import time
 from collections.abc import Mapping
-from concurrent.futures import ProcessPoolExecutor, ThreadPoolExecutor, as_completed
 from contextlib import nullcontext
 from dataclasses import dataclass
 
 import numpy as np
 import torch
-from seisai_pick.trend.trend_fit_strategy import (
-    TwoPieceIRLSAutoBreakStrategy,
-    TwoPieceRansacAutoBreakStrategy,
-)
 
 from .config import PhysicsLiteConfig
 from .feasible import FeasibleBandResult, compute_velocity_t0_band_from_arrays
@@ -32,6 +27,36 @@ from .physical_center_fallback import (
     _emit_fallback_all_and_done,
     _finalize_result_with_pending_trend_fallback,
     _PendingTrendFallback,
+)
+from .physical_center_fit import (
+    _bin_representative_position,
+    _confidence_weights_for_obs,
+    _evenly_spaced_positions,
+    _fit_cache_key,
+    _fit_key_for_obs,
+    _fit_min_pts,
+    _fit_model_for_plan,
+    _fit_progress_fields,
+    _fit_strategy,
+    _fit_strategy_model,
+    _fit_task_cfg_values,
+    _fit_task_from_work_item,
+    _FitCacheEntry,
+    _FitTask,
+    _FitTaskCfgValues,
+    _FitTaskResult,
+    _limit_selected_positions,
+    _median_time_position,
+    _model_diagnostics,
+    _offset_spread_failure_reason,
+    _PhysicalFitStrategy,
+    _run_fit_task,
+    _run_fit_tasks_with_executor,
+    _sample_observation_indices_for_fit,
+    _set_fit_worker_torch_num_threads,
+    _stable_observation_seed,
+    _strategy_from_fit_task_cfg,
+    _tensor_to_numpy,
 )
 from .physical_center_geometry import (
     _signed_offset_side_labels,
@@ -114,24 +139,36 @@ from .trend import TrendResult
 
 _PHYSICAL_CENTER_PRIVATE_COMPAT = (
     _append_index,
+    _bin_representative_position,
     _build_gap_segment_context,
     _build_side_observation_context,
     _concat_group_traces,
+    _evenly_spaced_positions,
     _filtered_obs_key,
+    _fit_strategy_model,
+    _FitTaskCfgValues,
     _GapSegmentContext,
     _gap_context_key,
+    _indices_key,
     _index_key_contains,
+    _limit_selected_positions,
+    _median_time_position,
     _obs_key_or_build,
     _obs_with_target_gap_segment,
     _obs_with_target_labeled_side,
     _obs_with_target_side,
     _obs_with_target_signed_offset_side,
+    _offset_spread_failure_reason,
+    _run_fit_task,
     _select_group_ids,
+    _set_fit_worker_torch_num_threads,
     _SideObservationContext,
     _side_slot,
     _signed_offset_side_labels,
     _SignedOffsetSideLabels,
     _stable_unique,
+    _stable_observation_seed,
+    _strategy_from_fit_task_cfg,
     _trace_position_map,
     signed_offset_side_from_geometry,
     split_offset_gap_segments,
@@ -174,15 +211,6 @@ __all__ = [
 ]
 
 @dataclass(frozen=True)
-class _FitCacheEntry:
-    model: object | None
-    diagnostics: tuple[float, float, float, float, float, float, float] | None
-    fit_failed: bool
-    diagnostics_computed: bool = False
-    failure_reason: int | None = None
-
-
-@dataclass(frozen=True)
 class _TraceFitResult:
     plan: _ObservationPlan | None
     trend_model: object | None
@@ -217,47 +245,6 @@ class _FitContextWorkResult:
     trend_model: object | None
     diagnostics: tuple[float, float, float, float, float, float, float] | None
     valid_trace_indices: frozenset[int]
-
-
-@dataclass(frozen=True)
-class _FitTaskCfgValues:
-    fit_kind: str
-    n_iter: int
-    inlier_th_ms: float
-    irls_huber_c: float
-    irls_iters: int
-    min_pts: int
-    n_break_cand: int
-    q_lo: float
-    q_hi: float
-    seed: int
-    slope_eps: float
-    sort_offsets: bool
-    min_offset_spread_m: float
-    torch_num_threads_per_worker: int
-
-
-@dataclass(frozen=True)
-class _FitTask:
-    fit_key: tuple[int, ...]
-    x_obs: np.ndarray
-    y_obs: np.ndarray
-    w_obs: np.ndarray
-    obs_count_before_sampling: int
-    cfg_values: _FitTaskCfgValues
-
-
-@dataclass(frozen=True)
-class _FitTaskResult:
-    fit_key: tuple[int, ...]
-    trend_model: object | None
-    diagnostics: tuple[float, float, float, float, float, float, float] | None
-    fit_failed: bool
-    failure_reason: int | None
-    elapsed_sec: float
-    obs_count: int
-    obs_count_before_sampling: int
-    fit_attempted: bool
 
 
 @dataclass(frozen=True)
@@ -334,21 +321,6 @@ def _apply_anchor_selection_diagnostics(
     return result
 
 
-def _tensor_to_numpy(value) -> np.ndarray:
-    if hasattr(value, 'detach'):
-        return value.detach().cpu().numpy()
-    return np.asarray(value)
-
-
-_PhysicalFitStrategy = TwoPieceRansacAutoBreakStrategy | TwoPieceIRLSAutoBreakStrategy
-
-
-def _fit_min_pts(cfg: PhysicsLiteConfig) -> int:
-    if cfg.physical_trend.fit_kind == 'two_piece_irls_autobreak':
-        return int(cfg.two_piece_irls.min_pts)
-    return int(cfg.two_piece_ransac.min_pts)
-
-
 def _build_observation_plan(
     *,
     trace_idx: int,
@@ -378,238 +350,6 @@ def _build_observation_plan(
     )
 
 
-def _fit_strategy(cfg: PhysicsLiteConfig) -> _PhysicalFitStrategy:
-    if cfg.physical_trend.fit_kind == 'two_piece_irls_autobreak':
-        return TwoPieceIRLSAutoBreakStrategy(
-            huber_c=float(cfg.two_piece_irls.huber_c),
-            iters=int(cfg.two_piece_irls.iters),
-            min_pts=int(cfg.two_piece_irls.min_pts),
-            n_break_cand=int(cfg.two_piece_irls.n_break_cand),
-            q_lo=float(cfg.two_piece_irls.q_lo),
-            q_hi=float(cfg.two_piece_irls.q_hi),
-            slope_eps=float(cfg.two_piece_irls.slope_eps),
-            sort_offsets=bool(cfg.two_piece_irls.sort_offsets),
-        )
-    return TwoPieceRansacAutoBreakStrategy(
-        n_iter=int(cfg.two_piece_ransac.n_iter),
-        inlier_th_ms=float(cfg.two_piece_ransac.inlier_th_ms),
-        min_pts=int(cfg.two_piece_ransac.min_pts),
-        n_break_cand=int(cfg.two_piece_ransac.n_break_cand),
-        q_lo=float(cfg.two_piece_ransac.q_lo),
-        q_hi=float(cfg.two_piece_ransac.q_hi),
-        seed=int(cfg.two_piece_ransac.seed),
-        slope_eps=float(cfg.two_piece_ransac.slope_eps),
-        sort_offsets=bool(cfg.two_piece_ransac.sort_offsets),
-    )
-
-
-def _confidence_weights_for_obs(coarse_pmax_obs: np.ndarray) -> np.ndarray:
-    w = np.asarray(coarse_pmax_obs, dtype=np.float32)
-    if w.ndim != 1:
-        w = w.reshape(-1)
-    good = np.isfinite(w) & (w > np.float32(0.0))
-    if not bool(np.any(good)):
-        return np.ones_like(w, dtype=np.float32)
-    fill = np.float32(np.median(w[good].astype(np.float64, copy=False)))
-    out = np.where(good, w, fill).astype(np.float32, copy=False)
-    return np.clip(out, np.float32(1.0e-6), None)
-
-
-def _fit_strategy_model(
-    strategy: _PhysicalFitStrategy,
-    x_tensor: torch.Tensor,
-    y_tensor: torch.Tensor,
-    w_tensor: torch.Tensor,
-):
-    if isinstance(strategy, TwoPieceIRLSAutoBreakStrategy):
-        return strategy.fit(x_tensor, y_tensor, w_tensor)
-    return strategy.fit(x_tensor, y_tensor)
-
-
-def _median_time_position(local_positions: np.ndarray, y_obs: np.ndarray) -> int:
-    positions = np.asarray(local_positions, dtype=np.int64)
-    if positions.size == 0:
-        msg = 'local_positions must be non-empty'
-        raise ValueError(msg)
-    y_values = np.asarray(y_obs, dtype=np.float32)[positions]
-    finite = np.isfinite(y_values)
-    if not np.any(finite):
-        return int(positions[0])
-    finite_positions = positions[finite]
-    finite_y = y_values[finite]
-    median_y = float(np.median(finite_y.astype(np.float64, copy=False)))
-    return int(finite_positions[int(np.argmin(np.abs(finite_y - median_y)))])
-
-
-def _stable_observation_seed(seed: int, values: np.ndarray, *, bin_id: int) -> int:
-    acc = int(seed) & 0xFFFFFFFF
-    for value in np.asarray(values, dtype=np.int64).tolist():
-        acc = (acc * 1664525 + int(value) + 1013904223) & 0xFFFFFFFF
-    return int((acc + int(bin_id) * 374761393) & 0xFFFFFFFF)
-
-
-def _bin_representative_position(
-    *,
-    local_positions: np.ndarray,
-    obs_indices: np.ndarray,
-    y_obs: np.ndarray,
-    p_obs: np.ndarray | None,
-    bin_pick: str,
-    random_seed: int,
-    bin_id: int,
-) -> int:
-    positions = np.asarray(local_positions, dtype=np.int64)
-    if positions.size == 0:
-        msg = 'local_positions must be non-empty'
-        raise ValueError(msg)
-    if bin_pick == 'median_time':
-        return _median_time_position(positions, y_obs)
-    if bin_pick == 'random':
-        seed = _stable_observation_seed(
-            random_seed,
-            np.asarray(obs_indices, dtype=np.int64)[positions],
-            bin_id=int(bin_id),
-        )
-        rng = np.random.default_rng(seed)
-        return int(positions[int(rng.integers(0, int(positions.size)))])
-
-    if p_obs is not None:
-        p_values = np.asarray(p_obs, dtype=np.float32)[positions]
-        finite = np.isfinite(p_values)
-        if np.any(finite):
-            finite_positions = positions[finite]
-            finite_p = p_values[finite]
-            return int(finite_positions[int(np.argmax(finite_p))])
-    return _median_time_position(positions, y_obs)
-
-
-def _evenly_spaced_positions(length: int, count: int) -> np.ndarray:
-    n = int(length)
-    k = int(count)
-    if k <= 0:
-        return np.zeros((0,), dtype=np.int64)
-    if k >= n:
-        return np.arange(n, dtype=np.int64)
-    raw = np.linspace(0.0, float(n - 1), num=k)
-    used: set[int] = set()
-    out: list[int] = []
-    for value in raw.tolist():
-        pos = int(np.rint(float(value)))
-        if pos in used:
-            for delta in range(1, n):
-                left = pos - delta
-                right = pos + delta
-                if left >= 0 and left not in used:
-                    pos = left
-                    break
-                if right < n and right not in used:
-                    pos = right
-                    break
-        used.add(pos)
-        out.append(pos)
-    return np.asarray(sorted(out), dtype=np.int64)
-
-
-def _limit_selected_positions(
-    selected_count: int,
-    *,
-    max_count: int,
-    preserve_edge_bins: bool,
-) -> np.ndarray:
-    n = int(selected_count)
-    max_n = int(max_count)
-    if n <= max_n:
-        return np.arange(n, dtype=np.int64)
-    if bool(preserve_edge_bins) and max_n >= 2 and n >= 2:
-        interior_count = max_n - 2
-        interior = _evenly_spaced_positions(n - 2, interior_count) + 1
-        return np.concatenate(
-            [
-                np.asarray([0], dtype=np.int64),
-                interior,
-                np.asarray([n - 1], dtype=np.int64),
-            ]
-        )
-    return _evenly_spaced_positions(n, max_n)
-
-
-def _sample_observation_indices_for_fit(
-    *,
-    obs_indices: np.ndarray,
-    offset_abs_m: np.ndarray,
-    pick_t_sec: np.ndarray,
-    coarse_pmax: np.ndarray | None,
-    cfg: PhysicsLiteConfig,
-    min_required_obs: int = 0,
-) -> np.ndarray:
-    sampling = cfg.physical_runtime.observation_sampling
-    obs = np.asarray(obs_indices, dtype=np.int64)
-    insufficient = np.zeros((0,), dtype=np.int64)
-    if not bool(sampling.enabled):
-        return obs
-    max_obs = int(sampling.max_obs_per_fit)
-    if int(obs.size) <= max_obs:
-        return obs
-
-    x_obs = np.asarray(offset_abs_m, dtype=np.float32)[obs]
-    y_obs = np.asarray(pick_t_sec, dtype=np.float32)[obs]
-    finite = np.isfinite(x_obs) & np.isfinite(y_obs)
-    finite_positions = np.flatnonzero(finite).astype(np.int64, copy=False)
-    if int(finite_positions.size) == 0:
-        return obs
-
-    finite_x = x_obs[finite_positions]
-    x_min = float(np.min(finite_x))
-    x_max = float(np.max(finite_x))
-    if (not np.isfinite(x_min)) or (not np.isfinite(x_max)) or x_max <= x_min:
-        return obs
-
-    n_bins = min(int(sampling.n_offset_bins), int(finite_positions.size))
-    edges = np.linspace(x_min, x_max, num=n_bins + 1, dtype=np.float64)
-    bin_ids = np.searchsorted(edges, finite_x.astype(np.float64), side='right') - 1
-    bin_ids = np.clip(bin_ids, 0, n_bins - 1).astype(np.int64, copy=False)
-
-    p_obs = (
-        None
-        if coarse_pmax is None
-        else np.asarray(coarse_pmax, dtype=np.float32)[obs]
-    )
-    selected_positions: list[int] = []
-    for bin_id in range(n_bins):
-        in_bin = finite_positions[bin_ids == int(bin_id)]
-        if int(in_bin.size) == 0:
-            continue
-        selected_positions.append(
-            _bin_representative_position(
-                local_positions=in_bin,
-                obs_indices=obs,
-                y_obs=y_obs,
-                p_obs=p_obs,
-                bin_pick=str(sampling.bin_pick),
-                random_seed=int(cfg.two_piece_ransac.seed),
-                bin_id=int(bin_id),
-            )
-        )
-
-    selected = obs[np.asarray(selected_positions, dtype=np.int64)]
-    min_after = max(
-        int(sampling.min_obs_per_fit_after_sampling),
-        int(min_required_obs),
-    )
-    if int(selected.size) < min_after:
-        return insufficient
-    if int(selected.size) > max_obs:
-        keep = _limit_selected_positions(
-            int(selected.size),
-            max_count=max_obs,
-            preserve_edge_bins=bool(sampling.preserve_edge_bins),
-        )
-        selected = selected[keep]
-    if int(selected.size) < min_after:
-        return insufficient
-    return np.asarray(selected, dtype=np.int64)
-
-
 def _predict_model_sec(trend_model, offset_m: float) -> float:
     pred = trend_model.predict(torch.tensor([float(offset_m)], dtype=torch.float32))
     pred_np = _tensor_to_numpy(pred).astype(np.float64, copy=False)
@@ -635,452 +375,6 @@ def _predict_model_array_sec(trend_model, offset_m: np.ndarray) -> np.ndarray:
         )
         raise ValueError(msg)
     return pred_np
-
-
-def _model_diagnostics(
-    trend_model,
-    *,
-    obs_offsets_m: np.ndarray,
-    obs_times_sec: np.ndarray,
-) -> tuple[float, float, float, float, float, float, float]:
-    edges = _tensor_to_numpy(trend_model.edges).astype(np.float32, copy=False)
-    coef = _tensor_to_numpy(trend_model.coef).astype(np.float32, copy=False)
-    if edges.shape != (3,) or coef.shape != (2, 2):
-        msg = 'trend model must expose edges (3,) and coef (2,2)'
-        raise ValueError(msg)
-
-    slope_near = float(coef[0, 0])
-    slope_far = float(coef[1, 0])
-    velocity_near = (
-        1.0 / slope_near
-        if np.isfinite(slope_near) and slope_near > 0.0
-        else np.nan
-    )
-    velocity_far = (
-        1.0 / slope_far
-        if np.isfinite(slope_far) and slope_far > 0.0
-        else np.nan
-    )
-
-    x_obs = torch.as_tensor(obs_offsets_m, dtype=torch.float32)
-    pred = _tensor_to_numpy(trend_model.predict(x_obs)).astype(np.float64, copy=False)
-    residual_ms = np.abs(np.asarray(obs_times_sec, dtype=np.float64) - pred) * 1000.0
-    residual_ms = residual_ms[np.isfinite(residual_ms)]
-    if residual_ms.size == 0:
-        resid_p50 = np.nan
-        resid_p90 = np.nan
-    else:
-        resid_p50 = float(np.percentile(residual_ms, 50.0))
-        resid_p90 = float(np.percentile(residual_ms, 90.0))
-
-    return (
-        float(edges[1]),
-        slope_near,
-        slope_far,
-        velocity_near,
-        velocity_far,
-        resid_p50,
-        resid_p90,
-    )
-
-
-def _fit_key_for_obs(
-    obs_indices: np.ndarray,
-    *,
-    precomputed_key: tuple[int, ...] | None = None,
-    runtime_diagnostics: PhysicalRuntimeDiagnostics | None = None,
-    after_sampling: bool = False,
-    count_missing_precomputed: bool = True,
-) -> tuple[int, ...]:
-    if precomputed_key is not None:
-        if runtime_diagnostics is not None:
-            runtime_diagnostics.inc('n_precomputed_fit_key_used')
-        return precomputed_key
-
-    if runtime_diagnostics is not None:
-        if bool(count_missing_precomputed):
-            runtime_diagnostics.inc('n_fit_key_missing_precomputed')
-        runtime_diagnostics.inc('n_fit_key_built_from_indices')
-        if bool(after_sampling):
-            runtime_diagnostics.inc('n_fit_key_built_after_sampling')
-    return _indices_key(obs_indices)
-
-
-def _fit_cache_key(plan: _ObservationPlan) -> tuple[int, ...]:
-    return _fit_key_for_obs(plan.obs_indices, precomputed_key=plan.obs_key)
-
-
-def _offset_spread_failure_reason(
-    x_obs: np.ndarray,
-    *,
-    min_pts: int,
-    min_offset_spread_m: float,
-) -> int | None:
-    finite_x = np.asarray(x_obs, dtype=np.float64)
-    finite_x = finite_x[np.isfinite(finite_x)]
-    if int(finite_x.size) < int(min_pts):
-        return PHYSICAL_MODEL_FAILURE_INSUFFICIENT_OBSERVATIONS
-    if float(np.ptp(finite_x)) < float(min_offset_spread_m):
-        return PHYSICAL_MODEL_FAILURE_INSUFFICIENT_OBSERVATIONS
-    return None
-
-
-def _fit_task_cfg_values(cfg: PhysicsLiteConfig) -> _FitTaskCfgValues:
-    executor = cfg.physical_runtime.fit_executor
-    is_irls = cfg.physical_trend.fit_kind == 'two_piece_irls_autobreak'
-    return _FitTaskCfgValues(
-        fit_kind=str(cfg.physical_trend.fit_kind),
-        n_iter=int(cfg.two_piece_ransac.n_iter),
-        inlier_th_ms=float(cfg.two_piece_ransac.inlier_th_ms),
-        irls_huber_c=float(cfg.two_piece_irls.huber_c),
-        irls_iters=int(cfg.two_piece_irls.iters),
-        min_pts=_fit_min_pts(cfg),
-        n_break_cand=(
-            int(cfg.two_piece_irls.n_break_cand)
-            if is_irls
-            else int(cfg.two_piece_ransac.n_break_cand)
-        ),
-        q_lo=(
-            float(cfg.two_piece_irls.q_lo)
-            if is_irls
-            else float(cfg.two_piece_ransac.q_lo)
-        ),
-        q_hi=(
-            float(cfg.two_piece_irls.q_hi)
-            if is_irls
-            else float(cfg.two_piece_ransac.q_hi)
-        ),
-        seed=int(cfg.two_piece_ransac.seed),
-        slope_eps=(
-            float(cfg.two_piece_irls.slope_eps)
-            if is_irls
-            else float(cfg.two_piece_ransac.slope_eps)
-        ),
-        sort_offsets=(
-            bool(cfg.two_piece_irls.sort_offsets)
-            if is_irls
-            else bool(cfg.two_piece_ransac.sort_offsets)
-        ),
-        min_offset_spread_m=float(cfg.physical_trend.min_offset_spread_m),
-        torch_num_threads_per_worker=int(executor.torch_num_threads_per_worker),
-    )
-
-
-def _fit_task_from_work_item(
-    work_item: _FitContextWorkItem,
-    *,
-    cfg_values: _FitTaskCfgValues,
-) -> _FitTask:
-    return _FitTask(
-        fit_key=work_item.fit_key,
-        x_obs=np.asarray(work_item.x_obs, dtype=np.float32),
-        y_obs=np.asarray(work_item.y_obs, dtype=np.float32),
-        w_obs=np.asarray(work_item.w_obs, dtype=np.float32),
-        obs_count_before_sampling=int(work_item.obs_count_before_sampling),
-        cfg_values=cfg_values,
-    )
-
-
-def _strategy_from_fit_task_cfg(
-    cfg_values: _FitTaskCfgValues,
-) -> _PhysicalFitStrategy:
-    if cfg_values.fit_kind == 'two_piece_irls_autobreak':
-        return TwoPieceIRLSAutoBreakStrategy(
-            huber_c=float(cfg_values.irls_huber_c),
-            iters=int(cfg_values.irls_iters),
-            min_pts=int(cfg_values.min_pts),
-            n_break_cand=int(cfg_values.n_break_cand),
-            q_lo=float(cfg_values.q_lo),
-            q_hi=float(cfg_values.q_hi),
-            slope_eps=float(cfg_values.slope_eps),
-            sort_offsets=bool(cfg_values.sort_offsets),
-        )
-    return TwoPieceRansacAutoBreakStrategy(
-        n_iter=int(cfg_values.n_iter),
-        inlier_th_ms=float(cfg_values.inlier_th_ms),
-        min_pts=int(cfg_values.min_pts),
-        n_break_cand=int(cfg_values.n_break_cand),
-        q_lo=float(cfg_values.q_lo),
-        q_hi=float(cfg_values.q_hi),
-        seed=int(cfg_values.seed),
-        slope_eps=float(cfg_values.slope_eps),
-        sort_offsets=bool(cfg_values.sort_offsets),
-    )
-
-
-def _run_fit_task(task: _FitTask) -> _FitTaskResult:
-    cfg_values = task.cfg_values
-    x_obs = np.asarray(task.x_obs, dtype=np.float32)
-    y_obs = np.asarray(task.y_obs, dtype=np.float32)
-    w_obs = np.asarray(task.w_obs, dtype=np.float32)
-    spread_failure_reason = _offset_spread_failure_reason(
-        x_obs,
-        min_pts=int(cfg_values.min_pts),
-        min_offset_spread_m=float(cfg_values.min_offset_spread_m),
-    )
-    if spread_failure_reason is not None:
-        return _FitTaskResult(
-            fit_key=task.fit_key,
-            trend_model=None,
-            diagnostics=None,
-            fit_failed=False,
-            failure_reason=spread_failure_reason,
-            elapsed_sec=0.0,
-            obs_count=int(x_obs.size),
-            obs_count_before_sampling=int(task.obs_count_before_sampling),
-            fit_attempted=False,
-        )
-
-    strategy = _strategy_from_fit_task_cfg(cfg_values)
-    start = time.perf_counter()
-    trend_model = _fit_strategy_model(
-        strategy,
-        torch.as_tensor(x_obs, dtype=torch.float32),
-        torch.as_tensor(y_obs, dtype=torch.float32),
-        torch.as_tensor(w_obs, dtype=torch.float32),
-    )
-    elapsed = time.perf_counter() - start
-    if trend_model is None:
-        return _FitTaskResult(
-            fit_key=task.fit_key,
-            trend_model=None,
-            diagnostics=None,
-            fit_failed=True,
-            failure_reason=PHYSICAL_MODEL_FAILURE_FIT_FAILED,
-            elapsed_sec=elapsed,
-            obs_count=int(x_obs.size),
-            obs_count_before_sampling=int(task.obs_count_before_sampling),
-            fit_attempted=True,
-        )
-    try:
-        diagnostics = _model_diagnostics(
-            trend_model,
-            obs_offsets_m=x_obs,
-            obs_times_sec=y_obs,
-        )
-    except (TypeError, ValueError, RuntimeError):
-        diagnostics = None
-    return _FitTaskResult(
-        fit_key=task.fit_key,
-        trend_model=trend_model,
-        diagnostics=diagnostics,
-        fit_failed=False,
-        failure_reason=None,
-        elapsed_sec=elapsed,
-        obs_count=int(x_obs.size),
-        obs_count_before_sampling=int(task.obs_count_before_sampling),
-        fit_attempted=True,
-    )
-
-
-def _set_fit_worker_torch_num_threads(num_threads: int) -> None:
-    torch.set_num_threads(int(num_threads))
-
-
-def _fit_progress_fields(
-    *,
-    done: int,
-    total: int,
-    start_sec: float,
-    runtime_diagnostics: PhysicalRuntimeDiagnostics | None,
-    force: bool = False,
-) -> dict[str, object]:
-    elapsed = max(0.0, time.perf_counter() - float(start_sec))
-    rate = (float(done) / elapsed) if elapsed > 0.0 else 0.0
-    remaining = max(0, int(total) - int(done))
-    eta = (float(remaining) / rate) if rate > 0.0 else 0.0
-    fields: dict[str, object] = {
-        'done': int(done),
-        'total': int(total),
-        'elapsed': elapsed,
-        'rate': rate,
-        'eta': eta,
-        'force': force,
-    }
-    if runtime_diagnostics is not None:
-        fields.update(
-            {
-                'cache_hit': int(runtime_diagnostics.n_cache_hits),
-                'cache_miss': int(runtime_diagnostics.n_cache_misses),
-                'n_fit_calls': int(runtime_diagnostics.n_fit_calls),
-                'fit_total_sec': float(runtime_diagnostics.ransac_fit_total_sec),
-            }
-        )
-    return fields
-
-
-def _run_fit_tasks_with_executor(
-    tasks: list[_FitTask],
-    *,
-    cfg: PhysicsLiteConfig,
-    progress: object | None = None,
-    progress_context: Mapping[str, object] | None = None,
-    progress_start_done: int = 0,
-    progress_total: int | None = None,
-    progress_start_sec: float | None = None,
-    runtime_diagnostics: PhysicalRuntimeDiagnostics | None = None,
-    progress_cache_miss_base: int = 0,
-    progress_fit_calls_base: int = 0,
-    progress_fit_total_sec_base: float = 0.0,
-) -> dict[tuple[int, ...], _FitTaskResult]:
-    reporter = (
-        progress
-        if progress is not None
-        else build_progress_reporter(cfg.physical_runtime.progress)
-    )
-    context = dict(progress_context or {})
-    total = len(tasks) if progress_total is None else int(progress_total)
-    start_sec = (
-        time.perf_counter()
-        if progress_start_sec is None
-        else progress_start_sec
-    )
-    fit_calls_done = 0
-    fit_total_sec = float(progress_fit_total_sec_base)
-    executor_cfg = cfg.physical_runtime.fit_executor
-    if str(executor_cfg.backend) == 'thread':
-        with ThreadPoolExecutor(max_workers=executor_cfg.max_workers) as executor:
-            futures = [executor.submit(_run_fit_task, task) for task in tasks]
-            out: dict[tuple[int, ...], _FitTaskResult] = {}
-            for completed, future in enumerate(as_completed(futures), start=1):
-                result = future.result()
-                out[result.fit_key] = result
-                if bool(result.fit_attempted):
-                    fit_calls_done += 1
-                    fit_total_sec += float(result.elapsed_sec)
-                fields = _fit_progress_fields(
-                    done=int(progress_start_done) + completed,
-                    total=total,
-                    start_sec=start_sec,
-                    runtime_diagnostics=runtime_diagnostics,
-                    force=int(progress_start_done) + completed >= total,
-                )
-                fields.update(
-                    {
-                        'cache_miss': int(progress_cache_miss_base) + completed,
-                        'n_fit_calls': int(progress_fit_calls_base) + fit_calls_done,
-                        'fit_total_sec': fit_total_sec,
-                    }
-                )
-                reporter.emit(
-                    'fit.progress',
-                    **context,
-                    **fields,
-                )
-            return out
-
-    with ProcessPoolExecutor(
-        max_workers=executor_cfg.max_workers,
-        initializer=_set_fit_worker_torch_num_threads,
-        initargs=(int(executor_cfg.torch_num_threads_per_worker),),
-    ) as executor:
-        futures = [executor.submit(_run_fit_task, task) for task in tasks]
-        out: dict[tuple[int, ...], _FitTaskResult] = {}
-        for completed, future in enumerate(as_completed(futures), start=1):
-            result = future.result()
-            out[result.fit_key] = result
-            if bool(result.fit_attempted):
-                fit_calls_done += 1
-                fit_total_sec += float(result.elapsed_sec)
-            fields = _fit_progress_fields(
-                done=int(progress_start_done) + completed,
-                total=total,
-                start_sec=start_sec,
-                runtime_diagnostics=runtime_diagnostics,
-                force=int(progress_start_done) + completed >= total,
-            )
-            fields.update(
-                {
-                    'cache_miss': int(progress_cache_miss_base) + completed,
-                    'n_fit_calls': int(progress_fit_calls_base) + fit_calls_done,
-                    'fit_total_sec': fit_total_sec,
-                }
-            )
-            reporter.emit(
-                'fit.progress',
-                **context,
-                **fields,
-            )
-        return out
-
-
-def _fit_model_for_plan(
-    *,
-    strategy: _PhysicalFitStrategy,
-    plan: _ObservationPlan,
-    x_obs: np.ndarray,
-    y_obs: np.ndarray,
-    w_obs: np.ndarray,
-    min_pts: int,
-    min_offset_spread_m: float,
-    cache: dict[tuple[int, ...], _FitCacheEntry],
-    runtime_diagnostics: PhysicalRuntimeDiagnostics | None = None,
-    obs_count_before_sampling: int | None = None,
-) -> tuple[
-    object | None,
-    tuple[float, float, float, float, float, float, float] | None,
-    int | None,
-]:
-    spread_failure_reason = _offset_spread_failure_reason(
-        x_obs,
-        min_pts=int(min_pts),
-        min_offset_spread_m=float(min_offset_spread_m),
-    )
-    if spread_failure_reason is not None:
-        return None, None, spread_failure_reason
-
-    cache_key = _fit_cache_key(plan)
-    entry = cache.get(cache_key)
-    if entry is None:
-        if runtime_diagnostics is not None:
-            runtime_diagnostics.record_cache_miss()
-        try:
-            x_tensor = torch.as_tensor(x_obs, dtype=torch.float32)
-            y_tensor = torch.as_tensor(y_obs, dtype=torch.float32)
-            w_tensor = torch.as_tensor(w_obs, dtype=torch.float32)
-            if runtime_diagnostics is None:
-                trend_model = _fit_strategy_model(
-                    strategy,
-                    x_tensor,
-                    y_tensor,
-                    w_tensor,
-                )
-            else:
-                with runtime_diagnostics.time_ransac_fit(
-                    obs_count=int(np.asarray(x_obs).size),
-                    obs_count_before=obs_count_before_sampling,
-                ):
-                    trend_model = _fit_strategy_model(
-                        strategy,
-                        x_tensor,
-                        y_tensor,
-                        w_tensor,
-                    )
-        except (TypeError, ValueError, RuntimeError):
-            trend_model = None
-
-        if trend_model is None:
-            entry = _FitCacheEntry(
-                model=None,
-                diagnostics=None,
-                fit_failed=True,
-                failure_reason=PHYSICAL_MODEL_FAILURE_FIT_FAILED,
-            )
-        else:
-            entry = _FitCacheEntry(
-                model=trend_model,
-                diagnostics=None,
-                fit_failed=False,
-            )
-        cache[cache_key] = entry
-    elif runtime_diagnostics is not None:
-        runtime_diagnostics.record_cache_hit()
-
-    if entry.failure_reason is not None:
-        return None, None, entry.failure_reason
-    if bool(entry.fit_failed):
-        return None, None, PHYSICAL_MODEL_FAILURE_FIT_FAILED
-    return entry.model, entry.diagnostics, None
 
 
 def _diagnostics_for_plan(

--- a/packages/seisai-engine/src/seisai_engine/pipelines/fbpick/physics/physical_center.py
+++ b/packages/seisai-engine/src/seisai_engine/pipelines/fbpick/physics/physical_center.py
@@ -16,6 +16,22 @@ from .geometry import (
     split_offset_gap_segments,
 )
 from .merge import MergeResult
+from .physical_center_context_fit import (
+    _assign_fit_context_fallback,
+    _assign_fit_context_work_item_outcome,
+    _build_fit_context_work_items,
+    _build_observation_plan,
+    _cache_entry_from_fit_task_result,
+    _fit_and_assign_context_work_item,
+    _fit_and_assign_context_work_items,
+    _fit_and_assign_context_work_items_parallel,
+    _FitContextWorkItem,
+    _FitContextWorkResult,
+    _prepare_fit_context_assignments_for_trace_indices,
+    _prepare_trace_plan_assignment,
+    _record_cached_context_hits,
+    _record_new_fit_task_diagnostics,
+)
 from .physical_center_fallback import (
     _allocate_result_arrays,
     _as_bool_vector,
@@ -29,7 +45,6 @@ from .physical_center_fallback import (
 )
 from .physical_center_fit import (
     _bin_representative_position,
-    _confidence_weights_for_obs,
     _evenly_spaced_positions,
     _fit_cache_key,
     _fit_key_for_obs,
@@ -47,7 +62,6 @@ from .physical_center_fit import (
     _limit_selected_positions,
     _median_time_position,
     _offset_spread_failure_reason,
-    _PhysicalFitStrategy,
     _run_fit_task,
     _run_fit_tasks_with_executor,
     _sample_observation_indices_for_fit,
@@ -88,9 +102,6 @@ from .physical_center_observation import (
     _SideObservationContext,
     _stable_unique,
     _trace_position_map,
-)
-from .physical_center_observation import (
-    _build_observation_plan as _build_observation_plan_with_min_obs,
 )
 from .physical_center_prediction import (
     _assign_model_diagnostics,
@@ -140,7 +151,7 @@ from .physical_center_types import (
     PhysicalCenterResult,
 )
 from .pick_table import CoarsePickTable
-from .progress import NullProgressReporter, build_progress_reporter
+from .progress import build_progress_reporter
 from .runtime_diagnostics import PhysicalRuntimeDiagnostics
 from .runtime_policy import (
     SourceXYAnchorSelectionResult,
@@ -150,23 +161,43 @@ from .trend import TrendResult
 
 _PHYSICAL_CENTER_PRIVATE_COMPAT = (
     _append_index,
+    _assign_fit_context_fallback,
+    _assign_fit_context_work_item_outcome,
     _assign_model_diagnostics,
     _assign_model_diagnostics_batch,
     _assign_model_prediction,
     _assign_model_prediction_batch,
     _assign_prepared_model_prediction_batch,
     _bin_representative_position,
+    _build_fit_context_work_items,
     _build_gap_segment_context,
+    _build_observation_plan,
     _build_side_observation_context,
+    _cache_entry_from_fit_task_result,
     _concat_group_traces,
     _diagnostics_for_plan,
     _evenly_spaced_positions,
+    _FitContextWorkItem,
+    _FitContextWorkResult,
     _filtered_obs_key,
     _fit_cache_key,
+    _fit_and_assign_context_work_item,
+    _fit_and_assign_context_work_items,
+    _fit_and_assign_context_work_items_parallel,
+    _fit_key_for_obs,
+    _fit_min_pts,
+    _fit_model_for_plan,
+    _fit_progress_fields,
     _fit_strategy_model,
+    _fit_task_cfg_values,
+    _fit_task_from_work_item,
+    _FitCacheEntry,
+    _FitTask,
     _FitTaskCfgValues,
+    _FitTaskResult,
     _GapSegmentContext,
     _gap_context_key,
+    _GroupObservationContext,
     _indices_key,
     _index_key_contains,
     _limit_selected_positions,
@@ -179,7 +210,13 @@ _PHYSICAL_CENTER_PRIVATE_COMPAT = (
     _offset_spread_failure_reason,
     _predict_model_array_sec,
     _predict_model_sec,
+    _prepare_fit_context_assignments_for_trace_indices,
+    _prepare_trace_plan_assignment,
+    _record_cached_context_hits,
+    _record_new_fit_task_diagnostics,
     _run_fit_task,
+    _run_fit_tasks_with_executor,
+    _sample_observation_indices_for_fit,
     _select_group_ids,
     _set_fit_worker_torch_num_threads,
     _SideObservationContext,
@@ -194,6 +231,7 @@ _PHYSICAL_CENTER_PRIVATE_COMPAT = (
     _trace_position_map,
     _TraceFitResult,
     _TracePlanAssignment,
+    CoarseGeometry,
     signed_offset_side_from_geometry,
     split_offset_gap_segments,
 )
@@ -233,25 +271,6 @@ __all__ = [
     'build_geometry_two_piece_physical_center',
     'preflight_geometry_two_piece_fallback',
 ]
-
-@dataclass(frozen=True)
-class _FitContextWorkItem:
-    fit_key: tuple[int, ...]
-    fit_plan: _ObservationPlan
-    obs_count_before_sampling: int
-    trace_indices: np.ndarray
-    runtime_fit_source: int
-    assignments: tuple[_TracePlanAssignment, ...]
-    x_obs: np.ndarray
-    y_obs: np.ndarray
-    w_obs: np.ndarray
-
-
-@dataclass(frozen=True)
-class _FitContextWorkResult:
-    trend_model: object | None
-    diagnostics: tuple[float, float, float, float, float, float, float] | None
-    valid_trace_indices: frozenset[int]
 
 
 @dataclass(frozen=True)
@@ -326,713 +345,6 @@ def _apply_anchor_selection_diagnostics(
             source_distance_m=result.source_distance_m,
         )
     return result
-
-
-def _build_observation_plan(
-    *,
-    trace_idx: int,
-    target_group_id: int,
-    group_context_by_id: Mapping[int, _GroupObservationContext],
-    geometry: CoarseGeometry | None,
-    offset_abs_m: np.ndarray,
-    offset_signed_m: np.ndarray | None,
-    cfg: PhysicsLiteConfig,
-    runtime_diagnostics: PhysicalRuntimeDiagnostics | None = None,
-    plan_cache: _ObservationPlanCache | None = None,
-    min_fit_obs: int | None = None,
-) -> _ObservationPlan | None:
-    return _build_observation_plan_with_min_obs(
-        trace_idx=trace_idx,
-        target_group_id=target_group_id,
-        group_context_by_id=group_context_by_id,
-        geometry=geometry,
-        offset_abs_m=offset_abs_m,
-        offset_signed_m=offset_signed_m,
-        cfg=cfg,
-        min_fit_obs=(
-            2 * _fit_min_pts(cfg) if min_fit_obs is None else int(min_fit_obs)
-        ),
-        runtime_diagnostics=runtime_diagnostics,
-        plan_cache=plan_cache,
-    )
-
-def _prepare_trace_plan_assignment(
-    *,
-    arrays: dict[str, np.ndarray],
-    trace_idx: int,
-    group_id_by_trace: np.ndarray,
-    group_context_by_id: Mapping[int, _GroupObservationContext],
-    geometry: CoarseGeometry | None,
-    offset_abs_m: np.ndarray,
-    offset_signed_m: np.ndarray | None,
-    offset_source: int,
-    pick_t_sec: np.ndarray,
-    table: CoarsePickTable,
-    feasible: FeasibleBandResult,
-    trend: TrendResult,
-    trend_provider: object | None = None,
-    merged: MergeResult,
-    cfg: PhysicsLiteConfig,
-    observation_plan_cache: _ObservationPlanCache,
-    min_fit_obs: int,
-    runtime_diagnostics: PhysicalRuntimeDiagnostics | None,
-    pending_trend_fallback: _PendingTrendFallback | None = None,
-) -> _TracePlanAssignment | None:
-    arrays['physical_offset_source'][trace_idx] = np.uint8(offset_source)
-    if (
-        not np.isfinite(offset_abs_m[trace_idx])
-        or int(group_id_by_trace[trace_idx]) < 0
-    ):
-        _assign_fallback(
-            arrays,
-            trace_idx,
-            failure_reason=PHYSICAL_MODEL_FAILURE_GEOMETRY_INVALID,
-            table=table,
-            feasible=feasible,
-            trend=trend,
-            trend_provider=trend_provider,
-            merged=merged,
-            pending_trend_fallback=pending_trend_fallback,
-        )
-        return None
-
-    plan = _build_observation_plan(
-        trace_idx=trace_idx,
-        target_group_id=int(group_id_by_trace[trace_idx]),
-        group_context_by_id=group_context_by_id,
-        geometry=geometry,
-        offset_abs_m=offset_abs_m,
-        offset_signed_m=offset_signed_m,
-        cfg=cfg,
-        runtime_diagnostics=runtime_diagnostics,
-        plan_cache=observation_plan_cache,
-    )
-    if plan is None:
-        _assign_fallback(
-            arrays,
-            trace_idx,
-            failure_reason=PHYSICAL_MODEL_FAILURE_INSUFFICIENT_OBSERVATIONS,
-            table=table,
-            feasible=feasible,
-            trend=trend,
-            trend_provider=trend_provider,
-            merged=merged,
-            pending_trend_fallback=pending_trend_fallback,
-        )
-        return None
-
-    arrays['physical_model_neighbor_count'][trace_idx] = np.int32(plan.neighbor_count)
-    arrays['physical_prefilter_valid_count'][trace_idx] = np.int32(
-        plan.prefilter_valid_count
-    )
-    arrays['physical_model_segment_id'][trace_idx] = np.int32(plan.segment_id)
-    arrays['physical_model_side'][trace_idx] = np.int8(plan.side)
-
-    if int(plan.obs_indices.size) < int(min_fit_obs):
-        _assign_fallback(
-            arrays,
-            trace_idx,
-            failure_reason=PHYSICAL_MODEL_FAILURE_INSUFFICIENT_OBSERVATIONS,
-            table=table,
-            feasible=feasible,
-            trend=trend,
-            trend_provider=trend_provider,
-            merged=merged,
-            pending_trend_fallback=pending_trend_fallback,
-        )
-        return None
-
-    obs_count_before_sampling = int(np.asarray(plan.obs_indices).size)
-    with (
-        runtime_diagnostics.time_block('observation_sampling_sec')
-        if runtime_diagnostics is not None
-        else nullcontext()
-    ):
-        obs_indices = _sample_observation_indices_for_fit(
-            obs_indices=plan.obs_indices,
-            offset_abs_m=offset_abs_m,
-            pick_t_sec=pick_t_sec,
-            coarse_pmax=table.coarse_pmax,
-            cfg=cfg,
-            min_required_obs=int(min_fit_obs),
-        )
-    sampling_changed = obs_indices is not plan.obs_indices
-    precomputed_fit_key = None if sampling_changed else plan.obs_key
-    fit_key = _fit_key_for_obs(
-        obs_indices,
-        precomputed_key=precomputed_fit_key,
-        runtime_diagnostics=runtime_diagnostics,
-        after_sampling=sampling_changed,
-        count_missing_precomputed=not sampling_changed,
-    )
-    fit_plan = _ObservationPlan(
-        obs_indices=obs_indices,
-        obs_key=fit_key,
-        neighbor_count=plan.neighbor_count,
-        prefilter_valid_count=plan.prefilter_valid_count,
-        segment_id=plan.segment_id,
-        side=plan.side,
-        relaxed=plan.relaxed,
-    )
-    return _TracePlanAssignment(
-        trace_idx=int(trace_idx),
-        plan=fit_plan,
-        fit_key=fit_key,
-        obs_count_before_sampling=obs_count_before_sampling,
-    )
-
-def _build_fit_context_work_items(
-    grouped_assignments: Mapping[tuple[int, ...], list[_TracePlanAssignment]],
-    *,
-    offset_abs_m: np.ndarray,
-    pick_t_sec: np.ndarray,
-    coarse_pmax: np.ndarray,
-    runtime_fit_source: int,
-) -> list[_FitContextWorkItem]:
-    work_items: list[_FitContextWorkItem] = []
-    for fit_key, assignments in grouped_assignments.items():
-        if not assignments:
-            continue
-        first = assignments[0]
-        trace_indices = np.asarray(
-            [item.trace_idx for item in assignments],
-            dtype=np.int64,
-        )
-        obs_indices = np.asarray(first.plan.obs_indices, dtype=np.int64)
-        work_items.append(
-            _FitContextWorkItem(
-                fit_key=fit_key,
-                fit_plan=first.plan,
-                obs_count_before_sampling=first.obs_count_before_sampling,
-                trace_indices=trace_indices,
-                runtime_fit_source=int(runtime_fit_source),
-                assignments=tuple(assignments),
-                x_obs=np.asarray(offset_abs_m[obs_indices], dtype=np.float32),
-                y_obs=np.asarray(pick_t_sec[obs_indices], dtype=np.float32),
-                w_obs=_confidence_weights_for_obs(
-                    np.asarray(coarse_pmax, dtype=np.float32)[obs_indices]
-                ),
-            )
-        )
-    return work_items
-
-
-def _assign_fit_context_fallback(
-    *,
-    arrays: dict[str, np.ndarray],
-    work_item: _FitContextWorkItem,
-    failure_reason: int,
-    table: CoarsePickTable,
-    feasible: FeasibleBandResult,
-    trend: TrendResult,
-    trend_provider: object | None = None,
-    merged: MergeResult,
-    pending_trend_fallback: _PendingTrendFallback | None = None,
-) -> None:
-    for trace_idx in np.asarray(work_item.trace_indices, dtype=np.int64).tolist():
-        _assign_fallback(
-            arrays,
-            int(trace_idx),
-            failure_reason=int(failure_reason),
-            table=table,
-            feasible=feasible,
-            trend=trend,
-            trend_provider=trend_provider,
-            merged=merged,
-            pending_trend_fallback=pending_trend_fallback,
-        )
-
-
-def _fit_and_assign_context_work_item(
-    *,
-    arrays: dict[str, np.ndarray],
-    work_item: _FitContextWorkItem,
-    offset_abs_m: np.ndarray,
-    table: CoarsePickTable,
-    feasible: FeasibleBandResult,
-    trend: TrendResult,
-    trend_provider: object | None = None,
-    merged: MergeResult,
-    cfg: PhysicsLiteConfig,
-    strategy: _PhysicalFitStrategy,
-    fit_cache: dict[tuple[int, ...], _FitCacheEntry],
-    runtime_diagnostics: PhysicalRuntimeDiagnostics | None,
-    pending_trend_fallback: _PendingTrendFallback | None = None,
-) -> _FitContextWorkResult:
-    trend_model, diagnostics, fit_failure_reason = _fit_model_for_plan(
-        strategy=strategy,
-        plan=work_item.fit_plan,
-        x_obs=work_item.x_obs,
-        y_obs=work_item.y_obs,
-        w_obs=work_item.w_obs,
-        min_pts=_fit_min_pts(cfg),
-        min_offset_spread_m=float(cfg.physical_trend.min_offset_spread_m),
-        cache=fit_cache,
-        runtime_diagnostics=runtime_diagnostics,
-        obs_count_before_sampling=int(work_item.obs_count_before_sampling),
-    )
-    if (
-        runtime_diagnostics is not None
-        and work_item.fit_key in fit_cache
-        and int(work_item.trace_indices.size) > 1
-    ):
-        runtime_diagnostics.record_cache_hit(int(work_item.trace_indices.size) - 1)
-
-    return _assign_fit_context_work_item_outcome(
-        arrays=arrays,
-        work_item=work_item,
-        offset_abs_m=offset_abs_m,
-        table=table,
-        feasible=feasible,
-        trend=trend,
-        trend_provider=trend_provider,
-        merged=merged,
-        fit_cache=fit_cache,
-        trend_model=trend_model,
-        diagnostics=diagnostics,
-        fit_failure_reason=fit_failure_reason,
-        runtime_diagnostics=runtime_diagnostics,
-        pending_trend_fallback=pending_trend_fallback,
-    )
-
-
-def _assign_fit_context_work_item_outcome(
-    *,
-    arrays: dict[str, np.ndarray],
-    work_item: _FitContextWorkItem,
-    offset_abs_m: np.ndarray,
-    table: CoarsePickTable,
-    feasible: FeasibleBandResult,
-    trend: TrendResult,
-    trend_provider: object | None = None,
-    merged: MergeResult,
-    fit_cache: dict[tuple[int, ...], _FitCacheEntry],
-    trend_model: object | None,
-    diagnostics: tuple[float, float, float, float, float, float, float] | None,
-    fit_failure_reason: int | None,
-    runtime_diagnostics: PhysicalRuntimeDiagnostics | None,
-    pending_trend_fallback: _PendingTrendFallback | None = None,
-) -> _FitContextWorkResult:
-    if fit_failure_reason is not None:
-        _assign_fit_context_fallback(
-            arrays=arrays,
-            work_item=work_item,
-            failure_reason=fit_failure_reason,
-            table=table,
-            feasible=feasible,
-            trend=trend,
-            trend_provider=trend_provider,
-            merged=merged,
-            pending_trend_fallback=pending_trend_fallback,
-        )
-        return _FitContextWorkResult(
-            trend_model=None,
-            diagnostics=None,
-            valid_trace_indices=frozenset(),
-        )
-
-    if trend_model is None:
-        _assign_fit_context_fallback(
-            arrays=arrays,
-            work_item=work_item,
-            failure_reason=PHYSICAL_MODEL_FAILURE_FIT_FAILED,
-            table=table,
-            feasible=feasible,
-            trend=trend,
-            trend_provider=trend_provider,
-            merged=merged,
-            pending_trend_fallback=pending_trend_fallback,
-        )
-        return _FitContextWorkResult(
-            trend_model=None,
-            diagnostics=None,
-            valid_trace_indices=frozenset(),
-        )
-
-    items = [
-        (
-            int(item.trace_idx),
-            _TraceFitResult(
-                plan=item.plan,
-                trend_model=trend_model,
-                diagnostics=diagnostics,
-                x_obs=work_item.x_obs,
-                y_obs=work_item.y_obs,
-            ),
-        )
-        for item in work_item.assignments
-    ]
-    valid, diagnostics = _assign_prepared_model_prediction_batch(
-        arrays=arrays,
-        items=items,
-        offset_abs_m=offset_abs_m,
-        dt=float(table.dt_scalar_sec),
-        n_samples=int(table.n_samples_orig),
-        runtime_fit_source=int(work_item.runtime_fit_source),
-        table=table,
-        feasible=feasible,
-        trend=trend,
-        trend_provider=trend_provider,
-        merged=merged,
-        fit_cache=fit_cache,
-        runtime_diagnostics=runtime_diagnostics,
-        pending_trend_fallback=pending_trend_fallback,
-    )
-    return _FitContextWorkResult(
-        trend_model=trend_model,
-        diagnostics=diagnostics,
-        valid_trace_indices=frozenset(
-            int(trace_idx)
-            for trace_idx in np.asarray(
-                work_item.trace_indices,
-                dtype=np.int64,
-            )[valid].tolist()
-        ),
-    )
-
-
-def _prepare_fit_context_assignments_for_trace_indices(
-    trace_indices: np.ndarray,
-    *,
-    arrays: dict[str, np.ndarray],
-    group_id_by_trace: np.ndarray,
-    group_context_by_id: Mapping[int, _GroupObservationContext],
-    geometry: CoarseGeometry | None,
-    offset_abs_m: np.ndarray,
-    offset_signed_m: np.ndarray | None,
-    offset_source: int,
-    pick_t_sec: np.ndarray,
-    table: CoarsePickTable,
-    feasible: FeasibleBandResult,
-    trend: TrendResult,
-    trend_provider: object | None = None,
-    merged: MergeResult,
-    cfg: PhysicsLiteConfig,
-    observation_plan_cache: _ObservationPlanCache,
-    min_fit_obs: int,
-    runtime_diagnostics: PhysicalRuntimeDiagnostics | None,
-    pending_trend_fallback: _PendingTrendFallback | None = None,
-) -> tuple[
-    dict[tuple[int, ...], list[_TracePlanAssignment]],
-    list[_TracePlanAssignment],
-]:
-    grouped: dict[tuple[int, ...], list[_TracePlanAssignment]] = {}
-    ordered: list[_TracePlanAssignment] = []
-    for trace_idx in np.asarray(trace_indices, dtype=np.int64).tolist():
-        assignment = _prepare_trace_plan_assignment(
-            arrays=arrays,
-            trace_idx=int(trace_idx),
-            group_id_by_trace=group_id_by_trace,
-            group_context_by_id=group_context_by_id,
-            geometry=geometry,
-            offset_abs_m=offset_abs_m,
-            offset_signed_m=offset_signed_m,
-            offset_source=offset_source,
-            pick_t_sec=pick_t_sec,
-            table=table,
-            feasible=feasible,
-            trend=trend,
-            trend_provider=trend_provider,
-            merged=merged,
-            cfg=cfg,
-            observation_plan_cache=observation_plan_cache,
-            min_fit_obs=min_fit_obs,
-            runtime_diagnostics=runtime_diagnostics,
-            pending_trend_fallback=pending_trend_fallback,
-        )
-        if assignment is None:
-            continue
-        grouped.setdefault(assignment.fit_key, []).append(assignment)
-        ordered.append(assignment)
-    return grouped, ordered
-
-
-def _fit_and_assign_context_work_items(
-    work_items: list[_FitContextWorkItem],
-    *,
-    arrays: dict[str, np.ndarray],
-    offset_abs_m: np.ndarray,
-    table: CoarsePickTable,
-    feasible: FeasibleBandResult,
-    trend: TrendResult,
-    trend_provider: object | None = None,
-    merged: MergeResult,
-    cfg: PhysicsLiteConfig,
-    strategy: _PhysicalFitStrategy,
-    fit_cache: dict[tuple[int, ...], _FitCacheEntry],
-    runtime_diagnostics: PhysicalRuntimeDiagnostics | None,
-    progress: object | None = None,
-    progress_context: Mapping[str, object] | None = None,
-    pending_trend_fallback: _PendingTrendFallback | None = None,
-) -> dict[tuple[int, ...], _FitContextWorkResult]:
-    reporter = progress if progress is not None else NullProgressReporter()
-    context = dict(progress_context or {})
-    fit_start = time.perf_counter()
-    if bool(cfg.physical_runtime.fit_executor.enabled) and work_items:
-        return _fit_and_assign_context_work_items_parallel(
-            work_items,
-            arrays=arrays,
-            offset_abs_m=offset_abs_m,
-            table=table,
-            feasible=feasible,
-            trend=trend,
-            trend_provider=trend_provider,
-            merged=merged,
-            cfg=cfg,
-            fit_cache=fit_cache,
-            runtime_diagnostics=runtime_diagnostics,
-            progress=reporter,
-            progress_context=context,
-            progress_start_sec=fit_start,
-            pending_trend_fallback=pending_trend_fallback,
-        )
-
-    results: dict[tuple[int, ...], _FitContextWorkResult] = {}
-    total = len(work_items)
-    reporter.emit(
-        'physical-center.fit_start',
-        **context,
-        work_items=total,
-        executor='serial',
-    )
-    for done, work_item in enumerate(work_items, start=1):
-        results[work_item.fit_key] = _fit_and_assign_context_work_item(
-            arrays=arrays,
-            work_item=work_item,
-            offset_abs_m=offset_abs_m,
-            table=table,
-            feasible=feasible,
-            trend=trend,
-            trend_provider=trend_provider,
-            merged=merged,
-            cfg=cfg,
-            strategy=strategy,
-            fit_cache=fit_cache,
-            runtime_diagnostics=runtime_diagnostics,
-            pending_trend_fallback=pending_trend_fallback,
-        )
-        reporter.emit(
-            'fit.progress',
-            **context,
-            **_fit_progress_fields(
-                done=done,
-                total=total,
-                start_sec=fit_start,
-                runtime_diagnostics=runtime_diagnostics,
-                force=done >= total,
-            ),
-        )
-    return results
-
-
-def _record_cached_context_hits(
-    *,
-    runtime_diagnostics: PhysicalRuntimeDiagnostics | None,
-    work_item: _FitContextWorkItem,
-) -> None:
-    if runtime_diagnostics is None:
-        return
-    extra_hits = int(work_item.trace_indices.size) - 1
-    if extra_hits > 0:
-        runtime_diagnostics.record_cache_hit(extra_hits)
-
-
-def _record_new_fit_task_diagnostics(
-    *,
-    runtime_diagnostics: PhysicalRuntimeDiagnostics | None,
-    work_item: _FitContextWorkItem,
-    task_result: _FitTaskResult,
-) -> None:
-    if runtime_diagnostics is None:
-        return
-    if task_result.failure_reason == PHYSICAL_MODEL_FAILURE_INSUFFICIENT_OBSERVATIONS:
-        return
-    runtime_diagnostics.record_cache_miss()
-    if bool(task_result.fit_attempted):
-        runtime_diagnostics.record_ransac_fit(
-            elapsed_sec=float(task_result.elapsed_sec),
-            obs_count=int(task_result.obs_count),
-            obs_count_before=int(task_result.obs_count_before_sampling),
-        )
-    extra_hits = int(work_item.trace_indices.size) - 1
-    if extra_hits > 0:
-        runtime_diagnostics.record_cache_hit(extra_hits)
-
-
-def _cache_entry_from_fit_task_result(
-    task_result: _FitTaskResult,
-) -> _FitCacheEntry | None:
-    if task_result.failure_reason == PHYSICAL_MODEL_FAILURE_INSUFFICIENT_OBSERVATIONS:
-        return None
-    if task_result.failure_reason is not None:
-        return _FitCacheEntry(
-            model=None,
-            diagnostics=None,
-            fit_failed=bool(task_result.fit_failed),
-            failure_reason=task_result.failure_reason,
-        )
-    if bool(task_result.fit_failed):
-        return _FitCacheEntry(
-            model=None,
-            diagnostics=None,
-            fit_failed=True,
-            failure_reason=PHYSICAL_MODEL_FAILURE_FIT_FAILED,
-        )
-    return _FitCacheEntry(
-        model=task_result.trend_model,
-        diagnostics=task_result.diagnostics,
-        fit_failed=False,
-        diagnostics_computed=task_result.diagnostics is not None,
-    )
-
-
-def _fit_and_assign_context_work_items_parallel(
-    work_items: list[_FitContextWorkItem],
-    *,
-    arrays: dict[str, np.ndarray],
-    offset_abs_m: np.ndarray,
-    table: CoarsePickTable,
-    feasible: FeasibleBandResult,
-    trend: TrendResult,
-    trend_provider: object | None = None,
-    merged: MergeResult,
-    cfg: PhysicsLiteConfig,
-    fit_cache: dict[tuple[int, ...], _FitCacheEntry],
-    runtime_diagnostics: PhysicalRuntimeDiagnostics | None,
-    progress: object | None = None,
-    progress_context: Mapping[str, object] | None = None,
-    progress_start_sec: float | None = None,
-    pending_trend_fallback: _PendingTrendFallback | None = None,
-) -> dict[tuple[int, ...], _FitContextWorkResult]:
-    reporter = progress if progress is not None else NullProgressReporter()
-    context = dict(progress_context or {})
-    fit_start = (
-        time.perf_counter()
-        if progress_start_sec is None
-        else progress_start_sec
-    )
-    total = len(work_items)
-    done = 0
-    reporter.emit(
-        'physical-center.fit_start',
-        **context,
-        work_items=total,
-        executor=str(cfg.physical_runtime.fit_executor.backend),
-        max_workers=cfg.physical_runtime.fit_executor.max_workers,
-    )
-    results: dict[tuple[int, ...], _FitContextWorkResult] = {}
-    pending_items: list[_FitContextWorkItem] = []
-    tasks: list[_FitTask] = []
-    cfg_values = _fit_task_cfg_values(cfg)
-
-    for work_item in work_items:
-        entry = fit_cache.get(work_item.fit_key)
-        if entry is None:
-            pending_items.append(work_item)
-            tasks.append(
-                _fit_task_from_work_item(work_item, cfg_values=cfg_values)
-            )
-            continue
-
-        _record_cached_context_hits(
-            runtime_diagnostics=runtime_diagnostics,
-            work_item=work_item,
-        )
-        fit_failure_reason = entry.failure_reason
-        if fit_failure_reason is None and bool(entry.fit_failed):
-            fit_failure_reason = PHYSICAL_MODEL_FAILURE_FIT_FAILED
-        results[work_item.fit_key] = _assign_fit_context_work_item_outcome(
-            arrays=arrays,
-            work_item=work_item,
-            offset_abs_m=offset_abs_m,
-            table=table,
-            feasible=feasible,
-            trend=trend,
-            trend_provider=trend_provider,
-            merged=merged,
-            fit_cache=fit_cache,
-            trend_model=entry.model,
-            diagnostics=entry.diagnostics,
-            fit_failure_reason=fit_failure_reason,
-            runtime_diagnostics=runtime_diagnostics,
-            pending_trend_fallback=pending_trend_fallback,
-        )
-        done += 1
-        reporter.emit(
-            'fit.progress',
-            **context,
-            **_fit_progress_fields(
-                done=done,
-                total=total,
-                start_sec=fit_start,
-                runtime_diagnostics=runtime_diagnostics,
-                force=done >= total,
-            ),
-        )
-
-    if tasks:
-        start = time.perf_counter()
-        task_results_by_key = _run_fit_tasks_with_executor(
-            tasks,
-            cfg=cfg,
-            progress=reporter,
-            progress_context=context,
-            progress_start_done=done,
-            progress_total=total,
-            progress_start_sec=fit_start,
-            runtime_diagnostics=runtime_diagnostics,
-            progress_cache_miss_base=(
-                int(runtime_diagnostics.n_cache_misses)
-                if runtime_diagnostics is not None
-                else 0
-            ),
-            progress_fit_calls_base=(
-                int(runtime_diagnostics.n_fit_calls)
-                if runtime_diagnostics is not None
-                else 0
-            ),
-            progress_fit_total_sec_base=(
-                float(runtime_diagnostics.ransac_fit_total_sec)
-                if runtime_diagnostics is not None
-                else 0.0
-            ),
-        )
-        wall_sec = time.perf_counter() - start
-        if runtime_diagnostics is not None:
-            runtime_diagnostics.record_fit_executor_run(
-                wall_sec=wall_sec,
-                tasks=len(tasks),
-            )
-
-        for work_item in pending_items:
-            task_result = task_results_by_key[work_item.fit_key]
-            entry = _cache_entry_from_fit_task_result(task_result)
-            if entry is not None:
-                fit_cache[work_item.fit_key] = entry
-            _record_new_fit_task_diagnostics(
-                runtime_diagnostics=runtime_diagnostics,
-                work_item=work_item,
-                task_result=task_result,
-            )
-            done += 1
-            results[work_item.fit_key] = _assign_fit_context_work_item_outcome(
-                arrays=arrays,
-                work_item=work_item,
-                offset_abs_m=offset_abs_m,
-                table=table,
-                feasible=feasible,
-                trend=trend,
-                trend_provider=trend_provider,
-                merged=merged,
-                fit_cache=fit_cache,
-                trend_model=task_result.trend_model,
-                diagnostics=task_result.diagnostics,
-                fit_failure_reason=task_result.failure_reason,
-                runtime_diagnostics=runtime_diagnostics,
-                pending_trend_fallback=pending_trend_fallback,
-            )
-
-    return results
 
 
 def _anchor_model_key(
@@ -1780,6 +1092,7 @@ def build_geometry_two_piece_physical_center(
             runtime_diagnostics=runtime_diagnostics,
             progress=reporter,
             progress_context=context,
+            fit_model_for_plan=_fit_model_for_plan,
             pending_trend_fallback=pending_trend_fallback,
         )
         if runtime_diagnostics is not None:
@@ -2000,6 +1313,7 @@ def build_geometry_two_piece_physical_center(
                     runtime_diagnostics=runtime_diagnostics,
                     progress=reporter,
                     progress_context=context,
+                    fit_model_for_plan=_fit_model_for_plan,
                     pending_trend_fallback=pending_trend_fallback,
                 )
 
@@ -2145,6 +1459,7 @@ def build_geometry_two_piece_physical_center(
                     runtime_diagnostics=runtime_diagnostics,
                     progress=reporter,
                     progress_context=context,
+                    fit_model_for_plan=_fit_model_for_plan,
                     pending_trend_fallback=pending_trend_fallback,
                 )
                 assigned_count = sum(
@@ -2309,11 +1624,10 @@ def build_geometry_two_piece_physical_center(
         stage='fit_context_preparation',
     )
     stage_start = time.perf_counter()
-    fit_context_assignments: dict[tuple[int, ...], list[_TracePlanAssignment]] = {}
-    for trace_idx in range(n):
-        assignment = _prepare_trace_plan_assignment(
+    fit_context_assignments, _fit_context_ordered_assignments = (
+        _prepare_fit_context_assignments_for_trace_indices(
+            np.arange(n, dtype=np.int64),
             arrays=arrays,
-            trace_idx=trace_idx,
             group_id_by_trace=group_id_by_trace,
             group_context_by_id=group_context_by_id,
             geometry=geometry,
@@ -2332,10 +1646,7 @@ def build_geometry_two_piece_physical_center(
             runtime_diagnostics=runtime_diagnostics,
             pending_trend_fallback=pending_trend_fallback,
         )
-        if assignment is not None:
-            fit_context_assignments.setdefault(assignment.fit_key, []).append(
-                assignment
-            )
+    )
     reporter.emit(
         'physical-center.stage_done',
         **context,
@@ -2372,6 +1683,7 @@ def build_geometry_two_piece_physical_center(
         runtime_diagnostics=runtime_diagnostics,
         progress=reporter,
         progress_context=context,
+        fit_model_for_plan=_fit_model_for_plan,
         pending_trend_fallback=pending_trend_fallback,
     )
 

--- a/packages/seisai-engine/src/seisai_engine/pipelines/fbpick/physics/physical_center.py
+++ b/packages/seisai-engine/src/seisai_engine/pipelines/fbpick/physics/physical_center.py
@@ -74,6 +74,7 @@ from .physical_center_fit import (
     _stable_observation_seed,
     _strategy_from_fit_task_cfg,
 )
+from .physical_center_full_fit import run_full_fit_policy
 from .physical_center_geometry import (
     PhysicalCenterGeometryContext,
     _signed_offset_side_labels,
@@ -1569,43 +1570,7 @@ def build_geometry_two_piece_physical_center(
         )
         return result
 
-    reporter.emit(
-        'physical-center.stage_start',
-        **context,
-        stage='fit_context_preparation',
-    )
-    stage_start = time.perf_counter()
-    fit_context_assignments, _fit_context_ordered_assignments = (
-        _prepare_fit_context_assignments_for_trace_indices(
-            np.arange(n, dtype=np.int64),
-            inputs=inputs,
-            build_context=build_context,
-            workspace=workspace,
-        )
-    )
-    reporter.emit(
-        'physical-center.stage_done',
-        **context,
-        stage='fit_context_preparation',
-        elapsed=time.perf_counter() - stage_start,
-        unique_keys=len(fit_context_assignments),
-    )
-
-    work_items = _build_fit_context_work_items(
-        fit_context_assignments,
-        offset_abs_m=offset_abs_m,
-        pick_t_sec=pick_t_sec,
-        coarse_pmax=table.coarse_pmax,
-        runtime_fit_source=PHYSICAL_RUNTIME_FIT_SOURCE_FULL_FIT,
-    )
-    reporter.emit(
-        'physical-center.contexts_built',
-        **context,
-        work_items=len(work_items),
-        unique_keys=len(fit_context_assignments),
-    )
-    _fit_and_assign_context_work_items(
-        work_items,
+    return run_full_fit_policy(
         inputs=inputs,
         build_context=build_context,
         workspace=workspace,
@@ -1614,25 +1579,3 @@ def build_geometry_two_piece_physical_center(
         progress_context=context,
         fit_model_for_plan=_fit_model_for_plan,
     )
-
-    if runtime_diagnostics is not None:
-        runtime_diagnostics.set_unique_fit_contexts(len(fit_cache))
-
-    result = _finalize_result_with_pending_trend_fallback(
-        arrays,
-        pending_trend_fallback=pending_trend_fallback,
-        table=table,
-        feasible=feasible,
-        trend=trend,
-        merged=merged,
-        trend_provider=trend_provider,
-    )
-    reporter.emit(
-        'physical-center.done',
-        **context,
-        status='ok',
-        n_traces=n,
-        n_source_groups=len(groups),
-        n_unique_fit_contexts=len(fit_cache),
-    )
-    return result

--- a/packages/seisai-engine/src/seisai_engine/pipelines/fbpick/physics/physical_center_context.py
+++ b/packages/seisai-engine/src/seisai_engine/pipelines/fbpick/physics/physical_center_context.py
@@ -1,0 +1,116 @@
+"""Orchestration context objects for physical-center fitting."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+import numpy as np
+
+if TYPE_CHECKING:
+    from .config import PhysicsLiteConfig
+    from .feasible import FeasibleBandResult
+    from .geometry import CoarseGeometry, SourceGroup
+    from .merge import MergeResult
+    from .physical_center_fallback import _PendingTrendFallback
+    from .physical_center_fit import _FitCacheEntry
+    from .physical_center_geometry import (
+        PhysicalCenterGeometryContext,
+        _SignedOffsetSideLabels,
+    )
+    from .physical_center_observation import (
+        _GroupObservationContext,
+        _ObservationPlanCache,
+    )
+    from .pick_table import CoarsePickTable
+    from .runtime_diagnostics import PhysicalRuntimeDiagnostics
+    from .trend import TrendResult
+
+__all__ = [
+    'PhysicalCenterBuildContext',
+    'PhysicalCenterInputs',
+    'PhysicalCenterWorkspace',
+]
+
+
+@dataclass(frozen=True)
+class PhysicalCenterInputs:
+    """Immutable inputs for one physical-center build.
+
+    Array-valued inputs are retained by reference to preserve existing behavior.
+    """
+
+    coarse_npz: Mapping[str, np.ndarray]
+    table: CoarsePickTable
+    feasible: FeasibleBandResult
+    trend: TrendResult
+    merged: MergeResult
+    cfg: PhysicsLiteConfig
+    trend_provider: object | None = None
+
+
+@dataclass(frozen=True)
+class PhysicalCenterBuildContext:
+    """Geometry, source grouping, and fit-preparation state.
+
+    Array-valued fields are retained by reference. Mutable execution state belongs
+    in ``PhysicalCenterWorkspace`` instead.
+    """
+
+    geometry_context: PhysicalCenterGeometryContext
+    pick_t_sec: np.ndarray
+    valid_for_fit: np.ndarray
+    group_context_by_id: Mapping[int, _GroupObservationContext]
+    observation_plan_cache: _ObservationPlanCache
+    min_fit_obs: int
+
+    @property
+    def geometry(self) -> CoarseGeometry | None:
+        return self.geometry_context.geometry
+
+    @property
+    def offset_abs_m(self) -> np.ndarray:
+        offset_abs_m = self.geometry_context.offset_abs_m
+        if offset_abs_m is None:
+            msg = 'physical-center build context requires offset_abs_m'
+            raise RuntimeError(msg)
+        return offset_abs_m
+
+    @property
+    def offset_signed_m(self) -> np.ndarray | None:
+        return self.geometry_context.offset_signed_m
+
+    @property
+    def offset_signed_labels(self) -> _SignedOffsetSideLabels | None:
+        return self.geometry_context.offset_signed_labels
+
+    @property
+    def offset_source(self) -> int:
+        return int(self.geometry_context.offset_source)
+
+    @property
+    def groups(self) -> tuple[SourceGroup, ...]:
+        return self.geometry_context.groups
+
+    @property
+    def groups_by_id(self) -> Mapping[int, SourceGroup]:
+        return self.geometry_context.groups_by_id
+
+    @property
+    def group_id_by_trace(self) -> np.ndarray:
+        return self.geometry_context.group_id_by_trace
+
+    @property
+    def source_groups_from_geometry(self) -> bool:
+        return bool(self.geometry_context.source_groups_from_geometry)
+
+
+@dataclass
+class PhysicalCenterWorkspace:
+    """Mutable execution state for one physical-center build."""
+
+    arrays: dict[str, np.ndarray]
+    fit_cache: dict[tuple[int, ...], _FitCacheEntry]
+    runtime_diagnostics: PhysicalRuntimeDiagnostics | None = None
+    pending_trend_fallback: _PendingTrendFallback | None = None

--- a/packages/seisai-engine/src/seisai_engine/pipelines/fbpick/physics/physical_center_context_fit.py
+++ b/packages/seisai-engine/src/seisai_engine/pipelines/fbpick/physics/physical_center_context_fit.py
@@ -1,0 +1,806 @@
+"""Fit-context preparation, execution, and assignment helpers."""
+
+from __future__ import annotations
+
+import time
+from collections.abc import Callable
+from contextlib import nullcontext
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+import numpy as np
+
+from .physical_center_fallback import _assign_fallback
+from .physical_center_fit import (
+    _confidence_weights_for_obs,
+    _fit_key_for_obs,
+    _fit_min_pts,
+    _fit_model_for_plan,
+    _fit_progress_fields,
+    _fit_task_cfg_values,
+    _fit_task_from_work_item,
+    _FitCacheEntry,
+    _run_fit_tasks_with_executor,
+    _sample_observation_indices_for_fit,
+)
+from .physical_center_observation import (
+    _build_observation_plan as _build_observation_plan_with_min_obs,
+)
+from .physical_center_observation import (
+    _ObservationPlan,
+)
+from .physical_center_prediction import (
+    _assign_prepared_model_prediction_batch,
+    _TraceFitResult,
+    _TracePlanAssignment,
+)
+from .physical_center_types import (
+    PHYSICAL_MODEL_FAILURE_FIT_FAILED,
+    PHYSICAL_MODEL_FAILURE_GEOMETRY_INVALID,
+    PHYSICAL_MODEL_FAILURE_INSUFFICIENT_OBSERVATIONS,
+)
+from .progress import NullProgressReporter
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+
+    from .config import PhysicsLiteConfig
+    from .feasible import FeasibleBandResult
+    from .geometry import CoarseGeometry
+    from .merge import MergeResult
+    from .physical_center_fallback import _PendingTrendFallback
+    from .physical_center_fit import (
+        _FitTask,
+        _FitTaskResult,
+        _PhysicalFitStrategy,
+    )
+    from .physical_center_observation import (
+        _GroupObservationContext,
+        _ObservationPlanCache,
+    )
+    from .pick_table import CoarsePickTable
+    from .runtime_diagnostics import PhysicalRuntimeDiagnostics
+    from .trend import TrendResult
+
+_FitDiagnostics = tuple[float, float, float, float, float, float, float]
+_FitModelForPlan = Callable[
+    ...,
+    tuple[object | None, _FitDiagnostics | None, int | None],
+]
+
+
+@dataclass(frozen=True)
+class _FitContextWorkItem:
+    fit_key: tuple[int, ...]
+    fit_plan: _ObservationPlan
+    obs_count_before_sampling: int
+    trace_indices: np.ndarray
+    runtime_fit_source: int
+    assignments: tuple[_TracePlanAssignment, ...]
+    x_obs: np.ndarray
+    y_obs: np.ndarray
+    w_obs: np.ndarray
+
+
+@dataclass(frozen=True)
+class _FitContextWorkResult:
+    trend_model: object | None
+    diagnostics: _FitDiagnostics | None
+    valid_trace_indices: frozenset[int]
+
+
+def _build_observation_plan(  # noqa: PLR0913
+    *,
+    trace_idx: int,
+    target_group_id: int,
+    group_context_by_id: Mapping[int, _GroupObservationContext],
+    geometry: CoarseGeometry | None,
+    offset_abs_m: np.ndarray,
+    offset_signed_m: np.ndarray | None,
+    cfg: PhysicsLiteConfig,
+    runtime_diagnostics: PhysicalRuntimeDiagnostics | None = None,
+    plan_cache: _ObservationPlanCache | None = None,
+    min_fit_obs: int | None = None,
+) -> _ObservationPlan | None:
+    return _build_observation_plan_with_min_obs(
+        trace_idx=trace_idx,
+        target_group_id=target_group_id,
+        group_context_by_id=group_context_by_id,
+        geometry=geometry,
+        offset_abs_m=offset_abs_m,
+        offset_signed_m=offset_signed_m,
+        cfg=cfg,
+        min_fit_obs=(
+            2 * _fit_min_pts(cfg) if min_fit_obs is None else int(min_fit_obs)
+        ),
+        runtime_diagnostics=runtime_diagnostics,
+        plan_cache=plan_cache,
+    )
+
+
+def _prepare_trace_plan_assignment(  # noqa: PLR0913
+    *,
+    arrays: dict[str, np.ndarray],
+    trace_idx: int,
+    group_id_by_trace: np.ndarray,
+    group_context_by_id: Mapping[int, _GroupObservationContext],
+    geometry: CoarseGeometry | None,
+    offset_abs_m: np.ndarray,
+    offset_signed_m: np.ndarray | None,
+    offset_source: int,
+    pick_t_sec: np.ndarray,
+    table: CoarsePickTable,
+    feasible: FeasibleBandResult,
+    trend: TrendResult,
+    trend_provider: object | None = None,
+    merged: MergeResult,
+    cfg: PhysicsLiteConfig,
+    observation_plan_cache: _ObservationPlanCache,
+    min_fit_obs: int,
+    runtime_diagnostics: PhysicalRuntimeDiagnostics | None,
+    pending_trend_fallback: _PendingTrendFallback | None = None,
+) -> _TracePlanAssignment | None:
+    arrays['physical_offset_source'][trace_idx] = np.uint8(offset_source)
+    if (
+        not np.isfinite(offset_abs_m[trace_idx])
+        or int(group_id_by_trace[trace_idx]) < 0
+    ):
+        _assign_fallback(
+            arrays,
+            trace_idx,
+            failure_reason=PHYSICAL_MODEL_FAILURE_GEOMETRY_INVALID,
+            table=table,
+            feasible=feasible,
+            trend=trend,
+            trend_provider=trend_provider,
+            merged=merged,
+            pending_trend_fallback=pending_trend_fallback,
+        )
+        return None
+
+    plan = _build_observation_plan(
+        trace_idx=trace_idx,
+        target_group_id=int(group_id_by_trace[trace_idx]),
+        group_context_by_id=group_context_by_id,
+        geometry=geometry,
+        offset_abs_m=offset_abs_m,
+        offset_signed_m=offset_signed_m,
+        cfg=cfg,
+        runtime_diagnostics=runtime_diagnostics,
+        plan_cache=observation_plan_cache,
+    )
+    if plan is None:
+        _assign_fallback(
+            arrays,
+            trace_idx,
+            failure_reason=PHYSICAL_MODEL_FAILURE_INSUFFICIENT_OBSERVATIONS,
+            table=table,
+            feasible=feasible,
+            trend=trend,
+            trend_provider=trend_provider,
+            merged=merged,
+            pending_trend_fallback=pending_trend_fallback,
+        )
+        return None
+
+    arrays['physical_model_neighbor_count'][trace_idx] = np.int32(plan.neighbor_count)
+    arrays['physical_prefilter_valid_count'][trace_idx] = np.int32(
+        plan.prefilter_valid_count
+    )
+    arrays['physical_model_segment_id'][trace_idx] = np.int32(plan.segment_id)
+    arrays['physical_model_side'][trace_idx] = np.int8(plan.side)
+
+    if int(plan.obs_indices.size) < int(min_fit_obs):
+        _assign_fallback(
+            arrays,
+            trace_idx,
+            failure_reason=PHYSICAL_MODEL_FAILURE_INSUFFICIENT_OBSERVATIONS,
+            table=table,
+            feasible=feasible,
+            trend=trend,
+            trend_provider=trend_provider,
+            merged=merged,
+            pending_trend_fallback=pending_trend_fallback,
+        )
+        return None
+
+    obs_count_before_sampling = int(np.asarray(plan.obs_indices).size)
+    with (
+        runtime_diagnostics.time_block('observation_sampling_sec')
+        if runtime_diagnostics is not None
+        else nullcontext()
+    ):
+        obs_indices = _sample_observation_indices_for_fit(
+            obs_indices=plan.obs_indices,
+            offset_abs_m=offset_abs_m,
+            pick_t_sec=pick_t_sec,
+            coarse_pmax=table.coarse_pmax,
+            cfg=cfg,
+            min_required_obs=int(min_fit_obs),
+        )
+    sampling_changed = obs_indices is not plan.obs_indices
+    precomputed_fit_key = None if sampling_changed else plan.obs_key
+    fit_key = _fit_key_for_obs(
+        obs_indices,
+        precomputed_key=precomputed_fit_key,
+        runtime_diagnostics=runtime_diagnostics,
+        after_sampling=sampling_changed,
+        count_missing_precomputed=not sampling_changed,
+    )
+    fit_plan = _ObservationPlan(
+        obs_indices=obs_indices,
+        obs_key=fit_key,
+        neighbor_count=plan.neighbor_count,
+        prefilter_valid_count=plan.prefilter_valid_count,
+        segment_id=plan.segment_id,
+        side=plan.side,
+        relaxed=plan.relaxed,
+    )
+    return _TracePlanAssignment(
+        trace_idx=int(trace_idx),
+        plan=fit_plan,
+        fit_key=fit_key,
+        obs_count_before_sampling=obs_count_before_sampling,
+    )
+
+
+def _build_fit_context_work_items(
+    grouped_assignments: Mapping[tuple[int, ...], list[_TracePlanAssignment]],
+    *,
+    offset_abs_m: np.ndarray,
+    pick_t_sec: np.ndarray,
+    coarse_pmax: np.ndarray,
+    runtime_fit_source: int,
+) -> list[_FitContextWorkItem]:
+    work_items: list[_FitContextWorkItem] = []
+    for fit_key, assignments in grouped_assignments.items():
+        if not assignments:
+            continue
+        first = assignments[0]
+        trace_indices = np.asarray(
+            [item.trace_idx for item in assignments],
+            dtype=np.int64,
+        )
+        obs_indices = np.asarray(first.plan.obs_indices, dtype=np.int64)
+        work_items.append(
+            _FitContextWorkItem(
+                fit_key=fit_key,
+                fit_plan=first.plan,
+                obs_count_before_sampling=first.obs_count_before_sampling,
+                trace_indices=trace_indices,
+                runtime_fit_source=int(runtime_fit_source),
+                assignments=tuple(assignments),
+                x_obs=np.asarray(offset_abs_m[obs_indices], dtype=np.float32),
+                y_obs=np.asarray(pick_t_sec[obs_indices], dtype=np.float32),
+                w_obs=_confidence_weights_for_obs(
+                    np.asarray(coarse_pmax, dtype=np.float32)[obs_indices]
+                ),
+            )
+        )
+    return work_items
+
+
+def _assign_fit_context_fallback(  # noqa: PLR0913
+    *,
+    arrays: dict[str, np.ndarray],
+    work_item: _FitContextWorkItem,
+    failure_reason: int,
+    table: CoarsePickTable,
+    feasible: FeasibleBandResult,
+    trend: TrendResult,
+    trend_provider: object | None = None,
+    merged: MergeResult,
+    pending_trend_fallback: _PendingTrendFallback | None = None,
+) -> None:
+    for trace_idx in np.asarray(work_item.trace_indices, dtype=np.int64).tolist():
+        _assign_fallback(
+            arrays,
+            int(trace_idx),
+            failure_reason=int(failure_reason),
+            table=table,
+            feasible=feasible,
+            trend=trend,
+            trend_provider=trend_provider,
+            merged=merged,
+            pending_trend_fallback=pending_trend_fallback,
+        )
+
+
+def _fit_and_assign_context_work_item(  # noqa: PLR0913
+    *,
+    arrays: dict[str, np.ndarray],
+    work_item: _FitContextWorkItem,
+    offset_abs_m: np.ndarray,
+    table: CoarsePickTable,
+    feasible: FeasibleBandResult,
+    trend: TrendResult,
+    trend_provider: object | None = None,
+    merged: MergeResult,
+    cfg: PhysicsLiteConfig,
+    strategy: _PhysicalFitStrategy,
+    fit_cache: dict[tuple[int, ...], _FitCacheEntry],
+    runtime_diagnostics: PhysicalRuntimeDiagnostics | None,
+    fit_model_for_plan: _FitModelForPlan | None = None,
+    pending_trend_fallback: _PendingTrendFallback | None = None,
+) -> _FitContextWorkResult:
+    fit_model = (
+        _fit_model_for_plan
+        if fit_model_for_plan is None
+        else fit_model_for_plan
+    )
+    trend_model, diagnostics, fit_failure_reason = fit_model(
+        strategy=strategy,
+        plan=work_item.fit_plan,
+        x_obs=work_item.x_obs,
+        y_obs=work_item.y_obs,
+        w_obs=work_item.w_obs,
+        min_pts=_fit_min_pts(cfg),
+        min_offset_spread_m=float(cfg.physical_trend.min_offset_spread_m),
+        cache=fit_cache,
+        runtime_diagnostics=runtime_diagnostics,
+        obs_count_before_sampling=int(work_item.obs_count_before_sampling),
+    )
+    if (
+        runtime_diagnostics is not None
+        and work_item.fit_key in fit_cache
+        and int(work_item.trace_indices.size) > 1
+    ):
+        runtime_diagnostics.record_cache_hit(int(work_item.trace_indices.size) - 1)
+
+    return _assign_fit_context_work_item_outcome(
+        arrays=arrays,
+        work_item=work_item,
+        offset_abs_m=offset_abs_m,
+        table=table,
+        feasible=feasible,
+        trend=trend,
+        trend_provider=trend_provider,
+        merged=merged,
+        fit_cache=fit_cache,
+        trend_model=trend_model,
+        diagnostics=diagnostics,
+        fit_failure_reason=fit_failure_reason,
+        runtime_diagnostics=runtime_diagnostics,
+        pending_trend_fallback=pending_trend_fallback,
+    )
+
+
+def _assign_fit_context_work_item_outcome(  # noqa: PLR0913
+    *,
+    arrays: dict[str, np.ndarray],
+    work_item: _FitContextWorkItem,
+    offset_abs_m: np.ndarray,
+    table: CoarsePickTable,
+    feasible: FeasibleBandResult,
+    trend: TrendResult,
+    trend_provider: object | None = None,
+    merged: MergeResult,
+    fit_cache: dict[tuple[int, ...], _FitCacheEntry],
+    trend_model: object | None,
+    diagnostics: _FitDiagnostics | None,
+    fit_failure_reason: int | None,
+    runtime_diagnostics: PhysicalRuntimeDiagnostics | None,
+    pending_trend_fallback: _PendingTrendFallback | None = None,
+) -> _FitContextWorkResult:
+    if fit_failure_reason is not None:
+        _assign_fit_context_fallback(
+            arrays=arrays,
+            work_item=work_item,
+            failure_reason=fit_failure_reason,
+            table=table,
+            feasible=feasible,
+            trend=trend,
+            trend_provider=trend_provider,
+            merged=merged,
+            pending_trend_fallback=pending_trend_fallback,
+        )
+        return _FitContextWorkResult(
+            trend_model=None,
+            diagnostics=None,
+            valid_trace_indices=frozenset(),
+        )
+
+    if trend_model is None:
+        _assign_fit_context_fallback(
+            arrays=arrays,
+            work_item=work_item,
+            failure_reason=PHYSICAL_MODEL_FAILURE_FIT_FAILED,
+            table=table,
+            feasible=feasible,
+            trend=trend,
+            trend_provider=trend_provider,
+            merged=merged,
+            pending_trend_fallback=pending_trend_fallback,
+        )
+        return _FitContextWorkResult(
+            trend_model=None,
+            diagnostics=None,
+            valid_trace_indices=frozenset(),
+        )
+
+    items = [
+        (
+            int(item.trace_idx),
+            _TraceFitResult(
+                plan=item.plan,
+                trend_model=trend_model,
+                diagnostics=diagnostics,
+                x_obs=work_item.x_obs,
+                y_obs=work_item.y_obs,
+            ),
+        )
+        for item in work_item.assignments
+    ]
+    valid, diagnostics = _assign_prepared_model_prediction_batch(
+        arrays=arrays,
+        items=items,
+        offset_abs_m=offset_abs_m,
+        dt=float(table.dt_scalar_sec),
+        n_samples=int(table.n_samples_orig),
+        runtime_fit_source=int(work_item.runtime_fit_source),
+        table=table,
+        feasible=feasible,
+        trend=trend,
+        trend_provider=trend_provider,
+        merged=merged,
+        fit_cache=fit_cache,
+        runtime_diagnostics=runtime_diagnostics,
+        pending_trend_fallback=pending_trend_fallback,
+    )
+    return _FitContextWorkResult(
+        trend_model=trend_model,
+        diagnostics=diagnostics,
+        valid_trace_indices=frozenset(
+            int(trace_idx)
+            for trace_idx in np.asarray(
+                work_item.trace_indices,
+                dtype=np.int64,
+            )[valid].tolist()
+        ),
+    )
+
+
+def _prepare_fit_context_assignments_for_trace_indices(  # noqa: PLR0913
+    trace_indices: np.ndarray,
+    *,
+    arrays: dict[str, np.ndarray],
+    group_id_by_trace: np.ndarray,
+    group_context_by_id: Mapping[int, _GroupObservationContext],
+    geometry: CoarseGeometry | None,
+    offset_abs_m: np.ndarray,
+    offset_signed_m: np.ndarray | None,
+    offset_source: int,
+    pick_t_sec: np.ndarray,
+    table: CoarsePickTable,
+    feasible: FeasibleBandResult,
+    trend: TrendResult,
+    trend_provider: object | None = None,
+    merged: MergeResult,
+    cfg: PhysicsLiteConfig,
+    observation_plan_cache: _ObservationPlanCache,
+    min_fit_obs: int,
+    runtime_diagnostics: PhysicalRuntimeDiagnostics | None,
+    pending_trend_fallback: _PendingTrendFallback | None = None,
+) -> tuple[
+    dict[tuple[int, ...], list[_TracePlanAssignment]],
+    list[_TracePlanAssignment],
+]:
+    grouped: dict[tuple[int, ...], list[_TracePlanAssignment]] = {}
+    ordered: list[_TracePlanAssignment] = []
+    for trace_idx in np.asarray(trace_indices, dtype=np.int64).tolist():
+        assignment = _prepare_trace_plan_assignment(
+            arrays=arrays,
+            trace_idx=int(trace_idx),
+            group_id_by_trace=group_id_by_trace,
+            group_context_by_id=group_context_by_id,
+            geometry=geometry,
+            offset_abs_m=offset_abs_m,
+            offset_signed_m=offset_signed_m,
+            offset_source=offset_source,
+            pick_t_sec=pick_t_sec,
+            table=table,
+            feasible=feasible,
+            trend=trend,
+            trend_provider=trend_provider,
+            merged=merged,
+            cfg=cfg,
+            observation_plan_cache=observation_plan_cache,
+            min_fit_obs=min_fit_obs,
+            runtime_diagnostics=runtime_diagnostics,
+            pending_trend_fallback=pending_trend_fallback,
+        )
+        if assignment is None:
+            continue
+        grouped.setdefault(assignment.fit_key, []).append(assignment)
+        ordered.append(assignment)
+    return grouped, ordered
+
+
+def _fit_and_assign_context_work_items(  # noqa: PLR0913
+    work_items: list[_FitContextWorkItem],
+    *,
+    arrays: dict[str, np.ndarray],
+    offset_abs_m: np.ndarray,
+    table: CoarsePickTable,
+    feasible: FeasibleBandResult,
+    trend: TrendResult,
+    trend_provider: object | None = None,
+    merged: MergeResult,
+    cfg: PhysicsLiteConfig,
+    strategy: _PhysicalFitStrategy,
+    fit_cache: dict[tuple[int, ...], _FitCacheEntry],
+    runtime_diagnostics: PhysicalRuntimeDiagnostics | None,
+    progress: object | None = None,
+    progress_context: Mapping[str, object] | None = None,
+    fit_model_for_plan: _FitModelForPlan | None = None,
+    pending_trend_fallback: _PendingTrendFallback | None = None,
+) -> dict[tuple[int, ...], _FitContextWorkResult]:
+    reporter = progress if progress is not None else NullProgressReporter()
+    context = dict(progress_context or {})
+    fit_start = time.perf_counter()
+    if bool(cfg.physical_runtime.fit_executor.enabled) and work_items:
+        return _fit_and_assign_context_work_items_parallel(
+            work_items,
+            arrays=arrays,
+            offset_abs_m=offset_abs_m,
+            table=table,
+            feasible=feasible,
+            trend=trend,
+            trend_provider=trend_provider,
+            merged=merged,
+            cfg=cfg,
+            fit_cache=fit_cache,
+            runtime_diagnostics=runtime_diagnostics,
+            progress=reporter,
+            progress_context=context,
+            progress_start_sec=fit_start,
+            pending_trend_fallback=pending_trend_fallback,
+        )
+
+    results: dict[tuple[int, ...], _FitContextWorkResult] = {}
+    total = len(work_items)
+    reporter.emit(
+        'physical-center.fit_start',
+        **context,
+        work_items=total,
+        executor='serial',
+    )
+    for done, work_item in enumerate(work_items, start=1):
+        results[work_item.fit_key] = _fit_and_assign_context_work_item(
+            arrays=arrays,
+            work_item=work_item,
+            offset_abs_m=offset_abs_m,
+            table=table,
+            feasible=feasible,
+            trend=trend,
+            trend_provider=trend_provider,
+            merged=merged,
+            cfg=cfg,
+            strategy=strategy,
+            fit_cache=fit_cache,
+            runtime_diagnostics=runtime_diagnostics,
+            fit_model_for_plan=fit_model_for_plan,
+            pending_trend_fallback=pending_trend_fallback,
+        )
+        reporter.emit(
+            'fit.progress',
+            **context,
+            **_fit_progress_fields(
+                done=done,
+                total=total,
+                start_sec=fit_start,
+                runtime_diagnostics=runtime_diagnostics,
+                force=done >= total,
+            ),
+        )
+    return results
+
+
+def _record_cached_context_hits(
+    *,
+    runtime_diagnostics: PhysicalRuntimeDiagnostics | None,
+    work_item: _FitContextWorkItem,
+) -> None:
+    if runtime_diagnostics is None:
+        return
+    extra_hits = int(work_item.trace_indices.size) - 1
+    if extra_hits > 0:
+        runtime_diagnostics.record_cache_hit(extra_hits)
+
+
+def _record_new_fit_task_diagnostics(
+    *,
+    runtime_diagnostics: PhysicalRuntimeDiagnostics | None,
+    work_item: _FitContextWorkItem,
+    task_result: _FitTaskResult,
+) -> None:
+    if runtime_diagnostics is None:
+        return
+    if task_result.failure_reason == PHYSICAL_MODEL_FAILURE_INSUFFICIENT_OBSERVATIONS:
+        return
+    runtime_diagnostics.record_cache_miss()
+    if bool(task_result.fit_attempted):
+        runtime_diagnostics.record_ransac_fit(
+            elapsed_sec=float(task_result.elapsed_sec),
+            obs_count=int(task_result.obs_count),
+            obs_count_before=int(task_result.obs_count_before_sampling),
+        )
+    extra_hits = int(work_item.trace_indices.size) - 1
+    if extra_hits > 0:
+        runtime_diagnostics.record_cache_hit(extra_hits)
+
+
+def _cache_entry_from_fit_task_result(
+    task_result: _FitTaskResult,
+) -> _FitCacheEntry | None:
+    if task_result.failure_reason == PHYSICAL_MODEL_FAILURE_INSUFFICIENT_OBSERVATIONS:
+        return None
+    if task_result.failure_reason is not None:
+        return _FitCacheEntry(
+            model=None,
+            diagnostics=None,
+            fit_failed=bool(task_result.fit_failed),
+            failure_reason=task_result.failure_reason,
+        )
+    if bool(task_result.fit_failed):
+        return _FitCacheEntry(
+            model=None,
+            diagnostics=None,
+            fit_failed=True,
+            failure_reason=PHYSICAL_MODEL_FAILURE_FIT_FAILED,
+        )
+    return _FitCacheEntry(
+        model=task_result.trend_model,
+        diagnostics=task_result.diagnostics,
+        fit_failed=False,
+        diagnostics_computed=task_result.diagnostics is not None,
+    )
+
+
+def _fit_and_assign_context_work_items_parallel(  # noqa: PLR0913
+    work_items: list[_FitContextWorkItem],
+    *,
+    arrays: dict[str, np.ndarray],
+    offset_abs_m: np.ndarray,
+    table: CoarsePickTable,
+    feasible: FeasibleBandResult,
+    trend: TrendResult,
+    trend_provider: object | None = None,
+    merged: MergeResult,
+    cfg: PhysicsLiteConfig,
+    fit_cache: dict[tuple[int, ...], _FitCacheEntry],
+    runtime_diagnostics: PhysicalRuntimeDiagnostics | None,
+    progress: object | None = None,
+    progress_context: Mapping[str, object] | None = None,
+    progress_start_sec: float | None = None,
+    pending_trend_fallback: _PendingTrendFallback | None = None,
+) -> dict[tuple[int, ...], _FitContextWorkResult]:
+    reporter = progress if progress is not None else NullProgressReporter()
+    context = dict(progress_context or {})
+    fit_start = (
+        time.perf_counter()
+        if progress_start_sec is None
+        else progress_start_sec
+    )
+    total = len(work_items)
+    done = 0
+    reporter.emit(
+        'physical-center.fit_start',
+        **context,
+        work_items=total,
+        executor=str(cfg.physical_runtime.fit_executor.backend),
+        max_workers=cfg.physical_runtime.fit_executor.max_workers,
+    )
+    results: dict[tuple[int, ...], _FitContextWorkResult] = {}
+    pending_items: list[_FitContextWorkItem] = []
+    tasks: list[_FitTask] = []
+    cfg_values = _fit_task_cfg_values(cfg)
+
+    for work_item in work_items:
+        entry = fit_cache.get(work_item.fit_key)
+        if entry is None:
+            pending_items.append(work_item)
+            tasks.append(
+                _fit_task_from_work_item(work_item, cfg_values=cfg_values)
+            )
+            continue
+
+        _record_cached_context_hits(
+            runtime_diagnostics=runtime_diagnostics,
+            work_item=work_item,
+        )
+        fit_failure_reason = entry.failure_reason
+        if fit_failure_reason is None and bool(entry.fit_failed):
+            fit_failure_reason = PHYSICAL_MODEL_FAILURE_FIT_FAILED
+        results[work_item.fit_key] = _assign_fit_context_work_item_outcome(
+            arrays=arrays,
+            work_item=work_item,
+            offset_abs_m=offset_abs_m,
+            table=table,
+            feasible=feasible,
+            trend=trend,
+            trend_provider=trend_provider,
+            merged=merged,
+            fit_cache=fit_cache,
+            trend_model=entry.model,
+            diagnostics=entry.diagnostics,
+            fit_failure_reason=fit_failure_reason,
+            runtime_diagnostics=runtime_diagnostics,
+            pending_trend_fallback=pending_trend_fallback,
+        )
+        done += 1
+        reporter.emit(
+            'fit.progress',
+            **context,
+            **_fit_progress_fields(
+                done=done,
+                total=total,
+                start_sec=fit_start,
+                runtime_diagnostics=runtime_diagnostics,
+                force=done >= total,
+            ),
+        )
+
+    if tasks:
+        start = time.perf_counter()
+        task_results_by_key = _run_fit_tasks_with_executor(
+            tasks,
+            cfg=cfg,
+            progress=reporter,
+            progress_context=context,
+            progress_start_done=done,
+            progress_total=total,
+            progress_start_sec=fit_start,
+            runtime_diagnostics=runtime_diagnostics,
+            progress_cache_miss_base=(
+                int(runtime_diagnostics.n_cache_misses)
+                if runtime_diagnostics is not None
+                else 0
+            ),
+            progress_fit_calls_base=(
+                int(runtime_diagnostics.n_fit_calls)
+                if runtime_diagnostics is not None
+                else 0
+            ),
+            progress_fit_total_sec_base=(
+                float(runtime_diagnostics.ransac_fit_total_sec)
+                if runtime_diagnostics is not None
+                else 0.0
+            ),
+        )
+        wall_sec = time.perf_counter() - start
+        if runtime_diagnostics is not None:
+            runtime_diagnostics.record_fit_executor_run(
+                wall_sec=wall_sec,
+                tasks=len(tasks),
+            )
+
+        for work_item in pending_items:
+            task_result = task_results_by_key[work_item.fit_key]
+            entry = _cache_entry_from_fit_task_result(task_result)
+            if entry is not None:
+                fit_cache[work_item.fit_key] = entry
+            _record_new_fit_task_diagnostics(
+                runtime_diagnostics=runtime_diagnostics,
+                work_item=work_item,
+                task_result=task_result,
+            )
+            done += 1
+            results[work_item.fit_key] = _assign_fit_context_work_item_outcome(
+                arrays=arrays,
+                work_item=work_item,
+                offset_abs_m=offset_abs_m,
+                table=table,
+                feasible=feasible,
+                trend=trend,
+                trend_provider=trend_provider,
+                merged=merged,
+                fit_cache=fit_cache,
+                trend_model=task_result.trend_model,
+                diagnostics=task_result.diagnostics,
+                fit_failure_reason=task_result.failure_reason,
+                runtime_diagnostics=runtime_diagnostics,
+                pending_trend_fallback=pending_trend_fallback,
+            )
+
+    return results

--- a/packages/seisai-engine/src/seisai_engine/pipelines/fbpick/physics/physical_center_context_fit.py
+++ b/packages/seisai-engine/src/seisai_engine/pipelines/fbpick/physics/physical_center_context_fit.py
@@ -10,6 +10,11 @@ from typing import TYPE_CHECKING
 
 import numpy as np
 
+from .physical_center_context import (
+    PhysicalCenterBuildContext,
+    PhysicalCenterInputs,
+    PhysicalCenterWorkspace,
+)
 from .physical_center_fallback import _assign_fallback
 from .physical_center_fit import (
     _confidence_weights_for_obs,
@@ -120,26 +125,16 @@ def _build_observation_plan(  # noqa: PLR0913
 
 def _prepare_trace_plan_assignment(  # noqa: PLR0913
     *,
-    arrays: dict[str, np.ndarray],
+    inputs: PhysicalCenterInputs,
+    build_context: PhysicalCenterBuildContext,
+    workspace: PhysicalCenterWorkspace,
     trace_idx: int,
-    group_id_by_trace: np.ndarray,
-    group_context_by_id: Mapping[int, _GroupObservationContext],
-    geometry: CoarseGeometry | None,
-    offset_abs_m: np.ndarray,
-    offset_signed_m: np.ndarray | None,
-    offset_source: int,
-    pick_t_sec: np.ndarray,
-    table: CoarsePickTable,
-    feasible: FeasibleBandResult,
-    trend: TrendResult,
-    trend_provider: object | None = None,
-    merged: MergeResult,
-    cfg: PhysicsLiteConfig,
-    observation_plan_cache: _ObservationPlanCache,
-    min_fit_obs: int,
-    runtime_diagnostics: PhysicalRuntimeDiagnostics | None,
-    pending_trend_fallback: _PendingTrendFallback | None = None,
 ) -> _TracePlanAssignment | None:
+    arrays = workspace.arrays
+    offset_abs_m = build_context.offset_abs_m
+    offset_source = build_context.offset_source
+    group_id_by_trace = build_context.group_id_by_trace
+    runtime_diagnostics = workspace.runtime_diagnostics
     arrays['physical_offset_source'][trace_idx] = np.uint8(offset_source)
     if (
         not np.isfinite(offset_abs_m[trace_idx])
@@ -149,37 +144,37 @@ def _prepare_trace_plan_assignment(  # noqa: PLR0913
             arrays,
             trace_idx,
             failure_reason=PHYSICAL_MODEL_FAILURE_GEOMETRY_INVALID,
-            table=table,
-            feasible=feasible,
-            trend=trend,
-            trend_provider=trend_provider,
-            merged=merged,
-            pending_trend_fallback=pending_trend_fallback,
+            table=inputs.table,
+            feasible=inputs.feasible,
+            trend=inputs.trend,
+            trend_provider=inputs.trend_provider,
+            merged=inputs.merged,
+            pending_trend_fallback=workspace.pending_trend_fallback,
         )
         return None
 
     plan = _build_observation_plan(
         trace_idx=trace_idx,
         target_group_id=int(group_id_by_trace[trace_idx]),
-        group_context_by_id=group_context_by_id,
-        geometry=geometry,
+        group_context_by_id=build_context.group_context_by_id,
+        geometry=build_context.geometry,
         offset_abs_m=offset_abs_m,
-        offset_signed_m=offset_signed_m,
-        cfg=cfg,
+        offset_signed_m=build_context.offset_signed_m,
+        cfg=inputs.cfg,
         runtime_diagnostics=runtime_diagnostics,
-        plan_cache=observation_plan_cache,
+        plan_cache=build_context.observation_plan_cache,
     )
     if plan is None:
         _assign_fallback(
             arrays,
             trace_idx,
             failure_reason=PHYSICAL_MODEL_FAILURE_INSUFFICIENT_OBSERVATIONS,
-            table=table,
-            feasible=feasible,
-            trend=trend,
-            trend_provider=trend_provider,
-            merged=merged,
-            pending_trend_fallback=pending_trend_fallback,
+            table=inputs.table,
+            feasible=inputs.feasible,
+            trend=inputs.trend,
+            trend_provider=inputs.trend_provider,
+            merged=inputs.merged,
+            pending_trend_fallback=workspace.pending_trend_fallback,
         )
         return None
 
@@ -190,17 +185,17 @@ def _prepare_trace_plan_assignment(  # noqa: PLR0913
     arrays['physical_model_segment_id'][trace_idx] = np.int32(plan.segment_id)
     arrays['physical_model_side'][trace_idx] = np.int8(plan.side)
 
-    if int(plan.obs_indices.size) < int(min_fit_obs):
+    if int(plan.obs_indices.size) < int(build_context.min_fit_obs):
         _assign_fallback(
             arrays,
             trace_idx,
             failure_reason=PHYSICAL_MODEL_FAILURE_INSUFFICIENT_OBSERVATIONS,
-            table=table,
-            feasible=feasible,
-            trend=trend,
-            trend_provider=trend_provider,
-            merged=merged,
-            pending_trend_fallback=pending_trend_fallback,
+            table=inputs.table,
+            feasible=inputs.feasible,
+            trend=inputs.trend,
+            trend_provider=inputs.trend_provider,
+            merged=inputs.merged,
+            pending_trend_fallback=workspace.pending_trend_fallback,
         )
         return None
 
@@ -213,10 +208,10 @@ def _prepare_trace_plan_assignment(  # noqa: PLR0913
         obs_indices = _sample_observation_indices_for_fit(
             obs_indices=plan.obs_indices,
             offset_abs_m=offset_abs_m,
-            pick_t_sec=pick_t_sec,
-            coarse_pmax=table.coarse_pmax,
-            cfg=cfg,
-            min_required_obs=int(min_fit_obs),
+            pick_t_sec=build_context.pick_t_sec,
+            coarse_pmax=inputs.table.coarse_pmax,
+            cfg=inputs.cfg,
+            min_required_obs=int(build_context.min_fit_obs),
         )
     sampling_changed = obs_indices is not plan.obs_indices
     precomputed_fit_key = None if sampling_changed else plan.obs_key
@@ -308,21 +303,16 @@ def _assign_fit_context_fallback(  # noqa: PLR0913
 
 def _fit_and_assign_context_work_item(  # noqa: PLR0913
     *,
-    arrays: dict[str, np.ndarray],
+    inputs: PhysicalCenterInputs,
+    build_context: PhysicalCenterBuildContext,
+    workspace: PhysicalCenterWorkspace,
     work_item: _FitContextWorkItem,
-    offset_abs_m: np.ndarray,
-    table: CoarsePickTable,
-    feasible: FeasibleBandResult,
-    trend: TrendResult,
-    trend_provider: object | None = None,
-    merged: MergeResult,
-    cfg: PhysicsLiteConfig,
     strategy: _PhysicalFitStrategy,
-    fit_cache: dict[tuple[int, ...], _FitCacheEntry],
-    runtime_diagnostics: PhysicalRuntimeDiagnostics | None,
     fit_model_for_plan: _FitModelForPlan | None = None,
-    pending_trend_fallback: _PendingTrendFallback | None = None,
 ) -> _FitContextWorkResult:
+    cfg = inputs.cfg
+    fit_cache = workspace.fit_cache
+    runtime_diagnostics = workspace.runtime_diagnostics
     fit_model = (
         _fit_model_for_plan
         if fit_model_for_plan is None
@@ -348,20 +338,20 @@ def _fit_and_assign_context_work_item(  # noqa: PLR0913
         runtime_diagnostics.record_cache_hit(int(work_item.trace_indices.size) - 1)
 
     return _assign_fit_context_work_item_outcome(
-        arrays=arrays,
+        arrays=workspace.arrays,
         work_item=work_item,
-        offset_abs_m=offset_abs_m,
-        table=table,
-        feasible=feasible,
-        trend=trend,
-        trend_provider=trend_provider,
-        merged=merged,
+        offset_abs_m=build_context.offset_abs_m,
+        table=inputs.table,
+        feasible=inputs.feasible,
+        trend=inputs.trend,
+        trend_provider=inputs.trend_provider,
+        merged=inputs.merged,
         fit_cache=fit_cache,
         trend_model=trend_model,
         diagnostics=diagnostics,
         fit_failure_reason=fit_failure_reason,
         runtime_diagnostics=runtime_diagnostics,
-        pending_trend_fallback=pending_trend_fallback,
+        pending_trend_fallback=workspace.pending_trend_fallback,
     )
 
 
@@ -463,24 +453,9 @@ def _assign_fit_context_work_item_outcome(  # noqa: PLR0913
 def _prepare_fit_context_assignments_for_trace_indices(  # noqa: PLR0913
     trace_indices: np.ndarray,
     *,
-    arrays: dict[str, np.ndarray],
-    group_id_by_trace: np.ndarray,
-    group_context_by_id: Mapping[int, _GroupObservationContext],
-    geometry: CoarseGeometry | None,
-    offset_abs_m: np.ndarray,
-    offset_signed_m: np.ndarray | None,
-    offset_source: int,
-    pick_t_sec: np.ndarray,
-    table: CoarsePickTable,
-    feasible: FeasibleBandResult,
-    trend: TrendResult,
-    trend_provider: object | None = None,
-    merged: MergeResult,
-    cfg: PhysicsLiteConfig,
-    observation_plan_cache: _ObservationPlanCache,
-    min_fit_obs: int,
-    runtime_diagnostics: PhysicalRuntimeDiagnostics | None,
-    pending_trend_fallback: _PendingTrendFallback | None = None,
+    inputs: PhysicalCenterInputs,
+    build_context: PhysicalCenterBuildContext,
+    workspace: PhysicalCenterWorkspace,
 ) -> tuple[
     dict[tuple[int, ...], list[_TracePlanAssignment]],
     list[_TracePlanAssignment],
@@ -489,25 +464,10 @@ def _prepare_fit_context_assignments_for_trace_indices(  # noqa: PLR0913
     ordered: list[_TracePlanAssignment] = []
     for trace_idx in np.asarray(trace_indices, dtype=np.int64).tolist():
         assignment = _prepare_trace_plan_assignment(
-            arrays=arrays,
+            inputs=inputs,
+            build_context=build_context,
+            workspace=workspace,
             trace_idx=int(trace_idx),
-            group_id_by_trace=group_id_by_trace,
-            group_context_by_id=group_context_by_id,
-            geometry=geometry,
-            offset_abs_m=offset_abs_m,
-            offset_signed_m=offset_signed_m,
-            offset_source=offset_source,
-            pick_t_sec=pick_t_sec,
-            table=table,
-            feasible=feasible,
-            trend=trend,
-            trend_provider=trend_provider,
-            merged=merged,
-            cfg=cfg,
-            observation_plan_cache=observation_plan_cache,
-            min_fit_obs=min_fit_obs,
-            runtime_diagnostics=runtime_diagnostics,
-            pending_trend_fallback=pending_trend_fallback,
         )
         if assignment is None:
             continue
@@ -519,42 +479,28 @@ def _prepare_fit_context_assignments_for_trace_indices(  # noqa: PLR0913
 def _fit_and_assign_context_work_items(  # noqa: PLR0913
     work_items: list[_FitContextWorkItem],
     *,
-    arrays: dict[str, np.ndarray],
-    offset_abs_m: np.ndarray,
-    table: CoarsePickTable,
-    feasible: FeasibleBandResult,
-    trend: TrendResult,
-    trend_provider: object | None = None,
-    merged: MergeResult,
-    cfg: PhysicsLiteConfig,
+    inputs: PhysicalCenterInputs,
+    build_context: PhysicalCenterBuildContext,
+    workspace: PhysicalCenterWorkspace,
     strategy: _PhysicalFitStrategy,
-    fit_cache: dict[tuple[int, ...], _FitCacheEntry],
-    runtime_diagnostics: PhysicalRuntimeDiagnostics | None,
     progress: object | None = None,
     progress_context: Mapping[str, object] | None = None,
     fit_model_for_plan: _FitModelForPlan | None = None,
-    pending_trend_fallback: _PendingTrendFallback | None = None,
 ) -> dict[tuple[int, ...], _FitContextWorkResult]:
+    cfg = inputs.cfg
+    runtime_diagnostics = workspace.runtime_diagnostics
     reporter = progress if progress is not None else NullProgressReporter()
     context = dict(progress_context or {})
     fit_start = time.perf_counter()
     if bool(cfg.physical_runtime.fit_executor.enabled) and work_items:
         return _fit_and_assign_context_work_items_parallel(
             work_items,
-            arrays=arrays,
-            offset_abs_m=offset_abs_m,
-            table=table,
-            feasible=feasible,
-            trend=trend,
-            trend_provider=trend_provider,
-            merged=merged,
-            cfg=cfg,
-            fit_cache=fit_cache,
-            runtime_diagnostics=runtime_diagnostics,
+            inputs=inputs,
+            build_context=build_context,
+            workspace=workspace,
             progress=reporter,
             progress_context=context,
             progress_start_sec=fit_start,
-            pending_trend_fallback=pending_trend_fallback,
         )
 
     results: dict[tuple[int, ...], _FitContextWorkResult] = {}
@@ -567,20 +513,12 @@ def _fit_and_assign_context_work_items(  # noqa: PLR0913
     )
     for done, work_item in enumerate(work_items, start=1):
         results[work_item.fit_key] = _fit_and_assign_context_work_item(
-            arrays=arrays,
+            inputs=inputs,
+            build_context=build_context,
+            workspace=workspace,
             work_item=work_item,
-            offset_abs_m=offset_abs_m,
-            table=table,
-            feasible=feasible,
-            trend=trend,
-            trend_provider=trend_provider,
-            merged=merged,
-            cfg=cfg,
             strategy=strategy,
-            fit_cache=fit_cache,
-            runtime_diagnostics=runtime_diagnostics,
             fit_model_for_plan=fit_model_for_plan,
-            pending_trend_fallback=pending_trend_fallback,
         )
         reporter.emit(
             'fit.progress',
@@ -660,21 +598,18 @@ def _cache_entry_from_fit_task_result(
 def _fit_and_assign_context_work_items_parallel(  # noqa: PLR0913
     work_items: list[_FitContextWorkItem],
     *,
-    arrays: dict[str, np.ndarray],
-    offset_abs_m: np.ndarray,
-    table: CoarsePickTable,
-    feasible: FeasibleBandResult,
-    trend: TrendResult,
-    trend_provider: object | None = None,
-    merged: MergeResult,
-    cfg: PhysicsLiteConfig,
-    fit_cache: dict[tuple[int, ...], _FitCacheEntry],
-    runtime_diagnostics: PhysicalRuntimeDiagnostics | None,
+    inputs: PhysicalCenterInputs,
+    build_context: PhysicalCenterBuildContext,
+    workspace: PhysicalCenterWorkspace,
     progress: object | None = None,
     progress_context: Mapping[str, object] | None = None,
     progress_start_sec: float | None = None,
-    pending_trend_fallback: _PendingTrendFallback | None = None,
 ) -> dict[tuple[int, ...], _FitContextWorkResult]:
+    cfg = inputs.cfg
+    arrays = workspace.arrays
+    fit_cache = workspace.fit_cache
+    runtime_diagnostics = workspace.runtime_diagnostics
+    offset_abs_m = build_context.offset_abs_m
     reporter = progress if progress is not None else NullProgressReporter()
     context = dict(progress_context or {})
     fit_start = (
@@ -716,17 +651,17 @@ def _fit_and_assign_context_work_items_parallel(  # noqa: PLR0913
             arrays=arrays,
             work_item=work_item,
             offset_abs_m=offset_abs_m,
-            table=table,
-            feasible=feasible,
-            trend=trend,
-            trend_provider=trend_provider,
-            merged=merged,
+            table=inputs.table,
+            feasible=inputs.feasible,
+            trend=inputs.trend,
+            trend_provider=inputs.trend_provider,
+            merged=inputs.merged,
             fit_cache=fit_cache,
             trend_model=entry.model,
             diagnostics=entry.diagnostics,
             fit_failure_reason=fit_failure_reason,
             runtime_diagnostics=runtime_diagnostics,
-            pending_trend_fallback=pending_trend_fallback,
+            pending_trend_fallback=workspace.pending_trend_fallback,
         )
         done += 1
         reporter.emit(
@@ -790,17 +725,17 @@ def _fit_and_assign_context_work_items_parallel(  # noqa: PLR0913
                 arrays=arrays,
                 work_item=work_item,
                 offset_abs_m=offset_abs_m,
-                table=table,
-                feasible=feasible,
-                trend=trend,
-                trend_provider=trend_provider,
-                merged=merged,
+                table=inputs.table,
+                feasible=inputs.feasible,
+                trend=inputs.trend,
+                trend_provider=inputs.trend_provider,
+                merged=inputs.merged,
                 fit_cache=fit_cache,
                 trend_model=task_result.trend_model,
                 diagnostics=task_result.diagnostics,
                 fit_failure_reason=task_result.failure_reason,
                 runtime_diagnostics=runtime_diagnostics,
-                pending_trend_fallback=pending_trend_fallback,
+                pending_trend_fallback=workspace.pending_trend_fallback,
             )
 
     return results

--- a/packages/seisai-engine/src/seisai_engine/pipelines/fbpick/physics/physical_center_fallback.py
+++ b/packages/seisai-engine/src/seisai_engine/pipelines/fbpick/physics/physical_center_fallback.py
@@ -9,6 +9,7 @@ import numpy as np
 
 from .feasible import FeasibleBandResult
 from .merge import MergeResult
+from .physical_center_context import PhysicalCenterInputs
 from .physical_center_types import (
     PHYSICAL_MODEL_FAILURE_PHYSICAL_DISABLED,
     PHYSICAL_MODEL_STATUS_FALLBACK_EXISTING_TREND,
@@ -759,15 +760,12 @@ def _emit_fallback_all_and_done(
     reason: str,
     fallback_mode: str,
     failure_reason: int,
-    table: CoarsePickTable,
-    feasible: FeasibleBandResult,
-    trend: TrendResult,
-    merged: MergeResult,
+    inputs: PhysicalCenterInputs,
     reporter: object,
     context: Mapping[str, object],
     runtime_diagnostics: PhysicalRuntimeDiagnostics | None,
-    trend_provider: object | None = None,
 ) -> PhysicalCenterResult:
+    table = inputs.table
     n = int(table.n_traces)
     reporter.emit(
         'physical-center.stage_start',
@@ -786,10 +784,10 @@ def _emit_fallback_all_and_done(
             fallback_mode=fallback_mode,
             failure_reason=failure_reason,
             table=table,
-            feasible=feasible,
-            trend=trend,
-            trend_provider=trend_provider,
-            merged=merged,
+            feasible=inputs.feasible,
+            trend=inputs.trend,
+            trend_provider=inputs.trend_provider,
+            merged=inputs.merged,
         )
     reporter.emit(
         'physical-center.stage_done',

--- a/packages/seisai-engine/src/seisai_engine/pipelines/fbpick/physics/physical_center_fit.py
+++ b/packages/seisai-engine/src/seisai_engine/pipelines/fbpick/physics/physical_center_fit.py
@@ -1,0 +1,771 @@
+"""Two-piece physical-center fitting helpers."""
+
+from __future__ import annotations
+
+import time
+from concurrent.futures import ProcessPoolExecutor, ThreadPoolExecutor, as_completed
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+import numpy as np
+import torch
+from seisai_pick.trend.trend_fit_strategy import (
+    TwoPieceIRLSAutoBreakStrategy,
+    TwoPieceRansacAutoBreakStrategy,
+)
+
+from .physical_center_observation import _indices_key
+from .physical_center_types import (
+    PHYSICAL_MODEL_FAILURE_FIT_FAILED,
+    PHYSICAL_MODEL_FAILURE_INSUFFICIENT_OBSERVATIONS,
+)
+from .progress import build_progress_reporter
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+
+    from .config import PhysicsLiteConfig
+    from .physical_center_observation import _ObservationPlan
+    from .runtime_diagnostics import PhysicalRuntimeDiagnostics
+
+_PhysicalFitStrategy = TwoPieceRansacAutoBreakStrategy | TwoPieceIRLSAutoBreakStrategy
+
+
+@dataclass(frozen=True)
+class _FitCacheEntry:
+    model: object | None
+    diagnostics: tuple[float, float, float, float, float, float, float] | None
+    fit_failed: bool
+    diagnostics_computed: bool = False
+    failure_reason: int | None = None
+
+
+@dataclass(frozen=True)
+class _FitTaskCfgValues:
+    fit_kind: str
+    n_iter: int
+    inlier_th_ms: float
+    irls_huber_c: float
+    irls_iters: int
+    min_pts: int
+    n_break_cand: int
+    q_lo: float
+    q_hi: float
+    seed: int
+    slope_eps: float
+    sort_offsets: bool
+    min_offset_spread_m: float
+    torch_num_threads_per_worker: int
+
+
+@dataclass(frozen=True)
+class _FitTask:
+    fit_key: tuple[int, ...]
+    x_obs: np.ndarray
+    y_obs: np.ndarray
+    w_obs: np.ndarray
+    obs_count_before_sampling: int
+    cfg_values: _FitTaskCfgValues
+
+
+@dataclass(frozen=True)
+class _FitTaskResult:
+    fit_key: tuple[int, ...]
+    trend_model: object | None
+    diagnostics: tuple[float, float, float, float, float, float, float] | None
+    fit_failed: bool
+    failure_reason: int | None
+    elapsed_sec: float
+    obs_count: int
+    obs_count_before_sampling: int
+    fit_attempted: bool
+
+
+def _tensor_to_numpy(value: object) -> np.ndarray:
+    if hasattr(value, 'detach'):
+        return value.detach().cpu().numpy()
+    return np.asarray(value)
+
+
+def _fit_min_pts(cfg: PhysicsLiteConfig) -> int:
+    if cfg.physical_trend.fit_kind == 'two_piece_irls_autobreak':
+        return int(cfg.two_piece_irls.min_pts)
+    return int(cfg.two_piece_ransac.min_pts)
+
+
+def _fit_strategy(cfg: PhysicsLiteConfig) -> _PhysicalFitStrategy:
+    if cfg.physical_trend.fit_kind == 'two_piece_irls_autobreak':
+        return TwoPieceIRLSAutoBreakStrategy(
+            huber_c=float(cfg.two_piece_irls.huber_c),
+            iters=int(cfg.two_piece_irls.iters),
+            min_pts=int(cfg.two_piece_irls.min_pts),
+            n_break_cand=int(cfg.two_piece_irls.n_break_cand),
+            q_lo=float(cfg.two_piece_irls.q_lo),
+            q_hi=float(cfg.two_piece_irls.q_hi),
+            slope_eps=float(cfg.two_piece_irls.slope_eps),
+            sort_offsets=bool(cfg.two_piece_irls.sort_offsets),
+        )
+    return TwoPieceRansacAutoBreakStrategy(
+        n_iter=int(cfg.two_piece_ransac.n_iter),
+        inlier_th_ms=float(cfg.two_piece_ransac.inlier_th_ms),
+        min_pts=int(cfg.two_piece_ransac.min_pts),
+        n_break_cand=int(cfg.two_piece_ransac.n_break_cand),
+        q_lo=float(cfg.two_piece_ransac.q_lo),
+        q_hi=float(cfg.two_piece_ransac.q_hi),
+        seed=int(cfg.two_piece_ransac.seed),
+        slope_eps=float(cfg.two_piece_ransac.slope_eps),
+        sort_offsets=bool(cfg.two_piece_ransac.sort_offsets),
+    )
+
+
+def _confidence_weights_for_obs(coarse_pmax_obs: np.ndarray) -> np.ndarray:
+    w = np.asarray(coarse_pmax_obs, dtype=np.float32)
+    if w.ndim != 1:
+        w = w.reshape(-1)
+    good = np.isfinite(w) & (w > np.float32(0.0))
+    if not bool(np.any(good)):
+        return np.ones_like(w, dtype=np.float32)
+    fill = np.float32(np.median(w[good].astype(np.float64, copy=False)))
+    out = np.where(good, w, fill).astype(np.float32, copy=False)
+    return np.clip(out, np.float32(1.0e-6), None)
+
+
+def _fit_strategy_model(
+    strategy: _PhysicalFitStrategy,
+    x_tensor: torch.Tensor,
+    y_tensor: torch.Tensor,
+    w_tensor: torch.Tensor,
+) -> object | None:
+    if isinstance(strategy, TwoPieceIRLSAutoBreakStrategy):
+        return strategy.fit(x_tensor, y_tensor, w_tensor)
+    return strategy.fit(x_tensor, y_tensor)
+
+
+def _median_time_position(local_positions: np.ndarray, y_obs: np.ndarray) -> int:
+    positions = np.asarray(local_positions, dtype=np.int64)
+    if positions.size == 0:
+        msg = 'local_positions must be non-empty'
+        raise ValueError(msg)
+    y_values = np.asarray(y_obs, dtype=np.float32)[positions]
+    finite = np.isfinite(y_values)
+    if not np.any(finite):
+        return int(positions[0])
+    finite_positions = positions[finite]
+    finite_y = y_values[finite]
+    median_y = float(np.median(finite_y.astype(np.float64, copy=False)))
+    return int(finite_positions[int(np.argmin(np.abs(finite_y - median_y)))])
+
+
+def _stable_observation_seed(seed: int, values: np.ndarray, *, bin_id: int) -> int:
+    acc = int(seed) & 0xFFFFFFFF
+    for value in np.asarray(values, dtype=np.int64).tolist():
+        acc = (acc * 1664525 + int(value) + 1013904223) & 0xFFFFFFFF
+    return int((acc + int(bin_id) * 374761393) & 0xFFFFFFFF)
+
+
+def _bin_representative_position(  # noqa: PLR0913
+    *,
+    local_positions: np.ndarray,
+    obs_indices: np.ndarray,
+    y_obs: np.ndarray,
+    p_obs: np.ndarray | None,
+    bin_pick: str,
+    random_seed: int,
+    bin_id: int,
+) -> int:
+    positions = np.asarray(local_positions, dtype=np.int64)
+    if positions.size == 0:
+        msg = 'local_positions must be non-empty'
+        raise ValueError(msg)
+    if bin_pick == 'median_time':
+        return _median_time_position(positions, y_obs)
+    if bin_pick == 'random':
+        seed = _stable_observation_seed(
+            random_seed,
+            np.asarray(obs_indices, dtype=np.int64)[positions],
+            bin_id=int(bin_id),
+        )
+        rng = np.random.default_rng(seed)
+        return int(positions[int(rng.integers(0, int(positions.size)))])
+
+    if p_obs is not None:
+        p_values = np.asarray(p_obs, dtype=np.float32)[positions]
+        finite = np.isfinite(p_values)
+        if np.any(finite):
+            finite_positions = positions[finite]
+            finite_p = p_values[finite]
+            return int(finite_positions[int(np.argmax(finite_p))])
+    return _median_time_position(positions, y_obs)
+
+
+def _evenly_spaced_positions(length: int, count: int) -> np.ndarray:
+    n = int(length)
+    k = int(count)
+    if k <= 0:
+        return np.zeros((0,), dtype=np.int64)
+    if k >= n:
+        return np.arange(n, dtype=np.int64)
+    raw = np.linspace(0.0, float(n - 1), num=k)
+    used: set[int] = set()
+    out: list[int] = []
+    for value in raw.tolist():
+        pos = int(np.rint(float(value)))
+        if pos in used:
+            for delta in range(1, n):
+                left = pos - delta
+                right = pos + delta
+                if left >= 0 and left not in used:
+                    pos = left
+                    break
+                if right < n and right not in used:
+                    pos = right
+                    break
+        used.add(pos)
+        out.append(pos)
+    return np.asarray(sorted(out), dtype=np.int64)
+
+
+def _limit_selected_positions(
+    selected_count: int,
+    *,
+    max_count: int,
+    preserve_edge_bins: bool,
+) -> np.ndarray:
+    n = int(selected_count)
+    max_n = int(max_count)
+    if n <= max_n:
+        return np.arange(n, dtype=np.int64)
+    if bool(preserve_edge_bins) and max_n >= 2 and n >= 2:
+        interior_count = max_n - 2
+        interior = _evenly_spaced_positions(n - 2, interior_count) + 1
+        return np.concatenate(
+            [
+                np.asarray([0], dtype=np.int64),
+                interior,
+                np.asarray([n - 1], dtype=np.int64),
+            ]
+        )
+    return _evenly_spaced_positions(n, max_n)
+
+
+def _sample_observation_indices_for_fit(  # noqa: PLR0911, PLR0913
+    *,
+    obs_indices: np.ndarray,
+    offset_abs_m: np.ndarray,
+    pick_t_sec: np.ndarray,
+    coarse_pmax: np.ndarray | None,
+    cfg: PhysicsLiteConfig,
+    min_required_obs: int = 0,
+) -> np.ndarray:
+    sampling = cfg.physical_runtime.observation_sampling
+    obs = np.asarray(obs_indices, dtype=np.int64)
+    insufficient = np.zeros((0,), dtype=np.int64)
+    if not bool(sampling.enabled):
+        return obs
+    max_obs = int(sampling.max_obs_per_fit)
+    if int(obs.size) <= max_obs:
+        return obs
+
+    x_obs = np.asarray(offset_abs_m, dtype=np.float32)[obs]
+    y_obs = np.asarray(pick_t_sec, dtype=np.float32)[obs]
+    finite = np.isfinite(x_obs) & np.isfinite(y_obs)
+    finite_positions = np.flatnonzero(finite).astype(np.int64, copy=False)
+    if int(finite_positions.size) == 0:
+        return obs
+
+    finite_x = x_obs[finite_positions]
+    x_min = float(np.min(finite_x))
+    x_max = float(np.max(finite_x))
+    if (not np.isfinite(x_min)) or (not np.isfinite(x_max)) or x_max <= x_min:
+        return obs
+
+    n_bins = min(int(sampling.n_offset_bins), int(finite_positions.size))
+    edges = np.linspace(x_min, x_max, num=n_bins + 1, dtype=np.float64)
+    bin_ids = np.searchsorted(edges, finite_x.astype(np.float64), side='right') - 1
+    bin_ids = np.clip(bin_ids, 0, n_bins - 1).astype(np.int64, copy=False)
+
+    p_obs = (
+        None
+        if coarse_pmax is None
+        else np.asarray(coarse_pmax, dtype=np.float32)[obs]
+    )
+    selected_positions: list[int] = []
+    for bin_id in range(n_bins):
+        in_bin = finite_positions[bin_ids == int(bin_id)]
+        if int(in_bin.size) == 0:
+            continue
+        selected_positions.append(
+            _bin_representative_position(
+                local_positions=in_bin,
+                obs_indices=obs,
+                y_obs=y_obs,
+                p_obs=p_obs,
+                bin_pick=str(sampling.bin_pick),
+                random_seed=int(cfg.two_piece_ransac.seed),
+                bin_id=int(bin_id),
+            )
+        )
+
+    selected = obs[np.asarray(selected_positions, dtype=np.int64)]
+    min_after = max(
+        int(sampling.min_obs_per_fit_after_sampling),
+        int(min_required_obs),
+    )
+    if int(selected.size) < min_after:
+        return insufficient
+    if int(selected.size) > max_obs:
+        keep = _limit_selected_positions(
+            int(selected.size),
+            max_count=max_obs,
+            preserve_edge_bins=bool(sampling.preserve_edge_bins),
+        )
+        selected = selected[keep]
+    if int(selected.size) < min_after:
+        return insufficient
+    return np.asarray(selected, dtype=np.int64)
+
+
+def _model_diagnostics(
+    trend_model: object,
+    *,
+    obs_offsets_m: np.ndarray,
+    obs_times_sec: np.ndarray,
+) -> tuple[float, float, float, float, float, float, float]:
+    edges = _tensor_to_numpy(trend_model.edges).astype(np.float32, copy=False)
+    coef = _tensor_to_numpy(trend_model.coef).astype(np.float32, copy=False)
+    if edges.shape != (3,) or coef.shape != (2, 2):
+        msg = 'trend model must expose edges (3,) and coef (2,2)'
+        raise ValueError(msg)
+
+    slope_near = float(coef[0, 0])
+    slope_far = float(coef[1, 0])
+    velocity_near = (
+        1.0 / slope_near
+        if np.isfinite(slope_near) and slope_near > 0.0
+        else np.nan
+    )
+    velocity_far = (
+        1.0 / slope_far
+        if np.isfinite(slope_far) and slope_far > 0.0
+        else np.nan
+    )
+
+    x_obs = torch.as_tensor(obs_offsets_m, dtype=torch.float32)
+    pred = _tensor_to_numpy(trend_model.predict(x_obs)).astype(np.float64, copy=False)
+    residual_ms = np.abs(np.asarray(obs_times_sec, dtype=np.float64) - pred) * 1000.0
+    residual_ms = residual_ms[np.isfinite(residual_ms)]
+    if residual_ms.size == 0:
+        resid_p50 = np.nan
+        resid_p90 = np.nan
+    else:
+        resid_p50 = float(np.percentile(residual_ms, 50.0))
+        resid_p90 = float(np.percentile(residual_ms, 90.0))
+
+    return (
+        float(edges[1]),
+        slope_near,
+        slope_far,
+        velocity_near,
+        velocity_far,
+        resid_p50,
+        resid_p90,
+    )
+
+
+def _fit_key_for_obs(
+    obs_indices: np.ndarray,
+    *,
+    precomputed_key: tuple[int, ...] | None = None,
+    runtime_diagnostics: PhysicalRuntimeDiagnostics | None = None,
+    after_sampling: bool = False,
+    count_missing_precomputed: bool = True,
+) -> tuple[int, ...]:
+    if precomputed_key is not None:
+        if runtime_diagnostics is not None:
+            runtime_diagnostics.inc('n_precomputed_fit_key_used')
+        return precomputed_key
+
+    if runtime_diagnostics is not None:
+        if bool(count_missing_precomputed):
+            runtime_diagnostics.inc('n_fit_key_missing_precomputed')
+        runtime_diagnostics.inc('n_fit_key_built_from_indices')
+        if bool(after_sampling):
+            runtime_diagnostics.inc('n_fit_key_built_after_sampling')
+    return _indices_key(obs_indices)
+
+
+def _fit_cache_key(plan: _ObservationPlan) -> tuple[int, ...]:
+    return _fit_key_for_obs(plan.obs_indices, precomputed_key=plan.obs_key)
+
+
+def _offset_spread_failure_reason(
+    x_obs: np.ndarray,
+    *,
+    min_pts: int,
+    min_offset_spread_m: float,
+) -> int | None:
+    finite_x = np.asarray(x_obs, dtype=np.float64)
+    finite_x = finite_x[np.isfinite(finite_x)]
+    if int(finite_x.size) < int(min_pts):
+        return PHYSICAL_MODEL_FAILURE_INSUFFICIENT_OBSERVATIONS
+    if float(np.ptp(finite_x)) < float(min_offset_spread_m):
+        return PHYSICAL_MODEL_FAILURE_INSUFFICIENT_OBSERVATIONS
+    return None
+
+
+def _fit_task_cfg_values(cfg: PhysicsLiteConfig) -> _FitTaskCfgValues:
+    executor = cfg.physical_runtime.fit_executor
+    is_irls = cfg.physical_trend.fit_kind == 'two_piece_irls_autobreak'
+    return _FitTaskCfgValues(
+        fit_kind=str(cfg.physical_trend.fit_kind),
+        n_iter=int(cfg.two_piece_ransac.n_iter),
+        inlier_th_ms=float(cfg.two_piece_ransac.inlier_th_ms),
+        irls_huber_c=float(cfg.two_piece_irls.huber_c),
+        irls_iters=int(cfg.two_piece_irls.iters),
+        min_pts=_fit_min_pts(cfg),
+        n_break_cand=(
+            int(cfg.two_piece_irls.n_break_cand)
+            if is_irls
+            else int(cfg.two_piece_ransac.n_break_cand)
+        ),
+        q_lo=(
+            float(cfg.two_piece_irls.q_lo)
+            if is_irls
+            else float(cfg.two_piece_ransac.q_lo)
+        ),
+        q_hi=(
+            float(cfg.two_piece_irls.q_hi)
+            if is_irls
+            else float(cfg.two_piece_ransac.q_hi)
+        ),
+        seed=int(cfg.two_piece_ransac.seed),
+        slope_eps=(
+            float(cfg.two_piece_irls.slope_eps)
+            if is_irls
+            else float(cfg.two_piece_ransac.slope_eps)
+        ),
+        sort_offsets=(
+            bool(cfg.two_piece_irls.sort_offsets)
+            if is_irls
+            else bool(cfg.two_piece_ransac.sort_offsets)
+        ),
+        min_offset_spread_m=float(cfg.physical_trend.min_offset_spread_m),
+        torch_num_threads_per_worker=int(executor.torch_num_threads_per_worker),
+    )
+
+
+def _fit_task_from_work_item(
+    work_item: object,
+    *,
+    cfg_values: _FitTaskCfgValues,
+) -> _FitTask:
+    return _FitTask(
+        fit_key=work_item.fit_key,
+        x_obs=np.asarray(work_item.x_obs, dtype=np.float32),
+        y_obs=np.asarray(work_item.y_obs, dtype=np.float32),
+        w_obs=np.asarray(work_item.w_obs, dtype=np.float32),
+        obs_count_before_sampling=int(work_item.obs_count_before_sampling),
+        cfg_values=cfg_values,
+    )
+
+
+def _strategy_from_fit_task_cfg(
+    cfg_values: _FitTaskCfgValues,
+) -> _PhysicalFitStrategy:
+    if cfg_values.fit_kind == 'two_piece_irls_autobreak':
+        return TwoPieceIRLSAutoBreakStrategy(
+            huber_c=float(cfg_values.irls_huber_c),
+            iters=int(cfg_values.irls_iters),
+            min_pts=int(cfg_values.min_pts),
+            n_break_cand=int(cfg_values.n_break_cand),
+            q_lo=float(cfg_values.q_lo),
+            q_hi=float(cfg_values.q_hi),
+            slope_eps=float(cfg_values.slope_eps),
+            sort_offsets=bool(cfg_values.sort_offsets),
+        )
+    return TwoPieceRansacAutoBreakStrategy(
+        n_iter=int(cfg_values.n_iter),
+        inlier_th_ms=float(cfg_values.inlier_th_ms),
+        min_pts=int(cfg_values.min_pts),
+        n_break_cand=int(cfg_values.n_break_cand),
+        q_lo=float(cfg_values.q_lo),
+        q_hi=float(cfg_values.q_hi),
+        seed=int(cfg_values.seed),
+        slope_eps=float(cfg_values.slope_eps),
+        sort_offsets=bool(cfg_values.sort_offsets),
+    )
+
+
+def _run_fit_task(task: _FitTask) -> _FitTaskResult:
+    cfg_values = task.cfg_values
+    x_obs = np.asarray(task.x_obs, dtype=np.float32)
+    y_obs = np.asarray(task.y_obs, dtype=np.float32)
+    w_obs = np.asarray(task.w_obs, dtype=np.float32)
+    spread_failure_reason = _offset_spread_failure_reason(
+        x_obs,
+        min_pts=int(cfg_values.min_pts),
+        min_offset_spread_m=float(cfg_values.min_offset_spread_m),
+    )
+    if spread_failure_reason is not None:
+        return _FitTaskResult(
+            fit_key=task.fit_key,
+            trend_model=None,
+            diagnostics=None,
+            fit_failed=False,
+            failure_reason=spread_failure_reason,
+            elapsed_sec=0.0,
+            obs_count=int(x_obs.size),
+            obs_count_before_sampling=int(task.obs_count_before_sampling),
+            fit_attempted=False,
+        )
+
+    strategy = _strategy_from_fit_task_cfg(cfg_values)
+    start = time.perf_counter()
+    trend_model = _fit_strategy_model(
+        strategy,
+        torch.as_tensor(x_obs, dtype=torch.float32),
+        torch.as_tensor(y_obs, dtype=torch.float32),
+        torch.as_tensor(w_obs, dtype=torch.float32),
+    )
+    elapsed = time.perf_counter() - start
+    if trend_model is None:
+        return _FitTaskResult(
+            fit_key=task.fit_key,
+            trend_model=None,
+            diagnostics=None,
+            fit_failed=True,
+            failure_reason=PHYSICAL_MODEL_FAILURE_FIT_FAILED,
+            elapsed_sec=elapsed,
+            obs_count=int(x_obs.size),
+            obs_count_before_sampling=int(task.obs_count_before_sampling),
+            fit_attempted=True,
+        )
+    try:
+        diagnostics = _model_diagnostics(
+            trend_model,
+            obs_offsets_m=x_obs,
+            obs_times_sec=y_obs,
+        )
+    except (TypeError, ValueError, RuntimeError):
+        diagnostics = None
+    return _FitTaskResult(
+        fit_key=task.fit_key,
+        trend_model=trend_model,
+        diagnostics=diagnostics,
+        fit_failed=False,
+        failure_reason=None,
+        elapsed_sec=elapsed,
+        obs_count=int(x_obs.size),
+        obs_count_before_sampling=int(task.obs_count_before_sampling),
+        fit_attempted=True,
+    )
+
+
+def _set_fit_worker_torch_num_threads(num_threads: int) -> None:
+    torch.set_num_threads(int(num_threads))
+
+
+def _fit_progress_fields(
+    *,
+    done: int,
+    total: int,
+    start_sec: float,
+    runtime_diagnostics: PhysicalRuntimeDiagnostics | None,
+    force: bool = False,
+) -> dict[str, object]:
+    elapsed = max(0.0, time.perf_counter() - float(start_sec))
+    rate = (float(done) / elapsed) if elapsed > 0.0 else 0.0
+    remaining = max(0, int(total) - int(done))
+    eta = (float(remaining) / rate) if rate > 0.0 else 0.0
+    fields: dict[str, object] = {
+        'done': int(done),
+        'total': int(total),
+        'elapsed': elapsed,
+        'rate': rate,
+        'eta': eta,
+        'force': force,
+    }
+    if runtime_diagnostics is not None:
+        fields.update(
+            {
+                'cache_hit': int(runtime_diagnostics.n_cache_hits),
+                'cache_miss': int(runtime_diagnostics.n_cache_misses),
+                'n_fit_calls': int(runtime_diagnostics.n_fit_calls),
+                'fit_total_sec': float(runtime_diagnostics.ransac_fit_total_sec),
+            }
+        )
+    return fields
+
+
+def _run_fit_tasks_with_executor(  # noqa: PLR0913
+    tasks: list[_FitTask],
+    *,
+    cfg: PhysicsLiteConfig,
+    progress: object | None = None,
+    progress_context: Mapping[str, object] | None = None,
+    progress_start_done: int = 0,
+    progress_total: int | None = None,
+    progress_start_sec: float | None = None,
+    runtime_diagnostics: PhysicalRuntimeDiagnostics | None = None,
+    progress_cache_miss_base: int = 0,
+    progress_fit_calls_base: int = 0,
+    progress_fit_total_sec_base: float = 0.0,
+) -> dict[tuple[int, ...], _FitTaskResult]:
+    reporter = (
+        progress
+        if progress is not None
+        else build_progress_reporter(cfg.physical_runtime.progress)
+    )
+    context = dict(progress_context or {})
+    total = len(tasks) if progress_total is None else int(progress_total)
+    start_sec = (
+        time.perf_counter()
+        if progress_start_sec is None
+        else progress_start_sec
+    )
+    fit_calls_done = 0
+    fit_total_sec = float(progress_fit_total_sec_base)
+    executor_cfg = cfg.physical_runtime.fit_executor
+    if str(executor_cfg.backend) == 'thread':
+        with ThreadPoolExecutor(max_workers=executor_cfg.max_workers) as executor:
+            futures = [executor.submit(_run_fit_task, task) for task in tasks]
+            out: dict[tuple[int, ...], _FitTaskResult] = {}
+            for completed, future in enumerate(as_completed(futures), start=1):
+                result = future.result()
+                out[result.fit_key] = result
+                if bool(result.fit_attempted):
+                    fit_calls_done += 1
+                    fit_total_sec += float(result.elapsed_sec)
+                fields = _fit_progress_fields(
+                    done=int(progress_start_done) + completed,
+                    total=total,
+                    start_sec=start_sec,
+                    runtime_diagnostics=runtime_diagnostics,
+                    force=int(progress_start_done) + completed >= total,
+                )
+                fields.update(
+                    {
+                        'cache_miss': int(progress_cache_miss_base) + completed,
+                        'n_fit_calls': int(progress_fit_calls_base) + fit_calls_done,
+                        'fit_total_sec': fit_total_sec,
+                    }
+                )
+                reporter.emit(
+                    'fit.progress',
+                    **context,
+                    **fields,
+                )
+            return out
+
+    with ProcessPoolExecutor(
+        max_workers=executor_cfg.max_workers,
+        initializer=_set_fit_worker_torch_num_threads,
+        initargs=(int(executor_cfg.torch_num_threads_per_worker),),
+    ) as executor:
+        futures = [executor.submit(_run_fit_task, task) for task in tasks]
+        out: dict[tuple[int, ...], _FitTaskResult] = {}
+        for completed, future in enumerate(as_completed(futures), start=1):
+            result = future.result()
+            out[result.fit_key] = result
+            if bool(result.fit_attempted):
+                fit_calls_done += 1
+                fit_total_sec += float(result.elapsed_sec)
+            fields = _fit_progress_fields(
+                done=int(progress_start_done) + completed,
+                total=total,
+                start_sec=start_sec,
+                runtime_diagnostics=runtime_diagnostics,
+                force=int(progress_start_done) + completed >= total,
+            )
+            fields.update(
+                {
+                    'cache_miss': int(progress_cache_miss_base) + completed,
+                    'n_fit_calls': int(progress_fit_calls_base) + fit_calls_done,
+                    'fit_total_sec': fit_total_sec,
+                }
+            )
+            reporter.emit(
+                'fit.progress',
+                **context,
+                **fields,
+            )
+        return out
+
+
+def _fit_model_for_plan(  # noqa: PLR0913
+    *,
+    strategy: _PhysicalFitStrategy,
+    plan: _ObservationPlan,
+    x_obs: np.ndarray,
+    y_obs: np.ndarray,
+    w_obs: np.ndarray,
+    min_pts: int,
+    min_offset_spread_m: float,
+    cache: dict[tuple[int, ...], _FitCacheEntry],
+    runtime_diagnostics: PhysicalRuntimeDiagnostics | None = None,
+    obs_count_before_sampling: int | None = None,
+) -> tuple[
+    object | None,
+    tuple[float, float, float, float, float, float, float] | None,
+    int | None,
+]:
+    spread_failure_reason = _offset_spread_failure_reason(
+        x_obs,
+        min_pts=int(min_pts),
+        min_offset_spread_m=float(min_offset_spread_m),
+    )
+    if spread_failure_reason is not None:
+        return None, None, spread_failure_reason
+
+    cache_key = _fit_cache_key(plan)
+    entry = cache.get(cache_key)
+    if entry is None:
+        if runtime_diagnostics is not None:
+            runtime_diagnostics.record_cache_miss()
+        try:
+            x_tensor = torch.as_tensor(x_obs, dtype=torch.float32)
+            y_tensor = torch.as_tensor(y_obs, dtype=torch.float32)
+            w_tensor = torch.as_tensor(w_obs, dtype=torch.float32)
+            if runtime_diagnostics is None:
+                trend_model = _fit_strategy_model(
+                    strategy,
+                    x_tensor,
+                    y_tensor,
+                    w_tensor,
+                )
+            else:
+                with runtime_diagnostics.time_ransac_fit(
+                    obs_count=int(np.asarray(x_obs).size),
+                    obs_count_before=obs_count_before_sampling,
+                ):
+                    trend_model = _fit_strategy_model(
+                        strategy,
+                        x_tensor,
+                        y_tensor,
+                        w_tensor,
+                    )
+        except (TypeError, ValueError, RuntimeError):
+            trend_model = None
+
+        if trend_model is None:
+            entry = _FitCacheEntry(
+                model=None,
+                diagnostics=None,
+                fit_failed=True,
+                failure_reason=PHYSICAL_MODEL_FAILURE_FIT_FAILED,
+            )
+        else:
+            entry = _FitCacheEntry(
+                model=trend_model,
+                diagnostics=None,
+                fit_failed=False,
+            )
+        cache[cache_key] = entry
+    elif runtime_diagnostics is not None:
+        runtime_diagnostics.record_cache_hit()
+
+    if entry.failure_reason is not None:
+        return None, None, entry.failure_reason
+    if bool(entry.fit_failed):
+        return None, None, PHYSICAL_MODEL_FAILURE_FIT_FAILED
+    return entry.model, entry.diagnostics, None

--- a/packages/seisai-engine/src/seisai_engine/pipelines/fbpick/physics/physical_center_full_fit.py
+++ b/packages/seisai-engine/src/seisai_engine/pipelines/fbpick/physics/physical_center_full_fit.py
@@ -1,0 +1,117 @@
+"""Full fit-policy runner for physical-center fitting."""
+
+from __future__ import annotations
+
+import time
+from collections.abc import Mapping
+
+import numpy as np
+
+from .physical_center_context import (
+    PhysicalCenterBuildContext,
+    PhysicalCenterInputs,
+    PhysicalCenterWorkspace,
+)
+from .physical_center_context_fit import (
+    _build_fit_context_work_items,
+    _fit_and_assign_context_work_items,
+    _FitModelForPlan,
+    _prepare_fit_context_assignments_for_trace_indices,
+)
+from .physical_center_fallback import _finalize_result_with_pending_trend_fallback
+from .physical_center_fit import _fit_model_for_plan
+from .physical_center_types import (
+    PHYSICAL_RUNTIME_FIT_SOURCE_FULL_FIT,
+    PhysicalCenterResult,
+)
+from .progress import NullProgressReporter
+
+
+def run_full_fit_policy(
+    *,
+    inputs: PhysicalCenterInputs,
+    build_context: PhysicalCenterBuildContext,
+    workspace: PhysicalCenterWorkspace,
+    strategy: object,
+    progress: object | None = None,
+    progress_context: Mapping[str, object] | None = None,
+    fit_model_for_plan: _FitModelForPlan | None = None,
+) -> PhysicalCenterResult:
+    """Run the fit_policy='full' physical-center orchestration."""
+
+    table = inputs.table
+    reporter = progress if progress is not None else NullProgressReporter()
+    context = dict(progress_context or {})
+    n = int(table.n_traces)
+
+    reporter.emit(
+        'physical-center.stage_start',
+        **context,
+        stage='fit_context_preparation',
+    )
+    stage_start = time.perf_counter()
+    fit_context_assignments, _fit_context_ordered_assignments = (
+        _prepare_fit_context_assignments_for_trace_indices(
+            np.arange(n, dtype=np.int64),
+            inputs=inputs,
+            build_context=build_context,
+            workspace=workspace,
+        )
+    )
+    reporter.emit(
+        'physical-center.stage_done',
+        **context,
+        stage='fit_context_preparation',
+        elapsed=time.perf_counter() - stage_start,
+        unique_keys=len(fit_context_assignments),
+    )
+
+    work_items = _build_fit_context_work_items(
+        fit_context_assignments,
+        offset_abs_m=build_context.offset_abs_m,
+        pick_t_sec=build_context.pick_t_sec,
+        coarse_pmax=table.coarse_pmax,
+        runtime_fit_source=PHYSICAL_RUNTIME_FIT_SOURCE_FULL_FIT,
+    )
+    reporter.emit(
+        'physical-center.contexts_built',
+        **context,
+        work_items=len(work_items),
+        unique_keys=len(fit_context_assignments),
+    )
+    _fit_and_assign_context_work_items(
+        work_items,
+        inputs=inputs,
+        build_context=build_context,
+        workspace=workspace,
+        strategy=strategy,
+        progress=reporter,
+        progress_context=context,
+        fit_model_for_plan=(
+            _fit_model_for_plan
+            if fit_model_for_plan is None
+            else fit_model_for_plan
+        ),
+    )
+
+    if workspace.runtime_diagnostics is not None:
+        workspace.runtime_diagnostics.set_unique_fit_contexts(len(workspace.fit_cache))
+
+    result = _finalize_result_with_pending_trend_fallback(
+        workspace.arrays,
+        pending_trend_fallback=workspace.pending_trend_fallback,
+        table=table,
+        feasible=inputs.feasible,
+        trend=inputs.trend,
+        merged=inputs.merged,
+        trend_provider=inputs.trend_provider,
+    )
+    reporter.emit(
+        'physical-center.done',
+        **context,
+        status='ok',
+        n_traces=n,
+        n_source_groups=len(build_context.groups),
+        n_unique_fit_contexts=len(workspace.fit_cache),
+    )
+    return result

--- a/packages/seisai-engine/src/seisai_engine/pipelines/fbpick/physics/physical_center_prediction.py
+++ b/packages/seisai-engine/src/seisai_engine/pipelines/fbpick/physics/physical_center_prediction.py
@@ -1,0 +1,388 @@
+"""Physical-center model prediction and assignment helpers."""
+
+from __future__ import annotations
+
+from contextlib import nullcontext
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+import numpy as np
+import torch
+
+from .physical_center_fallback import _assign_fallback
+from .physical_center_fit import (
+    _fit_cache_key,
+    _FitCacheEntry,
+    _model_diagnostics,
+    _tensor_to_numpy,
+)
+from .physical_center_observation import _ObservationPlan
+from .physical_center_types import (
+    PHYSICAL_MODEL_FAILURE_NONE,
+    PHYSICAL_MODEL_FAILURE_PREDICTION_INVALID,
+    PHYSICAL_MODEL_STATUS_FALLBACK_RELAXED_SEGMENT,
+    PHYSICAL_MODEL_STATUS_TWO_PIECE_OK,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+
+    from .feasible import FeasibleBandResult
+    from .merge import MergeResult
+    from .physical_center_fallback import _PendingTrendFallback
+    from .pick_table import CoarsePickTable
+    from .runtime_diagnostics import PhysicalRuntimeDiagnostics
+    from .trend import TrendResult
+
+
+@dataclass(frozen=True)
+class _TraceFitResult:
+    plan: _ObservationPlan | None
+    trend_model: object | None
+    diagnostics: tuple[float, float, float, float, float, float, float] | None
+    x_obs: np.ndarray | None = None
+    y_obs: np.ndarray | None = None
+
+
+@dataclass(frozen=True)
+class _TracePlanAssignment:
+    trace_idx: int
+    plan: _ObservationPlan
+    fit_key: tuple[int, ...]
+    obs_count_before_sampling: int
+
+
+def _predict_model_sec(trend_model: object, offset_m: float) -> float:
+    pred = trend_model.predict(torch.tensor([float(offset_m)], dtype=torch.float32))
+    pred_np = _tensor_to_numpy(pred).astype(np.float64, copy=False)
+    if pred_np.shape != (1,):
+        msg = f'trend model prediction must have shape (1,), got {pred_np.shape}'
+        raise ValueError(msg)
+    return float(pred_np[0])
+
+
+def _predict_model_array_sec(trend_model: object, offset_m: np.ndarray) -> np.ndarray:
+    offsets = np.asarray(offset_m, dtype=np.float32)
+    if offsets.ndim != 1:
+        msg = 'offset_m must be 1D'
+        raise ValueError(msg)
+    if offsets.size == 0:
+        return np.zeros((0,), dtype=np.float64)
+    pred = trend_model.predict(torch.as_tensor(offsets, dtype=torch.float32))
+    pred_np = _tensor_to_numpy(pred).astype(np.float64, copy=False)
+    if pred_np.shape != offsets.shape:
+        msg = (
+            'trend model prediction must have shape '
+            f'{offsets.shape}, got {pred_np.shape}'
+        )
+        raise ValueError(msg)
+    return pred_np
+
+
+def _diagnostics_for_plan(
+    *,
+    plan: _ObservationPlan,
+    x_obs: np.ndarray,
+    y_obs: np.ndarray,
+    cache: dict[tuple[int, ...], _FitCacheEntry],
+) -> tuple[float, float, float, float, float, float, float] | None:
+    cache_key = _fit_cache_key(plan)
+    entry = cache[cache_key]
+    if bool(entry.fit_failed) or entry.model is None:
+        return None
+    if bool(entry.diagnostics_computed):
+        return entry.diagnostics
+
+    try:
+        diagnostics = _model_diagnostics(
+            entry.model,
+            obs_offsets_m=x_obs,
+            obs_times_sec=y_obs,
+        )
+    except (TypeError, ValueError, RuntimeError):
+        diagnostics = None
+    cache[cache_key] = _FitCacheEntry(
+        model=entry.model,
+        diagnostics=diagnostics,
+        fit_failed=False,
+        diagnostics_computed=True,
+        failure_reason=entry.failure_reason,
+    )
+    return diagnostics
+
+
+def _assign_model_diagnostics(
+    arrays: dict[str, np.ndarray],
+    trace_idx: int,
+    diagnostics: tuple[float, float, float, float, float, float, float] | None,
+) -> None:
+    _assign_model_diagnostics_batch(
+        arrays,
+        np.asarray([int(trace_idx)], dtype=np.int64),
+        diagnostics,
+    )
+
+
+def _assign_model_diagnostics_batch(
+    arrays: dict[str, np.ndarray],
+    trace_indices: np.ndarray,
+    diagnostics: tuple[float, float, float, float, float, float, float] | None,
+) -> None:
+    if diagnostics is None:
+        return
+    indices = np.asarray(trace_indices, dtype=np.int64)
+    if indices.size == 0:
+        return
+    (
+        break_offset,
+        slope_near,
+        slope_far,
+        velocity_near,
+        velocity_far,
+        resid_p50,
+        resid_p90,
+    ) = diagnostics
+    arrays['physical_model_break_offset_m'][indices] = np.float32(break_offset)
+    arrays['physical_model_slope_near_s_per_m'][indices] = np.float32(slope_near)
+    arrays['physical_model_slope_far_s_per_m'][indices] = np.float32(slope_far)
+    arrays['physical_model_velocity_near_m_s'][indices] = np.float32(velocity_near)
+    arrays['physical_model_velocity_far_m_s'][indices] = np.float32(velocity_far)
+    arrays['physical_model_resid_p50_ms'][indices] = np.float32(resid_p50)
+    arrays['physical_model_resid_p90_ms'][indices] = np.float32(resid_p90)
+
+
+def _shift_for_trace_indices(
+    t0_shift_sec: float | np.ndarray,
+    *,
+    trace_indices: np.ndarray,
+    n_traces: int,
+) -> float | np.ndarray:
+    shift = np.asarray(t0_shift_sec, dtype=np.float64)
+    if shift.ndim == 0:
+        return float(shift)
+    if shift.ndim != 1:
+        msg = 't0_shift_sec must be scalar or 1D'
+        raise ValueError(msg)
+    indices = np.asarray(trace_indices, dtype=np.int64)
+    if shift.shape == indices.shape:
+        return shift
+    if int(shift.shape[0]) == int(n_traces):
+        return shift[indices]
+    msg = (
+        't0_shift_sec vector must match trace_indices or full trace count, '
+        f'got {shift.shape[0]} for {indices.size} indices and {n_traces} traces'
+    )
+    raise ValueError(msg)
+
+
+def _status_for_plan_batch(
+    trace_indices: np.ndarray,
+    plan_by_trace: Mapping[int, _ObservationPlan] | _ObservationPlan,
+) -> np.ndarray:
+    indices = np.asarray(trace_indices, dtype=np.int64)
+    if isinstance(plan_by_trace, _ObservationPlan):
+        status = (
+            PHYSICAL_MODEL_STATUS_FALLBACK_RELAXED_SEGMENT
+            if bool(plan_by_trace.relaxed)
+            else PHYSICAL_MODEL_STATUS_TWO_PIECE_OK
+        )
+        return np.full((indices.size,), np.uint8(status), dtype=np.uint8)
+
+    out = np.empty((indices.size,), dtype=np.uint8)
+    for pos, trace_idx in enumerate(indices.tolist()):
+        plan = plan_by_trace[int(trace_idx)]
+        out[pos] = np.uint8(
+            PHYSICAL_MODEL_STATUS_FALLBACK_RELAXED_SEGMENT
+            if bool(plan.relaxed)
+            else PHYSICAL_MODEL_STATUS_TWO_PIECE_OK
+        )
+    return out
+
+
+def _assign_model_prediction_batch(  # noqa: PLR0913
+    arrays: dict[str, np.ndarray],
+    trace_indices: np.ndarray,
+    *,
+    trend_model: object,
+    diagnostics: tuple[float, float, float, float, float, float, float] | None,
+    plan_by_trace: Mapping[int, _ObservationPlan] | _ObservationPlan,
+    offset_abs_m: np.ndarray,
+    dt: float,
+    n_samples: int,
+    runtime_fit_source: int,
+    t0_shift_sec: float | np.ndarray = 0.0,
+    runtime_diagnostics: PhysicalRuntimeDiagnostics | None = None,
+) -> np.ndarray:
+    indices = np.asarray(trace_indices, dtype=np.int64)
+    if indices.ndim != 1:
+        msg = 'trace_indices must be 1D'
+        raise ValueError(msg)
+    if indices.size == 0:
+        return np.zeros((0,), dtype=np.bool_)
+
+    if runtime_diagnostics is not None:
+        runtime_diagnostics.inc('n_prediction_calls', int(indices.size))
+        runtime_diagnostics.inc('n_prediction_batches')
+
+    offset_arr = np.asarray(offset_abs_m, dtype=np.float32)
+    with (
+        runtime_diagnostics.time_block('prediction_sec')
+        if runtime_diagnostics is not None
+        else nullcontext()
+    ):
+        try:
+            physical_t_sec = _predict_model_array_sec(
+                trend_model,
+                offset_arr[indices],
+            )
+            shift = _shift_for_trace_indices(
+                t0_shift_sec,
+                trace_indices=indices,
+                n_traces=int(offset_arr.shape[0]),
+            )
+            physical_t_sec = physical_t_sec + shift
+        except (TypeError, ValueError, RuntimeError):
+            physical_t_sec = np.full((indices.size,), np.nan, dtype=np.float64)
+
+    valid = np.isfinite(physical_t_sec)
+    if not bool(np.any(valid)):
+        return valid.astype(np.bool_, copy=False)
+
+    with (
+        runtime_diagnostics.time_block('assignment_sec')
+        if runtime_diagnostics is not None
+        else nullcontext()
+    ):
+        valid_indices = indices[valid]
+        center_i = np.rint(physical_t_sec[valid] / float(dt)).astype(np.int64)
+        center_i = np.clip(center_i, 0, int(n_samples) - 1).astype(np.int32)
+        arrays['physical_center_i'][valid_indices] = center_i
+        arrays['physical_center_t_sec'][valid_indices] = (
+            center_i.astype(np.float64) * float(dt)
+        ).astype(np.float32)
+        arrays['physical_model_status'][valid_indices] = _status_for_plan_batch(
+            valid_indices,
+            plan_by_trace,
+        )
+        arrays['physical_model_failure_reason'][valid_indices] = np.uint8(
+            PHYSICAL_MODEL_FAILURE_NONE
+        )
+        arrays['physical_runtime_fit_source'][valid_indices] = np.uint8(
+            runtime_fit_source
+        )
+        _assign_model_diagnostics_batch(arrays, valid_indices, diagnostics)
+    return valid.astype(np.bool_, copy=False)
+
+
+def _assign_model_prediction(  # noqa: PLR0913
+    arrays: dict[str, np.ndarray],
+    trace_idx: int,
+    *,
+    trend_model: object,
+    diagnostics: tuple[float, float, float, float, float, float, float] | None,
+    plan: _ObservationPlan,
+    offset_abs_m: np.ndarray,
+    dt: float,
+    n_samples: int,
+    runtime_fit_source: int,
+    t0_shift_sec: float = 0.0,
+    runtime_diagnostics: PhysicalRuntimeDiagnostics | None = None,
+) -> bool:
+    valid = _assign_model_prediction_batch(
+        arrays,
+        np.asarray([int(trace_idx)], dtype=np.int64),
+        trend_model=trend_model,
+        diagnostics=diagnostics,
+        plan_by_trace=plan,
+        offset_abs_m=offset_abs_m,
+        dt=dt,
+        n_samples=n_samples,
+        runtime_fit_source=runtime_fit_source,
+        t0_shift_sec=t0_shift_sec,
+        runtime_diagnostics=runtime_diagnostics,
+    )
+    return bool(valid[0])
+
+
+def _assign_prepared_model_prediction_batch(  # noqa: PLR0913
+    *,
+    arrays: dict[str, np.ndarray],
+    items: list[tuple[int, _TraceFitResult]],
+    offset_abs_m: np.ndarray,
+    dt: float,
+    n_samples: int,
+    runtime_fit_source: int,
+    table: CoarsePickTable,
+    feasible: FeasibleBandResult,
+    trend: TrendResult,
+    trend_provider: object | None = None,
+    merged: MergeResult,
+    fit_cache: dict[tuple[int, ...], _FitCacheEntry],
+    t0_shift_sec: float | np.ndarray = 0.0,
+    runtime_diagnostics: PhysicalRuntimeDiagnostics | None = None,
+    pending_trend_fallback: _PendingTrendFallback | None = None,
+) -> tuple[np.ndarray, tuple[float, float, float, float, float, float, float] | None]:
+    if not items:
+        return np.zeros((0,), dtype=np.bool_), None
+
+    trace_indices = np.asarray(
+        [trace_idx for trace_idx, _result in items], dtype=np.int64
+    )
+    first_result = items[0][1]
+    if first_result.plan is None or first_result.trend_model is None:
+        msg = 'prepared model assignment requires plan and trend_model'
+        raise ValueError(msg)
+
+    plan_by_trace = {
+        int(trace_idx): result.plan
+        for trace_idx, result in items
+        if result.plan is not None
+    }
+    diagnostics = first_result.diagnostics
+    valid = _assign_model_prediction_batch(
+        arrays,
+        trace_indices,
+        trend_model=first_result.trend_model,
+        diagnostics=diagnostics,
+        plan_by_trace=plan_by_trace,
+        offset_abs_m=offset_abs_m,
+        dt=dt,
+        n_samples=n_samples,
+        runtime_fit_source=runtime_fit_source,
+        t0_shift_sec=t0_shift_sec,
+        runtime_diagnostics=runtime_diagnostics,
+    )
+
+    if bool(np.any(valid)) and diagnostics is None:
+        first_valid_pos = int(np.flatnonzero(valid)[0])
+        first_valid_result = items[first_valid_pos][1]
+        if (
+            first_valid_result.plan is not None
+            and first_valid_result.x_obs is not None
+            and first_valid_result.y_obs is not None
+        ):
+            diagnostics = _diagnostics_for_plan(
+                plan=first_valid_result.plan,
+                x_obs=first_valid_result.x_obs,
+                y_obs=first_valid_result.y_obs,
+                cache=fit_cache,
+            )
+            _assign_model_diagnostics_batch(
+                arrays,
+                trace_indices[valid],
+                diagnostics,
+            )
+
+    for trace_idx in trace_indices[~valid].tolist():
+        _assign_fallback(
+            arrays,
+            int(trace_idx),
+            failure_reason=PHYSICAL_MODEL_FAILURE_PREDICTION_INVALID,
+            table=table,
+            feasible=feasible,
+            trend=trend,
+            trend_provider=trend_provider,
+            merged=merged,
+            pending_trend_fallback=pending_trend_fallback,
+        )
+    return valid, diagnostics


### PR DESCRIPTION
Closes #150
Closes #151
Closes #152
Closes #153
Closes #154

## Issues
- #150 [Refactor] two-piece fit 戦略・観測 sampling・fit executor を抽出する
- #151 [Refactor] model prediction と per-trace diagnostics 代入を抽出する
- #152 [Refactor] fit context 単位の準備・実行・結果反映フローを抽出する
- #153 [Refactor] main orchestration の引数過多を減らす BuildContext/Workspace を導入する
- #154 [Refactor] fit_policy='full' の orchestration を runner として抽出する

Batch range: #150-#154
