### PR TITLE
Batch: address issues #196-#197

### DIFF
--- a/packages/seisai-engine/src/seisai_engine/pipelines/fbpick/physics/config.py
+++ b/packages/seisai-engine/src/seisai_engine/pipelines/fbpick/physics/config.py
@@ -655,15 +655,6 @@ def _physical_band_from_feasible_band(cfg: dict[str, Any]) -> PhysicalBandCfg:
     )
 
 
-def _same_physical_band(left: PhysicalBandCfg, right: PhysicalBandCfg) -> bool:
-    return (
-        math.isclose(float(left.vmin_m_s), float(right.vmin_m_s))
-        and math.isclose(float(left.vmax_m_s), float(right.vmax_m_s))
-        and math.isclose(float(left.t0_lo_ms), float(right.t0_lo_ms))
-        and math.isclose(float(left.t0_hi_ms), float(right.t0_hi_ms))
-    )
-
-
 def _resolve_physical_band_cfg(raw: dict[str, Any]) -> PhysicalBandCfg:
     physical_band_raw = _require_dict(raw.get('physical_band'), key='physical_band')
     physical_prefilter_raw = _require_dict(
@@ -673,24 +664,7 @@ def _resolve_physical_band_cfg(raw: dict[str, Any]) -> PhysicalBandCfg:
     feasible_band_raw = _require_dict(raw.get('feasible_band'), key='feasible_band')
 
     if 'physical_band' in raw:
-        band = _load_physical_band_cfg(physical_band_raw)
-        if 'physical_prefilter' in raw:
-            legacy = _physical_band_from_legacy_prefilter(physical_prefilter_raw)
-            if not _same_physical_band(band, legacy):
-                msg = (
-                    'physical_band and physical_prefilter velocity/t0 fields '
-                    'must match when both are present'
-                )
-                raise ValueError(msg)
-        if 'feasible_band' in raw and feasible_band_raw:
-            legacy = _physical_band_from_feasible_band(feasible_band_raw)
-            if not _same_physical_band(band, legacy):
-                msg = (
-                    'physical_band and feasible_band velocity/t0 fields must '
-                    'match when both are present'
-                )
-                raise ValueError(msg)
-        return band
+        return _load_physical_band_cfg(physical_band_raw)
     if 'physical_prefilter' in raw:
         _validate_physical_prefilter_cfg(
             _load_physical_prefilter_cfg(physical_prefilter_raw)

--- a/packages/seisai-engine/src/seisai_engine/pipelines/fbpick/physics/config.py
+++ b/packages/seisai-engine/src/seisai_engine/pipelines/fbpick/physics/config.py
@@ -18,7 +18,10 @@ __all__ = [
     'PhysicalAnchorReuseCfg',
     'PhysicalAnchorSelectionCfg',
     'PhysicalFallbackPolicyCfg',
+    'PhysicalBandCfg',
+    'PhysicalCoarseInBandFallbackCfg',
     'PhysicalFineWindowConstraintCfg',
+    'PhysicalFitObservationFilterCfg',
     'PhysicalFitExecutorCfg',
     'PhysicalModelSelectionCfg',
     'PhysicalNeighborPhysicalFitReuseCfg',
@@ -131,6 +134,22 @@ class NeighborContextCfg:
 
 
 @dataclass(frozen=True)
+class PhysicalBandCfg:
+    vmin_m_s: float = 300.0
+    vmax_m_s: float = 6000.0
+    t0_lo_ms: float = -20.0
+    t0_hi_ms: float = 200.0
+
+
+@dataclass(frozen=True)
+class PhysicalFitObservationFilterCfg:
+    enabled: bool = True
+    band_source: str = 'physical_band'
+    pmax_min: float = 0.0
+    use_existing_mask: bool = False
+
+
+@dataclass(frozen=True)
 class PhysicalPrefilterCfg:
     enabled: bool = True
     vmin_m_s: float = 300.0
@@ -232,7 +251,7 @@ class PhysicalFitExecutorCfg:
 @dataclass(frozen=True)
 class PhysicalFineWindowConstraintCfg:
     enabled: bool = True
-    band_source: str = 'physical_prefilter'
+    band_source: str = 'physical_band'
     time_len: int = 256
     center_index: int = 128
     require_center_inside_band: bool = True
@@ -245,6 +264,7 @@ class PhysicalFineWindowConstraintCfg:
 @dataclass(frozen=True)
 class PhysicalNeighborPhysicalFitReuseCfg:
     enabled: bool = False
+    band_source: str = 'physical_band'
     candidate_statuses: tuple[str, ...] = ('two_piece_ok', 'single_line_ok')
     max_source_xy_distance_m: float | None = None
     max_trace_distance: int | None = None
@@ -262,6 +282,13 @@ class PhysicalFallbackPolicyCfg:
     )
     allow_robust_fallback_as_fine_center: bool = True
     allow_feasible_clip_as_fine_center: bool = True
+
+
+@dataclass(frozen=True)
+class PhysicalCoarseInBandFallbackCfg:
+    enabled: bool = True
+    band_source: str = 'physical_band'
+    require_window_inside_band: bool = True
 
 
 @dataclass(frozen=True)
@@ -323,6 +350,9 @@ class PhysicalRuntimeCfg:
     neighbor_physical_fit_reuse: PhysicalNeighborPhysicalFitReuseCfg = (
         PhysicalNeighborPhysicalFitReuseCfg()
     )
+    coarse_in_band_fallback: PhysicalCoarseInBandFallbackCfg = (
+        PhysicalCoarseInBandFallbackCfg()
+    )
     fallback_policy: PhysicalFallbackPolicyCfg = PhysicalFallbackPolicyCfg()
     partial_trend_fallback: PhysicalPartialTrendFallbackCfg = (
         PhysicalPartialTrendFallbackCfg()
@@ -339,6 +369,10 @@ class PhysicsLiteConfig:
     robust_center: PhysicsRobustCenterCfg = PhysicsRobustCenterCfg()
     physical_trend: PhysicalTrendCfg = PhysicalTrendCfg()
     neighbor_context: NeighborContextCfg = NeighborContextCfg()
+    physical_band: PhysicalBandCfg = PhysicalBandCfg()
+    fit_observation_filter: PhysicalFitObservationFilterCfg = (
+        PhysicalFitObservationFilterCfg()
+    )
     physical_prefilter: PhysicalPrefilterCfg = PhysicalPrefilterCfg()
     two_piece_ransac: TwoPieceRansacCfg = TwoPieceRansacCfg()
     two_piece_irls: TwoPieceIrlsCfg = TwoPieceIrlsCfg()
@@ -592,6 +626,135 @@ def _load_neighbor_context_cfg(cfg: dict[str, Any]) -> NeighborContextCfg:
     )
 
 
+def _load_physical_band_cfg(cfg: dict[str, Any]) -> PhysicalBandCfg:
+    return PhysicalBandCfg(
+        vmin_m_s=float(optional_float(cfg, 'vmin_m_s', 300.0)),
+        vmax_m_s=float(optional_float(cfg, 'vmax_m_s', 6000.0)),
+        t0_lo_ms=float(optional_float(cfg, 't0_lo_ms', -20.0)),
+        t0_hi_ms=float(optional_float(cfg, 't0_hi_ms', 200.0)),
+    )
+
+
+def _physical_band_from_legacy_prefilter(
+    cfg: dict[str, Any],
+) -> PhysicalBandCfg:
+    return PhysicalBandCfg(
+        vmin_m_s=float(optional_float(cfg, 'vmin_m_s', 300.0)),
+        vmax_m_s=float(optional_float(cfg, 'vmax_m_s', 6000.0)),
+        t0_lo_ms=float(optional_float(cfg, 't0_lo_ms', -20.0)),
+        t0_hi_ms=float(optional_float(cfg, 't0_hi_ms', 200.0)),
+    )
+
+
+def _physical_band_from_feasible_band(cfg: dict[str, Any]) -> PhysicalBandCfg:
+    return PhysicalBandCfg(
+        vmin_m_s=float(optional_float(cfg, 'vmin_mask', 100.0)),
+        vmax_m_s=float(optional_float(cfg, 'vmax_mask', 5000.0)),
+        t0_lo_ms=float(optional_float(cfg, 't0_lo_ms', -10.0)),
+        t0_hi_ms=float(optional_float(cfg, 't0_hi_ms', 100.0)),
+    )
+
+
+def _same_physical_band(left: PhysicalBandCfg, right: PhysicalBandCfg) -> bool:
+    return (
+        math.isclose(float(left.vmin_m_s), float(right.vmin_m_s))
+        and math.isclose(float(left.vmax_m_s), float(right.vmax_m_s))
+        and math.isclose(float(left.t0_lo_ms), float(right.t0_lo_ms))
+        and math.isclose(float(left.t0_hi_ms), float(right.t0_hi_ms))
+    )
+
+
+def _resolve_physical_band_cfg(raw: dict[str, Any]) -> PhysicalBandCfg:
+    physical_band_raw = _require_dict(raw.get('physical_band'), key='physical_band')
+    physical_prefilter_raw = _require_dict(
+        raw.get('physical_prefilter'),
+        key='physical_prefilter',
+    )
+    feasible_band_raw = _require_dict(raw.get('feasible_band'), key='feasible_band')
+
+    if 'physical_band' in raw:
+        band = _load_physical_band_cfg(physical_band_raw)
+        if 'physical_prefilter' in raw:
+            legacy = _physical_band_from_legacy_prefilter(physical_prefilter_raw)
+            if not _same_physical_band(band, legacy):
+                msg = (
+                    'physical_band and physical_prefilter velocity/t0 fields '
+                    'must match when both are present'
+                )
+                raise ValueError(msg)
+        if 'feasible_band' in raw and feasible_band_raw:
+            legacy = _physical_band_from_feasible_band(feasible_band_raw)
+            if not _same_physical_band(band, legacy):
+                msg = (
+                    'physical_band and feasible_band velocity/t0 fields must '
+                    'match when both are present'
+                )
+                raise ValueError(msg)
+        return band
+    if 'physical_prefilter' in raw:
+        _validate_physical_prefilter_cfg(
+            _load_physical_prefilter_cfg(physical_prefilter_raw)
+        )
+        return _physical_band_from_legacy_prefilter(physical_prefilter_raw)
+    if 'feasible_band' in raw:
+        return _physical_band_from_feasible_band(feasible_band_raw)
+    return PhysicalBandCfg()
+
+
+def _load_fit_observation_filter_cfg(
+    cfg: dict[str, Any],
+    *,
+    legacy_prefilter: dict[str, Any],
+) -> PhysicalFitObservationFilterCfg:
+    legacy_enabled = bool(
+        optional_bool(legacy_prefilter, 'enabled', default=True)
+    )
+    band_source = optional_str(cfg, 'band_source', 'physical_band')
+    if band_source is None:
+        msg = 'fit_observation_filter.band_source must not be null'
+        raise TypeError(msg)
+    return PhysicalFitObservationFilterCfg(
+        enabled=bool(optional_bool(cfg, 'enabled', default=legacy_enabled)),
+        band_source=str(band_source),
+        pmax_min=float(
+            optional_float(
+                cfg,
+                'pmax_min',
+                float(optional_float(legacy_prefilter, 'pmax_min', 0.0)),
+            )
+        ),
+        use_existing_mask=bool(
+            optional_bool(
+                cfg,
+                'use_existing_mask',
+                default=bool(
+                    optional_bool(
+                        legacy_prefilter,
+                        'use_existing_feasible_mask',
+                        default=False,
+                    )
+                ),
+            )
+        ),
+    )
+
+
+def _effective_physical_prefilter_cfg(
+    *,
+    band: PhysicalBandCfg,
+    fit_filter: PhysicalFitObservationFilterCfg,
+) -> PhysicalPrefilterCfg:
+    return PhysicalPrefilterCfg(
+        enabled=bool(fit_filter.enabled),
+        vmin_m_s=float(band.vmin_m_s),
+        vmax_m_s=float(band.vmax_m_s),
+        t0_lo_ms=float(band.t0_lo_ms),
+        t0_hi_ms=float(band.t0_hi_ms),
+        pmax_min=float(fit_filter.pmax_min),
+        use_existing_feasible_mask=bool(fit_filter.use_existing_mask),
+    )
+
+
 def _load_physical_prefilter_cfg(cfg: dict[str, Any]) -> PhysicalPrefilterCfg:
     return PhysicalPrefilterCfg(
         enabled=bool(optional_bool(cfg, 'enabled', default=True)),
@@ -761,7 +924,7 @@ def _load_physical_fit_executor_cfg(cfg: dict[str, Any]) -> PhysicalFitExecutorC
 def _load_physical_fine_window_constraint_cfg(
     cfg: dict[str, Any],
 ) -> PhysicalFineWindowConstraintCfg:
-    band_source = optional_str(cfg, 'band_source', 'physical_prefilter')
+    band_source = optional_str(cfg, 'band_source', 'physical_band')
     invalid_policy = optional_str(
         cfg,
         'invalid_policy',
@@ -805,7 +968,14 @@ def _load_physical_fine_window_constraint_cfg(
 def _load_physical_neighbor_fit_reuse_cfg(
     cfg: dict[str, Any],
 ) -> PhysicalNeighborPhysicalFitReuseCfg:
+    band_source = optional_str(cfg, 'band_source', 'physical_band')
     invalid_policy = optional_str(cfg, 'invalid_policy', 'try_coarse_in_band')
+    if band_source is None:
+        msg = (
+            'physical_runtime.neighbor_physical_fit_reuse.band_source '
+            'must not be null'
+        )
+        raise TypeError(msg)
     if invalid_policy is None:
         msg = (
             'physical_runtime.neighbor_physical_fit_reuse.invalid_policy '
@@ -817,6 +987,7 @@ def _load_physical_neighbor_fit_reuse_cfg(
         max_trace_distance = int(optional_int(cfg, 'max_trace_distance', 0))
     return PhysicalNeighborPhysicalFitReuseCfg(
         enabled=bool(optional_bool(cfg, 'enabled', default=False)),
+        band_source=str(band_source),
         candidate_statuses=_optional_str_tuple(
             cfg,
             'candidate_statuses',
@@ -829,6 +1000,22 @@ def _load_physical_neighbor_fit_reuse_cfg(
         ),
         max_trace_distance=max_trace_distance,
         invalid_policy=str(invalid_policy),
+    )
+
+
+def _load_physical_coarse_in_band_fallback_cfg(
+    cfg: dict[str, Any],
+) -> PhysicalCoarseInBandFallbackCfg:
+    band_source = optional_str(cfg, 'band_source', 'physical_band')
+    if band_source is None:
+        msg = 'physical_runtime.coarse_in_band_fallback.band_source must not be null'
+        raise TypeError(msg)
+    return PhysicalCoarseInBandFallbackCfg(
+        enabled=bool(optional_bool(cfg, 'enabled', default=True)),
+        band_source=str(band_source),
+        require_window_inside_band=bool(
+            optional_bool(cfg, 'require_window_inside_band', default=True)
+        ),
     )
 
 
@@ -1040,6 +1227,12 @@ def _load_physical_runtime_cfg(cfg: dict[str, Any]) -> PhysicalRuntimeCfg:
         ),
         fine_window_constraint=fine_window_constraint,
         neighbor_physical_fit_reuse=neighbor_physical_fit_reuse,
+        coarse_in_band_fallback=_load_physical_coarse_in_band_fallback_cfg(
+            _require_dict(
+                cfg.get('coarse_in_band_fallback'),
+                key='physical_runtime.coarse_in_band_fallback',
+            )
+        ),
         fallback_policy=fallback_policy,
         partial_trend_fallback=_load_physical_partial_trend_fallback_cfg(
             _require_dict(
@@ -1137,6 +1330,37 @@ def _validate_physical_prefilter_cfg(cfg: PhysicalPrefilterCfg) -> None:
         raise ValueError(msg)
 
 
+def _validate_physical_band_cfg(cfg: PhysicalBandCfg) -> None:
+    _validate_positive_float('physical_band.vmin_m_s', cfg.vmin_m_s)
+    _validate_positive_float('physical_band.vmax_m_s', cfg.vmax_m_s)
+    if float(cfg.vmax_m_s) <= float(cfg.vmin_m_s):
+        msg = 'physical_band.vmax_m_s must be > physical_band.vmin_m_s'
+        raise ValueError(msg)
+    t0_lo_ms = _validate_finite_float('physical_band.t0_lo_ms', cfg.t0_lo_ms)
+    t0_hi_ms = _validate_finite_float('physical_band.t0_hi_ms', cfg.t0_hi_ms)
+    if t0_lo_ms > t0_hi_ms:
+        msg = 'physical_band.t0_lo_ms must be <= physical_band.t0_hi_ms'
+        raise ValueError(msg)
+
+
+def _validate_fit_observation_filter_cfg(
+    cfg: PhysicalFitObservationFilterCfg,
+) -> None:
+    if cfg.band_source != 'physical_band':
+        msg = (
+            'fit_observation_filter.band_source must be '
+            f"'physical_band', got {cfg.band_source!r}"
+        )
+        raise ValueError(msg)
+    pmax_min = _validate_finite_float(
+        'fit_observation_filter.pmax_min',
+        cfg.pmax_min,
+    )
+    if not 0.0 <= pmax_min <= 1.0:
+        msg = 'fit_observation_filter.pmax_min must lie in [0, 1]'
+        raise ValueError(msg)
+
+
 def _validate_two_piece_ransac_cfg(cfg: TwoPieceRansacCfg) -> None:
     _validate_positive_int('two_piece_ransac.n_iter', cfg.n_iter)
     _validate_positive_float('two_piece_ransac.inlier_th_ms', cfg.inlier_th_ms)
@@ -1199,10 +1423,10 @@ def _validate_physical_partial_trend_fallback_cfg(
 def _validate_physical_fine_window_constraint_cfg(
     cfg: PhysicalFineWindowConstraintCfg,
 ) -> None:
-    if cfg.band_source != 'physical_prefilter':
+    if cfg.band_source not in {'physical_band', 'physical_prefilter'}:
         msg = (
             'physical_runtime.fine_window_constraint.band_source must be '
-            f"'physical_prefilter', got {cfg.band_source!r}"
+            f"'physical_band' or 'physical_prefilter', got {cfg.band_source!r}"
         )
         raise ValueError(msg)
     _validate_positive_int(
@@ -1230,6 +1454,12 @@ def _validate_physical_fine_window_constraint_cfg(
 def _validate_physical_neighbor_fit_reuse_cfg(
     cfg: PhysicalNeighborPhysicalFitReuseCfg,
 ) -> None:
+    if cfg.band_source not in {'physical_band', 'physical_prefilter'}:
+        msg = (
+            'physical_runtime.neighbor_physical_fit_reuse.band_source must be '
+            f"'physical_band' or 'physical_prefilter', got {cfg.band_source!r}"
+        )
+        raise ValueError(msg)
     allowed_statuses = {'two_piece_ok', 'single_line_ok'}
     for status in cfg.candidate_statuses:
         if status not in allowed_statuses:
@@ -1254,6 +1484,17 @@ def _validate_physical_neighbor_fit_reuse_cfg(
         msg = (
             'physical_runtime.neighbor_physical_fit_reuse.invalid_policy must be '
             f"'try_coarse_in_band', got {cfg.invalid_policy!r}"
+        )
+        raise ValueError(msg)
+
+
+def _validate_physical_coarse_in_band_fallback_cfg(
+    cfg: PhysicalCoarseInBandFallbackCfg,
+) -> None:
+    if cfg.band_source not in {'physical_band', 'physical_prefilter'}:
+        msg = (
+            'physical_runtime.coarse_in_band_fallback.band_source must be '
+            f"'physical_band' or 'physical_prefilter', got {cfg.band_source!r}"
         )
         raise ValueError(msg)
 
@@ -1347,6 +1588,7 @@ def _validate_physical_runtime_cfg(cfg: PhysicalRuntimeCfg) -> None:
         raise ValueError(msg)
     _validate_physical_fine_window_constraint_cfg(cfg.fine_window_constraint)
     _validate_physical_neighbor_fit_reuse_cfg(cfg.neighbor_physical_fit_reuse)
+    _validate_physical_coarse_in_band_fallback_cfg(cfg.coarse_in_band_fallback)
     _validate_physical_fallback_policy_cfg(cfg.fallback_policy)
     _validate_physical_partial_trend_fallback_cfg(cfg.partial_trend_fallback)
     anchor = cfg.anchor_selection
@@ -1547,6 +1789,8 @@ def _validate_robust_center_cfg(cfg: PhysicsRobustCenterCfg) -> None:
 def _validate_physical_cfg(cfg: PhysicsLiteConfig) -> None:
     _validate_physical_trend_cfg(cfg.physical_trend)
     _validate_neighbor_context_cfg(cfg.neighbor_context)
+    _validate_physical_band_cfg(cfg.physical_band)
+    _validate_fit_observation_filter_cfg(cfg.fit_observation_filter)
     _validate_physical_prefilter_cfg(cfg.physical_prefilter)
     _validate_two_piece_ransac_cfg(cfg.two_piece_ransac)
     _validate_two_piece_irls_cfg(cfg.two_piece_irls)
@@ -1623,6 +1867,17 @@ def load_physics_lite_config(cfg: dict[str, Any] | None) -> PhysicsLiteConfig:
     if not isinstance(raw, dict):
         msg = 'physics config must be dict or null'
         raise TypeError(msg)
+    physical_band = _resolve_physical_band_cfg(raw)
+    fit_observation_filter = _load_fit_observation_filter_cfg(
+        _require_dict(
+            raw.get('fit_observation_filter'),
+            key='fit_observation_filter',
+        ),
+        legacy_prefilter=_require_dict(
+            raw.get('physical_prefilter'),
+            key='physical_prefilter',
+        ),
+    )
     typed = PhysicsLiteConfig(
         feasible_band=_load_feasible_band_cfg(
             _require_dict(raw.get('feasible_band'), key='feasible_band')
@@ -1643,8 +1898,11 @@ def load_physics_lite_config(cfg: dict[str, Any] | None) -> PhysicsLiteConfig:
         neighbor_context=_load_neighbor_context_cfg(
             _require_dict(raw.get('neighbor_context'), key='neighbor_context')
         ),
-        physical_prefilter=_load_physical_prefilter_cfg(
-            _require_dict(raw.get('physical_prefilter'), key='physical_prefilter')
+        physical_band=physical_band,
+        fit_observation_filter=fit_observation_filter,
+        physical_prefilter=_effective_physical_prefilter_cfg(
+            band=physical_band,
+            fit_filter=fit_observation_filter,
         ),
         two_piece_ransac=_load_two_piece_ransac_cfg(
             _require_dict(raw.get('two_piece_ransac'), key='two_piece_ransac')

--- a/packages/seisai-engine/src/seisai_engine/pipelines/fbpick/physics/physical_center_fit.py
+++ b/packages/seisai-engine/src/seisai_engine/pipelines/fbpick/physics/physical_center_fit.py
@@ -172,9 +172,17 @@ def _fit_min_obs_required(cfg: PhysicsLiteConfig) -> int:
         cfg.physical_trend.candidate_models,
     )
     min_pts = _fit_min_pts(cfg)
+    required: list[int] = []
     if MODEL_TYPE_TWO_PIECE in candidates:
+        required.append(2 * min_pts)
+    if (
+        MODEL_TYPE_SINGLE_LINE in candidates
+        and bool(cfg.physical_trend.model_selection.fallback_to_single_line)
+    ):
+        required.append(min_pts)
+    if not required:
         return 2 * min_pts
-    return min_pts
+    return min(required)
 
 
 def _fit_min_pts(cfg: PhysicsLiteConfig) -> int:

--- a/packages/seisai-engine/src/seisai_engine/pipelines/fbpick/physics/physical_center_fit.py
+++ b/packages/seisai-engine/src/seisai_engine/pipelines/fbpick/physics/physical_center_fit.py
@@ -175,10 +175,7 @@ def _fit_min_obs_required(cfg: PhysicsLiteConfig) -> int:
     required: list[int] = []
     if MODEL_TYPE_TWO_PIECE in candidates:
         required.append(2 * min_pts)
-    if (
-        MODEL_TYPE_SINGLE_LINE in candidates
-        and bool(cfg.physical_trend.model_selection.fallback_to_single_line)
-    ):
+    if MODEL_TYPE_SINGLE_LINE in candidates:
         required.append(min_pts)
     if not required:
         return 2 * min_pts

--- a/packages/seisai-engine/tests/test_fbpick_physical_center_fit.py
+++ b/packages/seisai-engine/tests/test_fbpick_physical_center_fit.py
@@ -216,6 +216,43 @@ def test_physical_center_auto_irls_selects_single_line_for_linear_data() -> None
     assert np.all(np.isnan(result.physical_fit_relative_improvement))
 
 
+def test_physical_center_auto_irls_attempts_single_line_below_two_piece_min() -> None:
+    offsets = np.linspace(0.0, 3000.0, 12, dtype=np.float32)
+    dt_sec = 0.001
+    pick_t_sec = np.float32(0.08) + offsets / np.float32(2000.0)
+    pick_i = np.rint(pick_t_sec / np.float32(dt_sec)).astype(np.int32)
+    coarse_npz, table, feasible, trend, merged = make_inputs(
+        offsets_m=offsets,
+        pick_i=pick_i,
+        dt_sec=dt_sec,
+        n_samples_orig=4000,
+    )
+
+    result = build_geometry_two_piece_physical_center(
+        coarse_npz=coarse_npz,
+        table=table,
+        feasible=feasible,
+        trend=trend,
+        merged=merged,
+        cfg=physical_cfg(
+            {
+                'physical_trend': {
+                    'fit_kind': 'auto_irls',
+                    'candidate_models': ['two_piece', 'single_line'],
+                    'segment_by_offset_sign': False,
+                    'split_by_offset_gap': False,
+                },
+                'two_piece_irls': {'min_pts': 8, 'n_break_cand': 16},
+            }
+        ),
+    )
+
+    assert np.all(result.physical_model_status == PHYSICAL_MODEL_STATUS_SINGLE_LINE_OK)
+    assert np.all(result.physical_fit_selected_model == 'single_line')
+    assert np.all(np.isfinite(result.physical_fit_single_line_cost))
+    assert np.all(np.isposinf(result.physical_fit_two_piece_cost))
+
+
 def test_physical_center_auto_irls_selects_two_piece_when_improved() -> None:
     offsets = np.linspace(0.0, 4000.0, 48, dtype=np.float32)
     coarse_npz, table, feasible, trend, merged = make_inputs(offsets_m=offsets)

--- a/packages/seisai-engine/tests/test_fbpick_physical_center_fit.py
+++ b/packages/seisai-engine/tests/test_fbpick_physical_center_fit.py
@@ -253,6 +253,21 @@ def test_physical_center_auto_irls_attempts_single_line_below_two_piece_min() ->
     assert np.all(np.isposinf(result.physical_fit_two_piece_cost))
 
 
+def test_fit_min_obs_required_explicit_single_line_ignores_fallback_flag() -> None:
+    cfg = physical_cfg(
+        {
+            'physical_trend': {
+                'fit_kind': 'auto_irls',
+                'candidate_models': ['single_line'],
+                'model_selection': {'fallback_to_single_line': False},
+            },
+            'two_piece_irls': {'min_pts': 6},
+        }
+    )
+
+    assert fit_mod._fit_min_obs_required(cfg) == 6
+
+
 def test_physical_center_auto_irls_selects_two_piece_when_improved() -> None:
     offsets = np.linspace(0.0, 4000.0, 48, dtype=np.float32)
     coarse_npz, table, feasible, trend, merged = make_inputs(offsets_m=offsets)

--- a/packages/seisai-engine/tests/test_fbpick_physics.py
+++ b/packages/seisai-engine/tests/test_fbpick_physics.py
@@ -714,24 +714,33 @@ def test_load_physics_lite_config_derives_physical_band_from_legacy_feasible_ban
     assert cfg.physical_band.t0_hi_ms == pytest.approx(90.0)
 
 
-def test_load_physics_lite_config_rejects_conflicting_legacy_band() -> None:
-    with pytest.raises(ValueError, match='physical_band and physical_prefilter'):
-        load_physics_lite_config(
-            {
-                'physical_band': {
-                    'vmin_m_s': 300.0,
-                    'vmax_m_s': 6000.0,
-                    't0_lo_ms': -20.0,
-                    't0_hi_ms': 200.0,
-                },
-                'physical_prefilter': {
-                    'vmin_m_s': 400.0,
-                    'vmax_m_s': 6000.0,
-                    't0_lo_ms': -20.0,
-                    't0_hi_ms': 200.0,
-                },
-            }
-        )
+def test_load_physics_lite_config_uses_physical_band_before_legacy_bands() -> None:
+    cfg = load_physics_lite_config(
+        {
+            'physical_band': {
+                'vmin_m_s': 350.0,
+                'vmax_m_s': 5500.0,
+                't0_lo_ms': -15.0,
+                't0_hi_ms': 150.0,
+            },
+            'physical_prefilter': {
+                'pmax_min': 0.07,
+            },
+            'feasible_band': {
+                'vmin_mask': 250.0,
+                'vmax_mask': 4500.0,
+                't0_lo_ms': -12.0,
+                't0_hi_ms': 90.0,
+            },
+        }
+    )
+
+    assert cfg.physical_band.vmin_m_s == pytest.approx(350.0)
+    assert cfg.physical_band.vmax_m_s == pytest.approx(5500.0)
+    assert cfg.physical_band.t0_lo_ms == pytest.approx(-15.0)
+    assert cfg.physical_band.t0_hi_ms == pytest.approx(150.0)
+    assert cfg.fit_observation_filter.pmax_min == pytest.approx(0.07)
+    assert cfg.physical_prefilter.vmin_m_s == pytest.approx(350.0)
 
 
 def test_load_physics_lite_config_accepts_nested_diagnostics_block() -> None:

--- a/packages/seisai-engine/tests/test_fbpick_physics.py
+++ b/packages/seisai-engine/tests/test_fbpick_physics.py
@@ -543,6 +543,11 @@ def test_load_physics_lite_config_defaults_include_physical_trend_blocks() -> No
     assert cfg.neighbor_context.mode == 'nearest_source_xy'
     assert cfg.neighbor_context.k_neighbors == 5
     assert cfg.neighbor_context.max_source_distance_m is None
+    assert cfg.physical_band.vmin_m_s == 300.0
+    assert cfg.physical_band.vmax_m_s == 6000.0
+    assert cfg.fit_observation_filter.enabled is True
+    assert cfg.fit_observation_filter.band_source == 'physical_band'
+    assert cfg.fit_observation_filter.pmax_min == 0.0
     assert cfg.physical_prefilter.vmin_m_s == 300.0
     assert cfg.physical_prefilter.vmax_m_s == 6000.0
     assert cfg.two_piece_ransac.q_lo == 0.15
@@ -605,6 +610,12 @@ def test_load_physics_lite_config_defaults_include_physical_trend_blocks() -> No
     assert cfg.physical_runtime.fit_executor.max_workers is None
     assert cfg.physical_runtime.fit_executor.torch_num_threads_per_worker == 1
     assert cfg.physical_runtime.fit_executor.chunksize == 1
+    assert cfg.physical_runtime.fine_window_constraint.band_source == 'physical_band'
+    assert (
+        cfg.physical_runtime.neighbor_physical_fit_reuse.band_source
+        == 'physical_band'
+    )
+    assert cfg.physical_runtime.coarse_in_band_fallback.band_source == 'physical_band'
     assert cfg.physical_runtime.partial_trend_fallback.enabled is True
     assert cfg.physical_runtime.partial_trend_fallback.max_fraction == pytest.approx(
         0.05
@@ -632,6 +643,95 @@ def test_load_physics_lite_config_defaults_include_physical_trend_blocks() -> No
     assert cfg.physical_runtime.progress.print_on_non_tty is True
     assert cfg.physical_runtime.progress.include_stage_events is True
     assert cfg.physical_runtime.progress.include_summary is True
+
+
+def test_load_physics_lite_config_accepts_physical_band_and_fit_filter() -> None:
+    cfg = load_physics_lite_config(
+        {
+            'physical_band': {
+                'vmin_m_s': 350.0,
+                'vmax_m_s': 5500.0,
+                't0_lo_ms': -15.0,
+                't0_hi_ms': 150.0,
+            },
+            'fit_observation_filter': {
+                'enabled': True,
+                'band_source': 'physical_band',
+                'pmax_min': 0.05,
+                'use_existing_mask': False,
+            },
+            'physical_runtime': {
+                'fine_window_constraint': {'band_source': 'physical_band'},
+                'neighbor_physical_fit_reuse': {'band_source': 'physical_band'},
+                'coarse_in_band_fallback': {'band_source': 'physical_band'},
+            },
+        }
+    )
+
+    assert cfg.physical_band.vmin_m_s == pytest.approx(350.0)
+    assert cfg.physical_band.vmax_m_s == pytest.approx(5500.0)
+    assert cfg.fit_observation_filter.pmax_min == pytest.approx(0.05)
+    assert cfg.physical_prefilter.vmin_m_s == pytest.approx(350.0)
+    assert cfg.physical_prefilter.pmax_min == pytest.approx(0.05)
+
+
+def test_load_physics_lite_config_derives_physical_band_from_legacy_prefilter() -> None:
+    cfg = load_physics_lite_config(
+        {
+            'physical_prefilter': {
+                'enabled': True,
+                'vmin_m_s': 400.0,
+                'vmax_m_s': 5000.0,
+                't0_lo_ms': -5.0,
+                't0_hi_ms': 125.0,
+                'pmax_min': 0.2,
+                'use_existing_feasible_mask': True,
+            }
+        }
+    )
+
+    assert cfg.physical_band.vmin_m_s == pytest.approx(400.0)
+    assert cfg.physical_band.vmax_m_s == pytest.approx(5000.0)
+    assert cfg.fit_observation_filter.pmax_min == pytest.approx(0.2)
+    assert cfg.fit_observation_filter.use_existing_mask is True
+
+
+def test_load_physics_lite_config_derives_physical_band_from_legacy_feasible_band() -> None:
+    cfg = load_physics_lite_config(
+        {
+            'feasible_band': {
+                'vmin_mask': 250.0,
+                'vmax_mask': 4500.0,
+                't0_lo_ms': -12.0,
+                't0_hi_ms': 90.0,
+            }
+        }
+    )
+
+    assert cfg.physical_band.vmin_m_s == pytest.approx(250.0)
+    assert cfg.physical_band.vmax_m_s == pytest.approx(4500.0)
+    assert cfg.physical_band.t0_lo_ms == pytest.approx(-12.0)
+    assert cfg.physical_band.t0_hi_ms == pytest.approx(90.0)
+
+
+def test_load_physics_lite_config_rejects_conflicting_legacy_band() -> None:
+    with pytest.raises(ValueError, match='physical_band and physical_prefilter'):
+        load_physics_lite_config(
+            {
+                'physical_band': {
+                    'vmin_m_s': 300.0,
+                    'vmax_m_s': 6000.0,
+                    't0_lo_ms': -20.0,
+                    't0_hi_ms': 200.0,
+                },
+                'physical_prefilter': {
+                    'vmin_m_s': 400.0,
+                    'vmax_m_s': 6000.0,
+                    't0_lo_ms': -20.0,
+                    't0_hi_ms': 200.0,
+                },
+            }
+        )
 
 
 def test_load_physics_lite_config_accepts_nested_diagnostics_block() -> None:
@@ -1200,6 +1300,8 @@ def test_physics_lite_config_to_dict_includes_physical_trend_blocks() -> None:
         {
             'physical_trend',
             'neighbor_context',
+            'physical_band',
+            'fit_observation_filter',
             'physical_prefilter',
             'two_piece_ransac',
             'physical_projection',
@@ -1208,6 +1310,8 @@ def test_physics_lite_config_to_dict_includes_physical_trend_blocks() -> None:
     )
     assert out['physical_trend']['enabled'] is True
     assert out['neighbor_context']['max_source_distance_m'] == 1000.0
+    assert out['physical_band']['vmin_m_s'] == 400.0
+    assert out['fit_observation_filter']['pmax_min'] == 0.25
     assert out['physical_projection']['mode'] == 'model'
     assert out['physical_runtime']['diagnostics_enabled'] is True
     assert out['physical_runtime']['fit_policy'] == 'full'

--- a/proc/fbpick/site54/oof/README.md
+++ b/proc/fbpick/site54/oof/README.md
@@ -48,7 +48,9 @@ Do not use `min_pick_ratio=0.3` as the site54 OOF runtime default. That threshol
 
 The site54 OOF physics default allows both two-piece and straight-line travel-time fits. `single_line_ok` is a valid physical fit result. `two_piece_ok` is selected only when the two-piece model improves over the single-line model by the configured relative-improvement threshold.
 
-The fine center policy is: self physical fit, then neighbor physical fit reuse, then coarse-in-band fallback, then reject. Neighbor reuse may use nearby successful `two_piece_ok` or `single_line_ok` fits. Coarse fallback is allowed only when the coarse pick sits inside the `physical_prefilter` band. If coarse is outside the band, or a 256-sample fine window cannot fit inside the `physical_prefilter` band, the trace is rejected by physics.
+The fine center policy is: self physical fit, then neighbor physical fit reuse, then coarse-in-band fallback, then reject. Neighbor reuse may use nearby successful `two_piece_ok` or `single_line_ok` fits. Coarse fallback is allowed only when the coarse pick sits inside the canonical `physical_band`. If coarse is outside the band, or a 256-sample fine window cannot fit inside the `physical_band`, the trace is rejected by physics.
+
+The site54 default uses one velocity/t0 band, `physical_band`, for fit observation velocity/t0 filtering, fit validation, neighbor reuse, coarse fallback, fine-window validity, and viewer band display. It does not emit or depend on `feasible_band`. `physical_prefilter` is a legacy config name that the engine can still read for old configs; generated site54 configs use `fit_observation_filter` instead. `pmax_min` is a fit-observation quality threshold, not part of the velocity/t0 band, and belongs under `fit_observation_filter`.
 
 The site54 default does not use robust, feasible-clip, or unconditional coarse fallback as a fine center. Fine train and infer consume `fine_center_i` only where `fine_window_valid_mask` is true; invalid traces are excluded from fine train/infer windows. In final evaluation, invalid or rejected traces with a teacher pick count as misses rather than being removed from the denominator.
 

--- a/proc/fbpick/site54/oof/scripts/check_cv_outputs.py
+++ b/proc/fbpick/site54/oof/scripts/check_cv_outputs.py
@@ -34,10 +34,12 @@ FINE_INFER_ALLOWED_PATH_KEYS = set(FINE_INFER_REQUIRED_SINGLE_ENTRY_KEYS) | {
 STRICT_PHYSICS_KEYS = (
     "fine_center_i",
     "fine_window_valid_mask",
-    "fine_window_physical_lo_i",
-    "fine_window_physical_hi_i",
     "fine_window_reject_reason",
     "physical_model_status",
+)
+STRICT_PHYSICS_WINDOW_KEY_PAIRS = (
+    ("fine_window_physical_lo_i", "fine_window_physical_hi_i"),
+    ("physical_band_lo_i", "physical_band_hi_i"),
 )
 STRICT_FINAL_KEYS = (
     "final_pick_f",
@@ -293,6 +295,8 @@ def check_npz_count(
             try:
                 with np.load(path, allow_pickle=False) as z:
                     missing_keys = [key for key in strict_keys if key not in z.files]
+                    if strict_keys == STRICT_PHYSICS_KEYS:
+                        missing_keys.extend(missing_physics_window_keys(z.files))
             except Exception as exc:
                 failures.append(f"read_error={path}:{exc}")
                 break
@@ -342,6 +346,25 @@ def require_integer_trace_vector(
     return arr.astype(np.int64, copy=False)
 
 
+def missing_physics_window_keys(files: list[str]) -> list[str]:
+    file_set = set(files)
+    for lo_key, hi_key in STRICT_PHYSICS_WINDOW_KEY_PAIRS:
+        if lo_key in file_set and hi_key in file_set:
+            return []
+    for lo_key, hi_key in STRICT_PHYSICS_WINDOW_KEY_PAIRS:
+        present = [key in file_set for key in (lo_key, hi_key)]
+        if any(present):
+            return [key for key in (lo_key, hi_key) if key not in file_set]
+    return list(STRICT_PHYSICS_WINDOW_KEY_PAIRS[0])
+
+
+def physics_window_keys(z: np.lib.npyio.NpzFile) -> tuple[str, str]:
+    for lo_key, hi_key in STRICT_PHYSICS_WINDOW_KEY_PAIRS:
+        if lo_key in z.files and hi_key in z.files:
+            return lo_key, hi_key
+    raise KeyError(",".join(missing_physics_window_keys(z.files)))
+
+
 def strict_check_physics_npz(
     path: Path,
     *,
@@ -352,9 +375,11 @@ def strict_check_physics_npz(
     try:
         with np.load(path, allow_pickle=False) as z:
             missing = [key for key in STRICT_PHYSICS_KEYS if key not in z.files]
+            missing.extend(missing_physics_window_keys(z.files))
             if missing:
                 return f"{path.name}:missing_keys={','.join(missing)}"
             n_traces = npz_n_traces(z)
+            lo_key, hi_key = physics_window_keys(z)
             status = require_trace_vector(
                 z,
                 "physical_model_status",
@@ -374,12 +399,12 @@ def strict_check_physics_npz(
             )
             lo_i = require_integer_trace_vector(
                 z,
-                "fine_window_physical_lo_i",
+                lo_key,
                 n_traces=n_traces,
             )
             hi_i = require_integer_trace_vector(
                 z,
-                "fine_window_physical_hi_i",
+                hi_key,
                 n_traces=n_traces,
             )
             window_reason = require_trace_vector(
@@ -507,14 +532,15 @@ def strict_check_physics_final_pair(
                 n_traces=n_traces,
                 dtype=np.bool_,
             )
+            lo_key, hi_key = physics_window_keys(physics)
             lo_i = require_integer_trace_vector(
                 physics,
-                "fine_window_physical_lo_i",
+                lo_key,
                 n_traces=n_traces,
             )
             hi_i = require_integer_trace_vector(
                 physics,
-                "fine_window_physical_hi_i",
+                hi_key,
                 n_traces=n_traces,
             )
             reject = require_trace_vector(

--- a/proc/fbpick/site54/oof/scripts/check_cv_outputs.py
+++ b/proc/fbpick/site54/oof/scripts/check_cv_outputs.py
@@ -594,8 +594,28 @@ def strict_check_physics_config(config_path: Path) -> str | None:
         return f"{config_path.name}:config_not_dict"
     if "physical_band" not in cfg:
         return f"{config_path.name}:missing_physical_band"
-    if "fit_observation_filter" not in cfg:
+    physical_band = cfg.get("physical_band")
+    if isinstance(physical_band, dict) and "pmax_min" in physical_band:
+        return f"{config_path.name}:forbidden_physical_band.pmax_min"
+    fit_filter = cfg.get("fit_observation_filter")
+    if not isinstance(fit_filter, dict):
         return f"{config_path.name}:missing_fit_observation_filter"
+    if fit_filter.get("band_source") != "physical_band":
+        return (
+            f"{config_path.name}:fit_observation_filter.band_source="
+            f"{fit_filter.get('band_source')!r}"
+        )
+    if "pmax_min" not in fit_filter:
+        return f"{config_path.name}:missing_fit_observation_filter.pmax_min"
+    try:
+        pmax_min = float(fit_filter["pmax_min"])
+    except (TypeError, ValueError):
+        return (
+            f"{config_path.name}:fit_observation_filter.pmax_min="
+            f"{fit_filter.get('pmax_min')!r}"
+        )
+    if not 0.0 <= pmax_min <= 1.0:
+        return f"{config_path.name}:fit_observation_filter.pmax_min={pmax_min!r}"
     if "feasible_band" in cfg:
         return f"{config_path.name}:forbidden_feasible_band"
     if "physical_prefilter" in cfg:

--- a/proc/fbpick/site54/oof/scripts/check_cv_outputs.py
+++ b/proc/fbpick/site54/oof/scripts/check_cv_outputs.py
@@ -329,8 +329,26 @@ def require_trace_vector(
     return arr
 
 
-def strict_check_physics_npz(path: Path) -> str | None:
-    """Validate required physics NPZ keys and physical status values."""
+def require_integer_trace_vector(
+    z: np.lib.npyio.NpzFile,
+    key: str,
+    *,
+    n_traces: int,
+) -> np.ndarray:
+    """Return an integer trace-aligned NPZ array normalized for arithmetic."""
+    arr = require_trace_vector(z, key, n_traces=n_traces)
+    if not np.issubdtype(arr.dtype, np.integer):
+        raise ValueError(f"{key}_dtype={arr.dtype}/integer")
+    return arr.astype(np.int64, copy=False)
+
+
+def strict_check_physics_npz(
+    path: Path,
+    *,
+    time_len: int = 256,
+    center_index: int = 128,
+) -> str | None:
+    """Validate required physics NPZ keys and physical window contract."""
     try:
         with np.load(path, allow_pickle=False) as z:
             missing = [key for key in STRICT_PHYSICS_KEYS if key not in z.files]
@@ -343,15 +361,27 @@ def strict_check_physics_npz(path: Path) -> str | None:
                 n_traces=n_traces,
                 dtype=np.uint8,
             )
-            require_trace_vector(z, "fine_center_i", n_traces=n_traces)
+            center_i = require_integer_trace_vector(
+                z,
+                "fine_center_i",
+                n_traces=n_traces,
+            )
             valid = require_trace_vector(
                 z,
                 "fine_window_valid_mask",
                 n_traces=n_traces,
                 dtype=np.bool_,
             )
-            for key in ("fine_window_physical_lo_i", "fine_window_physical_hi_i"):
-                require_trace_vector(z, key, n_traces=n_traces)
+            lo_i = require_integer_trace_vector(
+                z,
+                "fine_window_physical_lo_i",
+                n_traces=n_traces,
+            )
+            hi_i = require_integer_trace_vector(
+                z,
+                "fine_window_physical_hi_i",
+                n_traces=n_traces,
+            )
             window_reason = require_trace_vector(
                 z,
                 "fine_window_reject_reason",
@@ -401,6 +431,17 @@ def strict_check_physics_npz(path: Path) -> str | None:
         return (
             f"{path.name}:valid_window_reject_reason="
             f"{int(valid_reason_reject[0])}"
+        )
+
+    window_start_i = center_i - int(center_index)
+    window_end_i = window_start_i + int(time_len) - 1
+    bad_window = np.flatnonzero(
+        valid & ((window_start_i < lo_i) | (window_end_i > hi_i))
+    )
+    if bad_window.size:
+        return (
+            f"{path.name}:valid_window_outside_physical_band="
+            f"{int(bad_window[0])}"
         )
 
     if (
@@ -466,17 +507,15 @@ def strict_check_physics_final_pair(
                 n_traces=n_traces,
                 dtype=np.bool_,
             )
-            lo_i = require_trace_vector(
+            lo_i = require_integer_trace_vector(
                 physics,
                 "fine_window_physical_lo_i",
                 n_traces=n_traces,
-                dtype=np.int64,
             )
-            hi_i = require_trace_vector(
+            hi_i = require_integer_trace_vector(
                 physics,
                 "fine_window_physical_hi_i",
                 n_traces=n_traces,
-                dtype=np.int64,
             )
             reject = require_trace_vector(
                 final,
@@ -493,17 +532,15 @@ def strict_check_physics_final_pair(
                 )
 
             if "window_start_i" in final.files and "window_end_i" in final.files:
-                start = require_trace_vector(
+                start = require_integer_trace_vector(
                     final,
                     "window_start_i",
                     n_traces=n_traces,
-                    dtype=np.int64,
                 )
-                end = require_trace_vector(
+                end = require_integer_trace_vector(
                     final,
                     "window_end_i",
                     n_traces=n_traces,
-                    dtype=np.int64,
                 )
                 bad_window = np.flatnonzero(valid & ((start < lo_i) | (end > hi_i)))
                 if bad_window.size:
@@ -516,6 +553,50 @@ def strict_check_physics_final_pair(
                     return f"{final_path.name}:window_len={int(bad_len[0])}"
     except (OSError, ValueError, KeyError, zipfile.BadZipFile) as exc:
         return f"{physics_path.name}:{final_path.name}:read_error={exc}"
+    return None
+
+
+def strict_check_physics_config(config_path: Path) -> str | None:
+    """Validate generated site54 physics config uses the physical band policy."""
+    if not config_path.is_file():
+        return f"missing={config_path}"
+    try:
+        cfg = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+    except (OSError, yaml.YAMLError) as exc:
+        return f"{config_path.name}:read_error={exc}"
+    if not isinstance(cfg, dict):
+        return f"{config_path.name}:config_not_dict"
+    if "physical_band" not in cfg:
+        return f"{config_path.name}:missing_physical_band"
+    if "fit_observation_filter" not in cfg:
+        return f"{config_path.name}:missing_fit_observation_filter"
+    if "feasible_band" in cfg:
+        return f"{config_path.name}:forbidden_feasible_band"
+    if "physical_prefilter" in cfg:
+        return f"{config_path.name}:forbidden_physical_prefilter"
+    runtime = cfg.get("physical_runtime")
+    if not isinstance(runtime, dict):
+        return f"{config_path.name}:missing_physical_runtime"
+    expected_sources = {
+        "fine_window_constraint": runtime.get("fine_window_constraint"),
+        "neighbor_physical_fit_reuse": runtime.get("neighbor_physical_fit_reuse"),
+        "coarse_in_band_fallback": runtime.get("coarse_in_band_fallback"),
+    }
+    for key, block in expected_sources.items():
+        if not isinstance(block, dict):
+            return f"{config_path.name}:missing_{key}"
+        if block.get("band_source") != "physical_band":
+            return f"{config_path.name}:{key}.band_source={block.get('band_source')!r}"
+    fallback = runtime.get("fallback_policy")
+    if isinstance(fallback, dict):
+        order = fallback.get("order")
+        if isinstance(order, list) and any("feasible_clip" in str(v) for v in order):
+            return f"{config_path.name}:forbidden_feasible_clip_policy"
+    text = config_path.read_text(encoding="utf-8")
+    if "fallback_feasible_clip" in text:
+        return f"{config_path.name}:forbidden_fallback_feasible_clip"
+    if "allow_feasible_clip_as_fine_center: true" in text:
+        return f"{config_path.name}:forbidden_feasible_clip_enabled"
     return None
 
 
@@ -820,6 +901,24 @@ def main() -> int:
             allow_smoke=args.smoke,
         )
         if args.strict:
+            for name in ("03_physics.yaml", "04_physics_qc.yaml"):
+                config_path = config_root / fold / name
+                if error := strict_check_physics_config(config_path):
+                    add_result(
+                        results,
+                        fold=fold,
+                        stage=name,
+                        ok=False,
+                        detail=error,
+                    )
+                else:
+                    add_result(
+                        results,
+                        fold=fold,
+                        stage=name,
+                        ok=True,
+                        detail=f"path={config_path}",
+                    )
             strict_error = strict_check_fine_train_config(
                 config_path=config_root / fold / "06_fine_train.yaml",
                 fine_fold_dir=fine_list_root / fold,

--- a/proc/fbpick/site54/oof/scripts/make_physics_fold_configs.py
+++ b/proc/fbpick/site54/oof/scripts/make_physics_fold_configs.py
@@ -103,7 +103,7 @@ def physics_runtime_cfg(args: argparse.Namespace) -> dict:
         },
         'fine_window_constraint': {
             'enabled': True,
-            'band_source': 'physical_prefilter',
+            'band_source': 'physical_band',
             'time_len': 256,
             'center_index': 128,
             'require_center_inside_band': True,
@@ -114,10 +114,16 @@ def physics_runtime_cfg(args: argparse.Namespace) -> dict:
         },
         'neighbor_physical_fit_reuse': {
             'enabled': True,
+            'band_source': 'physical_band',
             'candidate_statuses': ['two_piece_ok', 'single_line_ok'],
             'max_source_xy_distance_m': None,
             'max_trace_distance': None,
             'invalid_policy': 'try_coarse_in_band',
+        },
+        'coarse_in_band_fallback': {
+            'enabled': True,
+            'band_source': 'physical_band',
+            'require_window_inside_band': True,
         },
         'fallback_policy': {
             'enabled': True,
@@ -167,14 +173,17 @@ def physical_center_cfg(args: argparse.Namespace, *, qc: bool = False) -> dict:
             'max_source_distance_m': None,
             'include_self': True,
         },
-        'physical_prefilter': {
-            'enabled': True,
+        'physical_band': {
             'vmin_m_s': 300.0,
             'vmax_m_s': 6000.0,
             't0_lo_ms': -20.0,
             't0_hi_ms': 200.0,
+        },
+        'fit_observation_filter': {
+            'enabled': True,
+            'band_source': 'physical_band',
             'pmax_min': 0.0 if qc else 0.05,
-            'use_existing_feasible_mask': False,
+            'use_existing_mask': False,
         },
         'physical_projection': {'mode': 'model'},
         'two_piece_ransac': {
@@ -248,7 +257,6 @@ def physics_config(args: argparse.Namespace, fold: str) -> dict:
             'coarse_npz_dir': str(args.run_root / fold / '02_coarse_infer'),
             'out_dir': str(args.run_root / fold / '03_physics'),
         },
-        'feasible_band': {},
         'trend': {},
         'residual_statics': {},
         'keep_reject': {},

--- a/proc/fbpick/site54/oof/scripts/make_physics_fold_configs.py
+++ b/proc/fbpick/site54/oof/scripts/make_physics_fold_configs.py
@@ -61,7 +61,7 @@ def physics_runtime_cfg(args: argparse.Namespace) -> dict:
             'max_obs_per_fit': 64,
             'n_offset_bins': 64,
             'bin_pick': 'pmax_max',
-            'min_obs_per_fit_after_sampling': 16,
+            'min_obs_per_fit_after_sampling': 8,
             'preserve_edge_bins': True,
         },
         'fit_executor': {

--- a/tests/test_site54_fine_oof_config.py
+++ b/tests/test_site54_fine_oof_config.py
@@ -396,6 +396,18 @@ def test_make_physics_defaults_write_configs_under_run_root(
     )
     _assert_partial_physics_fallback(physics_cfg)
     _assert_partial_physics_fallback(physics_qc_cfg)
+    assert (
+        physics_cfg['physical_runtime']['observation_sampling'][
+            'min_obs_per_fit_after_sampling'
+        ]
+        == 8
+    )
+    assert (
+        physics_qc_cfg['physical_runtime']['observation_sampling'][
+            'min_obs_per_fit_after_sampling'
+        ]
+        == 8
+    )
     assert 'fallback_if_no_compatible_segment: robust' not in physics_text
     assert 'geometry_invalid_fallback: robust' not in physics_text
     assert 'group_invalid_fallback: robust' not in physics_text

--- a/tests/test_site54_fine_oof_config.py
+++ b/tests/test_site54_fine_oof_config.py
@@ -596,6 +596,26 @@ def test_check_cv_outputs_strict_npz_policy_accepts_new_keys(tmp_path: Path) -> 
     )
 
 
+def test_check_cv_outputs_strict_physics_npz_accepts_physical_band_keys(
+    tmp_path: Path,
+) -> None:
+    module = _load_check_cv_outputs()
+    physics_path = tmp_path / 'survey.robust.npz'
+
+    np.savez(
+        physics_path,
+        n_traces=np.asarray(1, dtype=np.int32),
+        fine_center_i=np.asarray([128], dtype=np.int32),
+        fine_window_valid_mask=np.asarray([True], dtype=np.bool_),
+        physical_band_lo_i=np.asarray([0], dtype=np.int32),
+        physical_band_hi_i=np.asarray([255], dtype=np.int32),
+        fine_window_reject_reason=np.asarray([0], dtype=np.uint8),
+        physical_model_status=np.asarray([0], dtype=np.uint8),
+    )
+
+    assert module.strict_check_physics_npz(physics_path) is None
+
+
 def test_check_cv_outputs_strict_final_npz_requires_fine_window_valid_mask(
     tmp_path: Path,
 ) -> None:

--- a/tests/test_site54_fine_oof_config.py
+++ b/tests/test_site54_fine_oof_config.py
@@ -65,7 +65,11 @@ def _load_oof_script(script_name: str, module_name: str) -> ModuleType:
     return module
 
 
-def _assert_partial_physics_fallback(cfg: dict) -> None:
+def _assert_partial_physics_fallback(
+    cfg: dict,
+    *,
+    expected_pmax_min: float,
+) -> None:
     trend = cfg['physical_trend']
     assert trend['fit_kind'] == 'auto_irls'
     assert trend['candidate_models'] == ['two_piece', 'single_line']
@@ -112,7 +116,19 @@ def _assert_partial_physics_fallback(cfg: dict) -> None:
         'single_line_ok',
     ]
     assert 'physical_band' in cfg
-    assert 'fit_observation_filter' in cfg
+    assert cfg['physical_band'] == {
+        'vmin_m_s': 300.0,
+        'vmax_m_s': 6000.0,
+        't0_lo_ms': -20.0,
+        't0_hi_ms': 200.0,
+    }
+    assert cfg['fit_observation_filter'] == {
+        'enabled': True,
+        'band_source': 'physical_band',
+        'pmax_min': expected_pmax_min,
+        'use_existing_mask': False,
+    }
+    assert 'pmax_min' not in cfg['physical_band']
     assert 'feasible_band' not in cfg
     assert 'physical_prefilter' not in cfg
 
@@ -394,8 +410,8 @@ def test_make_physics_defaults_write_configs_under_run_root(
             encoding='utf-8',
         ),
     )
-    _assert_partial_physics_fallback(physics_cfg)
-    _assert_partial_physics_fallback(physics_qc_cfg)
+    _assert_partial_physics_fallback(physics_cfg, expected_pmax_min=0.05)
+    _assert_partial_physics_fallback(physics_qc_cfg, expected_pmax_min=0.0)
     assert (
         physics_cfg['physical_runtime']['observation_sampling'][
             'min_obs_per_fit_after_sampling'
@@ -552,8 +568,8 @@ def test_run_site54_oof_cv_prepare_configs_writes_manifest_and_configs(
             encoding='utf-8',
         ),
     )
-    _assert_partial_physics_fallback(physics_cfg)
-    _assert_partial_physics_fallback(physics_qc_cfg)
+    _assert_partial_physics_fallback(physics_cfg, expected_pmax_min=0.05)
+    _assert_partial_physics_fallback(physics_qc_cfg, expected_pmax_min=0.0)
 
 
 def test_check_cv_outputs_strict_npz_policy_accepts_new_keys(tmp_path: Path) -> None:
@@ -614,6 +630,78 @@ def test_check_cv_outputs_strict_physics_npz_accepts_physical_band_keys(
     )
 
     assert module.strict_check_physics_npz(physics_path) is None
+
+
+def _strict_physics_config() -> dict:
+    return {
+        'physical_band': {
+            'vmin_m_s': 300.0,
+            'vmax_m_s': 6000.0,
+            't0_lo_ms': -20.0,
+            't0_hi_ms': 200.0,
+        },
+        'fit_observation_filter': {
+            'enabled': True,
+            'band_source': 'physical_band',
+            'pmax_min': 0.05,
+            'use_existing_mask': False,
+        },
+        'physical_runtime': {
+            'fine_window_constraint': {'band_source': 'physical_band'},
+            'neighbor_physical_fit_reuse': {'band_source': 'physical_band'},
+            'coarse_in_band_fallback': {'band_source': 'physical_band'},
+            'fallback_policy': {
+                'order': [
+                    'self_physical_fit',
+                    'neighbor_physical_fit_reuse',
+                    'coarse_in_band',
+                    'reject',
+                ],
+            },
+        },
+    }
+
+
+def test_check_cv_outputs_strict_physics_config_accepts_fit_filter_contract(
+    tmp_path: Path,
+) -> None:
+    module = _load_check_cv_outputs()
+    config_path = tmp_path / '03_physics.yaml'
+    config_path.write_text(
+        yaml.safe_dump(_strict_physics_config(), sort_keys=False),
+        encoding='utf-8',
+    )
+
+    assert module.strict_check_physics_config(config_path) is None
+
+
+def test_check_cv_outputs_strict_physics_config_requires_fit_filter_band_source(
+    tmp_path: Path,
+) -> None:
+    module = _load_check_cv_outputs()
+    config_path = tmp_path / '03_physics.yaml'
+    cfg = _strict_physics_config()
+    cfg['fit_observation_filter']['band_source'] = 'physical_prefilter'
+    config_path.write_text(yaml.safe_dump(cfg, sort_keys=False), encoding='utf-8')
+
+    assert module.strict_check_physics_config(config_path) == (
+        "03_physics.yaml:fit_observation_filter.band_source='physical_prefilter'"
+    )
+
+
+def test_check_cv_outputs_strict_physics_config_requires_fit_filter_pmax_min(
+    tmp_path: Path,
+) -> None:
+    module = _load_check_cv_outputs()
+    config_path = tmp_path / '03_physics.yaml'
+    cfg = _strict_physics_config()
+    del cfg['fit_observation_filter']['pmax_min']
+    cfg['physical_band']['pmax_min'] = 0.05
+    config_path.write_text(yaml.safe_dump(cfg, sort_keys=False), encoding='utf-8')
+
+    assert module.strict_check_physics_config(config_path) == (
+        '03_physics.yaml:forbidden_physical_band.pmax_min'
+    )
 
 
 def test_check_cv_outputs_strict_final_npz_requires_fine_window_valid_mask(

--- a/tests/test_site54_fine_oof_config.py
+++ b/tests/test_site54_fine_oof_config.py
@@ -102,13 +102,19 @@ def _assert_partial_physics_fallback(cfg: dict) -> None:
         'reject',
     ]
     assert runtime['fine_window_constraint']['enabled'] is True
-    assert runtime['fine_window_constraint']['band_source'] == 'physical_prefilter'
+    assert runtime['fine_window_constraint']['band_source'] == 'physical_band'
     assert runtime['fine_window_constraint']['time_len'] == 256
     assert runtime['fine_window_constraint']['center_index'] == 128
+    assert runtime['neighbor_physical_fit_reuse']['band_source'] == 'physical_band'
+    assert runtime['coarse_in_band_fallback']['band_source'] == 'physical_band'
     assert runtime['neighbor_physical_fit_reuse']['candidate_statuses'] == [
         'two_piece_ok',
         'single_line_ok',
     ]
+    assert 'physical_band' in cfg
+    assert 'fit_observation_filter' in cfg
+    assert 'feasible_band' not in cfg
+    assert 'physical_prefilter' not in cfg
 
 
 def test_fine_train_config_fixed_last_uses_last_checkpoint_policy(
@@ -596,6 +602,49 @@ def test_check_cv_outputs_strict_final_npz_requires_fine_window_valid_mask(
 
     assert module.strict_check_final_npz(final_path) == (
         'legacy.fbpick_final.npz:missing_keys=fine_window_valid_mask'
+    )
+
+
+def test_check_cv_outputs_strict_physics_npz_requires_physical_window_keys(
+    tmp_path: Path,
+) -> None:
+    module = _load_check_cv_outputs()
+    physics_path = tmp_path / 'legacy.robust.npz'
+
+    np.savez(
+        physics_path,
+        n_traces=np.asarray(1, dtype=np.int32),
+        fine_center_i=np.asarray([128], dtype=np.int32),
+        fine_window_valid_mask=np.asarray([True], dtype=np.bool_),
+        fine_window_reject_reason=np.asarray([0], dtype=np.uint8),
+        physical_model_status=np.asarray([0], dtype=np.uint8),
+    )
+
+    assert module.strict_check_physics_npz(physics_path) == (
+        'legacy.robust.npz:missing_keys='
+        'fine_window_physical_lo_i,fine_window_physical_hi_i'
+    )
+
+
+def test_check_cv_outputs_strict_physics_npz_rejects_valid_window_outside_band(
+    tmp_path: Path,
+) -> None:
+    module = _load_check_cv_outputs()
+    physics_path = tmp_path / 'outside-band.robust.npz'
+
+    np.savez(
+        physics_path,
+        n_traces=np.asarray(1, dtype=np.int32),
+        fine_center_i=np.asarray([128], dtype=np.int32),
+        fine_window_valid_mask=np.asarray([True], dtype=np.bool_),
+        fine_window_physical_lo_i=np.asarray([1], dtype=np.int32),
+        fine_window_physical_hi_i=np.asarray([255], dtype=np.int32),
+        fine_window_reject_reason=np.asarray([0], dtype=np.uint8),
+        physical_model_status=np.asarray([0], dtype=np.uint8),
+    )
+
+    assert module.strict_check_physics_npz(physics_path) == (
+        'outside-band.robust.npz:valid_window_outside_physical_band=0'
     )
 
 


### PR DESCRIPTION
Closes #196
Closes #197

## Issues
- #196 Issue: `feasible_band` を廃止し、速度/t0帯を `physical_band` に一本化する
- #197 Issue: auto_irls の single-line 許容時に観測数ゲートを two-piece 基準で早期rejectしない

Batch range: #196-#197
