### PR TITLE
Issue: 08_eval の final 評価・top error 表示を `final_pick_i` に統一し、high_conf final を通常出力から外す

### DIFF
--- a/proc/fbpick/site54/oof/README.md
+++ b/proc/fbpick/site54/oof/README.md
@@ -415,6 +415,11 @@ Continuous error statistics such as `accepted_mae_samples` are computed only on
 accepted predictions, so interpret them together with `coverage`. Millisecond
 metric columns are not emitted.
 
+For `08_eval`, the `final` stage uses `final_pick_i`. This matches the red final
+pick drawn by fine inference QC PNGs. `final_pick_f` may remain in the payload as
+an internal float pick, but site54 OOF normal evaluation does not use it.
+`final_high_conf` is also outside the normal evaluation output.
+
 Check the run-scoped CV outputs:
 
 ```bash

--- a/proc/fbpick/site54/oof/scripts/evaluate_fine_oof.py
+++ b/proc/fbpick/site54/oof/scripts/evaluate_fine_oof.py
@@ -210,7 +210,7 @@ def parse_csv_numbers(raw: str, *, dtype: type = float) -> tuple:
 
 def stage_specs(stages: Iterable[str]) -> dict[str, tuple[str, str | None]]:
     mapping = {
-        "final": ("final_pick_f", "final_conf"),
+        "final": ("final_pick_i", "final_conf"),
         "robust": ("robust_pick_i", "robust_conf"),
         "coarse": ("coarse_pick_i", "coarse_pmax"),
         "center": ("center_raw_i", None),
@@ -338,6 +338,31 @@ def accumulator_row(
             "" if n_teacher == 0 else float(int(acc_hits[float(th)]) / n_teacher)
         )
     return out
+
+
+def require_payload_vector(
+    payload: dict[str, np.ndarray],
+    key: str,
+    *,
+    n_traces: int,
+    tag: str,
+) -> np.ndarray:
+    if key not in payload:
+        raise KeyError(f"{tag}: missing key {key}")
+    arr = np.asarray(payload[key])
+    if arr.shape != (n_traces,):
+        raise ValueError(f"{tag}: {key} shape {arr.shape} != ({n_traces},)")
+    return arr
+
+
+def scalar_payload_value(
+    payload: dict[str, np.ndarray],
+    key: str,
+    trace_idx: int,
+) -> object:
+    if key not in payload:
+        return ""
+    return np.asarray(payload[key])[trace_idx].item()
 
 
 def main() -> int:
@@ -468,6 +493,8 @@ def main() -> int:
 
             for stage, (pick_key, conf_key) in specs.items():
                 if pick_key not in payload:
+                    if stage == "final" and pick_key == "final_pick_i":
+                        raise KeyError("final stage evaluation requires final_pick_i")
                     raise KeyError(f"{final_path} missing key {pick_key}")
 
                 pick = np.asarray(payload[pick_key], dtype=np.float64)
@@ -544,7 +571,9 @@ def main() -> int:
             if args.include_high_conf_final and "final" in file_stage_cache:
                 if "high_conf_mask" not in payload:
                     raise KeyError(f"{final_path} missing high_conf_mask")
-                pick = np.asarray(payload["final_pick_f"], dtype=np.float64)
+                if "final_pick_i" not in payload:
+                    raise KeyError("final_high_conf evaluation requires final_pick_i")
+                pick = np.asarray(payload["final_pick_i"], dtype=np.float64)
                 conf_arr = np.asarray(
                     payload.get("final_conf", np.full(n_traces, np.nan)),
                     dtype=np.float64,
@@ -605,39 +634,80 @@ def main() -> int:
                     else:
                         sel = np.argsort(abs_err)[::-1]
 
-                    final_pick = np.asarray(
-                        payload["final_pick_f"],
-                        dtype=np.float64,
+                    final_pick_i = require_payload_vector(
+                        payload,
+                        "final_pick_i",
+                        n_traces=n_traces,
+                        tag=tag,
                     )
                     for j in sel:
                         trace_idx = int(valid_indices[j])
                         top_error_rows.append(
                             {
+                                "run_id": args.run_id,
                                 "fold": fold,
-                                "data_name": tag,
-                                "trace_idx": trace_idx,
+                                "data_key": tag,
+                                "stage": "final",
+                                "segy_file": segy,
+                                "fb_file": fb_path,
+                                "final_npz": str(final_path),
+                                "trace_index": trace_idx,
+                                "ffid": scalar_payload_value(
+                                    payload,
+                                    "ffid_values",
+                                    trace_idx,
+                                ),
+                                "chno": scalar_payload_value(
+                                    payload,
+                                    "chno_values",
+                                    trace_idx,
+                                ),
                                 "fb_i": float(fb_i[trace_idx]),
-                                "final_pick_f": float(final_pick[trace_idx]),
+                                "final_pick_i": int(final_pick_i[trace_idx]),
                                 "error_samples": float(err[j]),
                                 "abs_error_samples": float(abs_err[j]),
+                                "error_ms": float(err[j] * dt_sec * 1000.0),
+                                "abs_error_ms": float(abs_err[j] * dt_sec * 1000.0),
+                                "coarse_pick_i": scalar_payload_value(
+                                    payload,
+                                    "coarse_pick_i",
+                                    trace_idx,
+                                ),
+                                "robust_pick_i": scalar_payload_value(
+                                    payload,
+                                    "robust_pick_i",
+                                    trace_idx,
+                                ),
+                                "window_start_i": scalar_payload_value(
+                                    payload,
+                                    "window_start_i",
+                                    trace_idx,
+                                ),
+                                "window_end_i": scalar_payload_value(
+                                    payload,
+                                    "window_end_i",
+                                    trace_idx,
+                                ),
+                                "fine_pick_local_i": scalar_payload_value(
+                                    payload,
+                                    "fine_pick_local_i",
+                                    trace_idx,
+                                ),
                                 "final_conf": (
                                     float(payload["final_conf"][trace_idx])
                                     if "final_conf" in payload
                                     else ""
                                 ),
-                                "ffid": (
-                                    int(payload["ffid_values"][trace_idx])
-                                    if "ffid_values" in payload
+                                "reject_mask": (
+                                    bool(payload["reject_mask"][trace_idx])
+                                    if "reject_mask" in payload
                                     else ""
                                 ),
-                                "chno": (
-                                    int(payload["chno_values"][trace_idx])
-                                    if "chno_values" in payload
+                                "reason_mask": (
+                                    int(payload["reason_mask"][trace_idx])
+                                    if "reason_mask" in payload
                                     else ""
                                 ),
-                                "segy": segy,
-                                "fb": fb_path,
-                                "final_npz": str(final_path),
                             }
                         )
 
@@ -681,6 +751,7 @@ def main() -> int:
         "n_files": n_files,
         "stages": acc_stages,
         "thresholds_samples": list(thresholds_samples),
+        "final_pick_key": "final_pick_i",
         "include_high_conf_final": bool(args.include_high_conf_final),
         "outputs": {
             "per_data_csv": str(out_dir / "per_data.csv"),

--- a/tests/test_site54_fine_oof_eval_metrics.py
+++ b/tests/test_site54_fine_oof_eval_metrics.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import csv
+import json
 import math
 import subprocess
 import sys
@@ -31,6 +32,7 @@ def _write_case(
     robust_pick: list[float],
     coarse_pick: list[float],
     reject_mask: list[bool],
+    final_pick_f: list[float] | None = None,
 ) -> None:
     fold_dir = fold_list_root / fold
     fold_dir.mkdir(parents=True, exist_ok=True)
@@ -48,12 +50,22 @@ def _write_case(
     out_dir = run_root / fold / "07_fine_infer"
     out_dir.mkdir(parents=True, exist_ok=True)
     final_npz = out_dir / f"{fold}__{data_name}.fbpick_final.npz"
+    final_pick_arr = np.asarray(final_pick, dtype=np.float32)
+    final_pick_i = np.where(np.isfinite(final_pick_arr), final_pick_arr, -1).astype(
+        np.int32,
+    )
+    final_pick_f_arr = (
+        np.asarray(final_pick_f, dtype=np.float32)
+        if final_pick_f is not None
+        else final_pick_arr
+    )
     np.savez(
         final_npz,
         dt_sec=np.asarray(0.004, dtype=np.float32),
-        n_samples_orig=np.asarray(200, dtype=np.int32),
+        n_samples_orig=np.asarray(1200, dtype=np.int32),
         n_traces=np.asarray(n_traces, dtype=np.int32),
-        final_pick_f=np.asarray(final_pick, dtype=np.float32),
+        final_pick_i=final_pick_i,
+        final_pick_f=final_pick_f_arr,
         final_conf=np.ones(n_traces, dtype=np.float32),
         robust_pick_i=np.asarray(robust_pick, dtype=np.float32),
         robust_conf=np.ones(n_traces, dtype=np.float32),
@@ -61,6 +73,10 @@ def _write_case(
         coarse_pmax=np.ones(n_traces, dtype=np.float32),
         high_conf_mask=np.ones(n_traces, dtype=np.bool_),
         reject_mask=np.asarray(reject_mask, dtype=np.bool_),
+        reason_mask=np.zeros(n_traces, dtype=np.uint8),
+        window_start_i=(final_pick_i - 128).astype(np.int32),
+        window_end_i=(final_pick_i + 127).astype(np.int32),
+        fine_pick_local_i=np.full(n_traces, 128, dtype=np.int32),
     )
 
 
@@ -163,3 +179,117 @@ def test_fine_oof_eval_uses_teacher_denominator_and_weighted_summary(
         assert rows
         assert not any("_ms" in column for column in rows[0])
         assert "n_eval" not in rows[0]
+
+
+def test_fine_oof_eval_final_stage_uses_final_pick_i(tmp_path: Path) -> None:
+    cv_root = tmp_path / "oof"
+    run_id = "eval_final_pick_i"
+    run_root = cv_root / "runs" / run_id
+    fold_list_root = (
+        run_root / "aggregate" / "05_collect_oof_lists" / "fine_fold_lists"
+    )
+    out_dir = run_root / "aggregate" / "08_eval"
+
+    _write_case(
+        run_root=run_root,
+        fold_list_root=fold_list_root,
+        fold="fold00",
+        data_name="a",
+        teacher=[110, 190, 310],
+        final_pick=[100, 200, 300],
+        final_pick_f=[1000, 1000, 1000],
+        robust_pick=[100, 200, 300],
+        coarse_pick=[100, 200, 300],
+        reject_mask=[False, False, False],
+    )
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--cv-root",
+            str(cv_root),
+            "--run-id",
+            run_id,
+            "--fold-list-root",
+            str(fold_list_root),
+            "--pred-root",
+            str(run_root),
+            "--out-dir",
+            str(out_dir),
+        ],
+        cwd=REPO_ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+
+    summary = _read_csv(out_dir / "summary.csv")
+    final_summary = next(row for row in summary if row["stage"] == "final")
+    assert float(final_summary["accepted_mae_samples"]) == 10.0
+
+    top_errors = _read_csv(out_dir / "top_errors_final.csv")
+    assert top_errors
+    assert "final_pick_i" in top_errors[0]
+    assert "final_pick_f" not in top_errors[0]
+    assert {float(row["abs_error_samples"]) for row in top_errors} == {10.0}
+
+    per_data = _read_csv(out_dir / "per_data.csv")
+    assert not any(row["stage"] == "final_high_conf" for row in per_data)
+
+    meta = json.loads((out_dir / "eval_meta.json").read_text(encoding="utf-8"))
+    assert meta["final_pick_key"] == "final_pick_i"
+    assert meta["include_high_conf_final"] is False
+
+
+def test_fine_oof_eval_final_stage_requires_final_pick_i(tmp_path: Path) -> None:
+    cv_root = tmp_path / "oof"
+    run_id = "eval_missing_final_pick_i"
+    run_root = cv_root / "runs" / run_id
+    fold_list_root = (
+        run_root / "aggregate" / "05_collect_oof_lists" / "fine_fold_lists"
+    )
+    out_dir = run_root / "aggregate" / "08_eval"
+
+    _write_case(
+        run_root=run_root,
+        fold_list_root=fold_list_root,
+        fold="fold00",
+        data_name="a",
+        teacher=[110],
+        final_pick=[100],
+        robust_pick=[100],
+        coarse_pick=[100],
+        reject_mask=[False],
+    )
+
+    final_npz = run_root / "fold00" / "07_fine_infer" / "fold00__a.fbpick_final.npz"
+    with np.load(final_npz, allow_pickle=False) as z:
+        payload = {key: z[key] for key in z.files if key != "final_pick_i"}
+    np.savez(final_npz, **payload)
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--cv-root",
+            str(cv_root),
+            "--run-id",
+            run_id,
+            "--fold-list-root",
+            str(fold_list_root),
+            "--pred-root",
+            str(run_root),
+            "--out-dir",
+            str(out_dir),
+        ],
+        cwd=REPO_ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode != 0
+    assert "final stage evaluation requires final_pick_i" in result.stderr


### PR DESCRIPTION
Closes #194

## Summary
- Issue: 08_eval の final 評価・top error 表示を `final_pick_i` に統一し、high_conf final を通常出力から外す

## Changed files
- `proc/fbpick/site54/oof/README.md`
- `proc/fbpick/site54/oof/scripts/evaluate_fine_oof.py`
- `tests/test_site54_fine_oof_eval_metrics.py`

## Checks
- `.work/codex/checks.log`: 1444 passed, 2 skipped, 5 warnings in 94.26s (0:01:34)

## Review
- `.work/codex/review.txt`: accept: yes
- findings: blocker 0, major 0, minor 0
