### PR TITLE
Issue: site54 08_eval を教師FBのみで評価し、raw record外pickは端にclipして誤差計算する

### DIFF
--- a/proc/fbpick/site54/oof/README.md
+++ b/proc/fbpick/site54/oof/README.md
@@ -408,19 +408,19 @@ python proc/fbpick/site54/oof/scripts/evaluate_fine_oof.py \
   --run-id baseline_physical_center
 ```
 
-`08_eval` writes `per_data.csv`, `per_fold.csv`, `summary.csv`, and
-`top_errors_final.csv`. site54 OOF evaluation fixes the denominator to every
-trace with a teacher FB pick. Missing predictions, NaN predictions, out-of-range
-picks, and rejected final/robust picks count as misses rather than being removed
-from the denominator. `within_k_samples` uses `n_teacher` as its denominator.
-Continuous error statistics such as `accepted_mae_samples` are computed only on
-accepted predictions, so interpret them together with `coverage`. Millisecond
-metric columns are not emitted.
+`08_eval` writes only `per_data.csv`, `summary_by_stage.csv`, and
+`eval_meta.json`. site54 OOF evaluation uses teacher traces where
+`fb_i` is finite, `fb_i > 0`, and `fb_i < n_samples_orig`; `fb_i == 0`
+is treated as unlabeled and excluded. Pick validity is finite-only. Finite picks
+outside the raw record are not removed: before error calculation they are clipped
+to `[0, n_samples_orig - 1]`, so out-of-record predictions still contribute to
+coverage and error metrics. `reject_mask`, `high_conf_mask`, accepted-prediction
+metrics, and top-error CSVs are not part of normal evaluation output.
 
 For `08_eval`, the `final` stage uses `final_pick_i`. This matches the red final
 pick drawn by fine inference QC PNGs. `final_pick_f` may remain in the payload as
 an internal float pick, but site54 OOF normal evaluation does not use it.
-`final_high_conf` is also outside the normal evaluation output.
+Normal evaluation stages are `final`, `robust`, and `coarse`.
 
 Check the run-scoped CV outputs:
 

--- a/proc/fbpick/site54/oof/scripts/check_cv_outputs.py
+++ b/proc/fbpick/site54/oof/scripts/check_cv_outputs.py
@@ -856,8 +856,7 @@ def check_eval(results: list[dict[str, Any]], *, run_root: Path) -> None:
     out_dir = run_root / "aggregate" / "08_eval"
     required = [
         out_dir / "per_data.csv",
-        out_dir / "per_fold.csv",
-        out_dir / "summary.csv",
+        out_dir / "summary_by_stage.csv",
         out_dir / "eval_meta.json",
     ]
     missing = [p for p in required if not p.is_file()]

--- a/proc/fbpick/site54/oof/scripts/evaluate_fine_oof.py
+++ b/proc/fbpick/site54/oof/scripts/evaluate_fine_oof.py
@@ -4,22 +4,50 @@ from __future__ import annotations
 import argparse
 import csv
 import json
+from collections.abc import Iterable
 from pathlib import Path
-from typing import Iterable, cast
+from typing import cast
 
 import numpy as np
 
-DEFAULT_THRESHOLDS_SAMPLES = (1.0, 2.0, 4.0, 8.0)
-REJECT_MASK_STAGES = {"final", "robust"}
-StageMetricResult = tuple[
-    dict[str, object],
-    np.ndarray,
-    np.ndarray,
-    np.ndarray | None,
-    np.ndarray,
-    dict[float, int],
+STAGE_PICK_KEYS = {
+    "final": "final_pick_i",
+    "robust": "robust_pick_i",
+    "coarse": "coarse_pick_i",
+}
+
+METRIC_COLUMNS = [
+    "run_id",
+    "fold",
+    "data_key",
+    "stage",
+    "segy_path",
+    "fb_path",
+    "pred_path",
+    "dt_sec",
+    "n_samples_orig",
+    "n_traces",
+    "n_teacher",
+    "n_pred_finite",
+    "n_pick_clipped_low",
+    "n_pick_clipped_high",
+    "n_pick_clipped",
+    "coverage",
+    "mae_samples",
+    "rmse_samples",
+    "median_abs_samples",
+    "p90_abs_samples",
+    "p95_abs_samples",
+    "p99_abs_samples",
+    "max_abs_samples",
+    "mae_ms",
+    "rmse_ms",
+    "median_abs_ms",
+    "p90_abs_ms",
+    "p95_abs_ms",
+    "p99_abs_ms",
+    "max_abs_ms",
 ]
-FileStageCacheValue = tuple[np.ndarray, np.ndarray, np.ndarray | None, np.ndarray]
 
 
 def read_list(path: Path) -> list[str]:
@@ -60,136 +88,25 @@ def load_fb_i(path: str | Path) -> np.ndarray:
     return arr.astype(np.float64, copy=False)
 
 
-def empty_metric_values(
-    *, thresholds_samples: tuple[float, ...], n_traces: int, n_teacher: int
-) -> dict[str, object]:
-    out: dict[str, object] = {
-        "n_traces": int(n_traces),
-        "n_teacher": int(n_teacher),
-        "n_pred_valid": 0,
-        "n_pred_accepted": 0,
-        "coverage": "" if n_teacher == 0 else 0.0,
-        "accepted_mae_samples": "",
-        "accepted_bias_samples": "",
-        "accepted_rmse_samples": "",
-        "accepted_median_abs_samples": "",
-        "accepted_p90_abs_samples": "",
-        "accepted_p95_abs_samples": "",
-        "accepted_p99_abs_samples": "",
-        "accepted_max_abs_samples": "",
-        "mean_conf": "",
-        "median_conf": "",
-    }
-    for th in thresholds_samples:
-        out[f"within_{th:g}_samples"] = "" if n_teacher == 0 else 0.0
-    return out
-
-
-def metric_prefix_values(
+def write_csv(
+    path: Path,
+    rows: list[dict[str, object]],
     *,
-    err_samples: np.ndarray,
-    abs_samples: np.ndarray,
-    conf: np.ndarray | None,
-    n_traces: int,
-    n_teacher: int,
-    n_pred_valid: int,
-    n_pred_accepted: int,
-    hit_counts: dict[float, int],
-    thresholds_samples: tuple[float, ...],
-) -> dict[str, object]:
-    if n_pred_accepted == 0:
-        out = empty_metric_values(
-            thresholds_samples=thresholds_samples,
-            n_traces=n_traces,
-            n_teacher=n_teacher,
-        )
-        out["n_pred_valid"] = int(n_pred_valid)
-        return out
-
-    out = {
-        "n_traces": int(n_traces),
-        "n_teacher": int(n_teacher),
-        "n_pred_valid": int(n_pred_valid),
-        "n_pred_accepted": int(n_pred_accepted),
-        "coverage": "" if n_teacher == 0 else float(n_pred_accepted / n_teacher),
-        "accepted_mae_samples": float(np.mean(abs_samples)),
-        "accepted_bias_samples": float(np.mean(err_samples)),
-        "accepted_rmse_samples": float(np.sqrt(np.mean(np.square(err_samples)))),
-        "accepted_median_abs_samples": float(np.percentile(abs_samples, 50)),
-        "accepted_p90_abs_samples": float(np.percentile(abs_samples, 90)),
-        "accepted_p95_abs_samples": float(np.percentile(abs_samples, 95)),
-        "accepted_p99_abs_samples": float(np.percentile(abs_samples, 99)),
-        "accepted_max_abs_samples": float(np.max(abs_samples)),
-    }
-
-    if conf is not None and conf.size:
-        conf_finite = conf[np.isfinite(conf)]
-        out["mean_conf"] = float(np.mean(conf_finite)) if conf_finite.size else ""
-        out["median_conf"] = (
-            float(np.percentile(conf_finite, 50)) if conf_finite.size else ""
-        )
-    else:
-        out["mean_conf"] = ""
-        out["median_conf"] = ""
-
-    for th in thresholds_samples:
-        out[f"within_{th:g}_samples"] = (
-            "" if n_teacher == 0 else float(hit_counts[float(th)] / n_teacher)
-        )
-
-    return out
-
-
-def evaluate_stage_metrics(
-    *,
-    fb_i: np.ndarray,
-    pick: np.ndarray,
-    teacher_mask: np.ndarray,
-    valid_pick: np.ndarray,
-    accepted_mask: np.ndarray,
-    conf_arr: np.ndarray | None,
-    n_traces: int,
-    thresholds_samples: tuple[float, ...],
-) -> StageMetricResult:
-    teacher_accepted = teacher_mask & accepted_mask
-    n_teacher = int(np.count_nonzero(teacher_mask))
-    n_pred_accepted = int(np.count_nonzero(teacher_accepted))
-    err = pick[teacher_accepted] - fb_i[teacher_accepted]
-    abs_err = np.abs(err)
-    hit_counts = {
-        float(th): int(
-            np.count_nonzero(teacher_accepted & (np.abs(pick - fb_i) <= float(th)))
-        )
-        for th in thresholds_samples
-    }
-    conf = conf_arr[teacher_accepted] if conf_arr is not None else None
-    values = metric_prefix_values(
-        err_samples=err,
-        abs_samples=abs_err,
-        conf=conf,
-        n_traces=n_traces,
-        n_teacher=n_teacher,
-        n_pred_valid=int(np.count_nonzero(teacher_mask & valid_pick)),
-        n_pred_accepted=n_pred_accepted,
-        hit_counts=hit_counts,
-        thresholds_samples=thresholds_samples,
-    )
-    return values, err, abs_err, conf, np.flatnonzero(teacher_accepted), hit_counts
-
-
-def write_csv(path: Path, rows: list[dict[str, object]]) -> None:
+    columns: list[str] | None = None,
+) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
-    if not rows:
+    if not rows and columns is None:
         path.write_text("", encoding="utf-8")
         return
 
-    columns: list[str] = []
-    seen = set()
-    for row in rows:
-        for key in row:
-            if key not in seen:
-                seen.add(key)
-                columns.append(key)
+    if columns is None:
+        columns = []
+        seen = set()
+        for row in rows:
+            for key in row:
+                if key not in seen:
+                    seen.add(key)
+                    columns.append(key)
 
     with path.open("w", newline="", encoding="utf-8") as f:
         writer = csv.DictWriter(f, fieldnames=columns, extrasaction="ignore")
@@ -198,47 +115,31 @@ def write_csv(path: Path, rows: list[dict[str, object]]) -> None:
             writer.writerow(row)
 
 
-def parse_csv_numbers(raw: str, *, dtype: type = float) -> tuple:
-    out = []
-    for raw_item in raw.split(","):
-        item = raw_item.strip()
-        if not item:
-            continue
-        out.append(dtype(item))
-    return tuple(out)
-
-
-def stage_specs(stages: Iterable[str]) -> dict[str, tuple[str, str | None]]:
-    mapping = {
-        "final": ("final_pick_i", "final_conf"),
-        "robust": ("robust_pick_i", "robust_conf"),
-        "coarse": ("coarse_pick_i", "coarse_pmax"),
-        "center": ("center_raw_i", None),
-    }
+def stage_specs(stages: Iterable[str]) -> dict[str, str]:
     out = {}
     for raw_stage in stages:
         stage = raw_stage.strip()
         if not stage:
             continue
-        if stage not in mapping:
-            raise ValueError(f"unknown stage={stage}; valid={sorted(mapping)}")
-        out[stage] = mapping[stage]
+        if stage not in STAGE_PICK_KEYS:
+            raise ValueError(f"unknown stage={stage}; valid={sorted(STAGE_PICK_KEYS)}")
+        out[stage] = STAGE_PICK_KEYS[stage]
     return out
 
 
-def new_accumulator(thresholds_samples: tuple[float, ...]) -> dict[str, object]:
+def new_accumulator() -> dict[str, object]:
     return {
         "n_files": 0,
         "n_traces": 0,
         "n_teacher": 0,
-        "n_pred_valid": 0,
-        "n_pred_accepted": 0,
+        "n_pred_finite": 0,
+        "n_pick_clipped_low": 0,
+        "n_pick_clipped_high": 0,
         "err_sum": 0.0,
         "sq_err_sum": 0.0,
+        "sq_err_ms_sum": 0.0,
         "abs_errors": [],
-        "conf_sum": 0.0,
-        "conf_count": 0,
-        "hit_counts": {float(th): 0 for th in thresholds_samples},
+        "abs_errors_ms": [],
     }
 
 
@@ -247,122 +148,200 @@ def update_accumulator(
     *,
     n_traces: int,
     n_teacher: int,
-    n_pred_valid: int,
-    n_pred_accepted: int,
+    n_pred_finite: int,
+    n_pick_clipped_low: int,
+    n_pick_clipped_high: int,
     err: np.ndarray,
     abs_err: np.ndarray,
-    conf: np.ndarray | None,
-    hit_counts: dict[float, int],
+    dt_sec: float,
 ) -> None:
     acc["n_files"] = int(acc["n_files"]) + 1
     acc["n_traces"] = int(acc["n_traces"]) + int(n_traces)
     acc["n_teacher"] = int(acc["n_teacher"]) + int(n_teacher)
-    acc["n_pred_valid"] = int(acc["n_pred_valid"]) + int(n_pred_valid)
-    acc["n_pred_accepted"] = int(acc["n_pred_accepted"]) + int(n_pred_accepted)
+    acc["n_pred_finite"] = int(acc["n_pred_finite"]) + int(n_pred_finite)
+    acc["n_pick_clipped_low"] = int(acc["n_pick_clipped_low"]) + int(
+        n_pick_clipped_low
+    )
+    acc["n_pick_clipped_high"] = int(acc["n_pick_clipped_high"]) + int(
+        n_pick_clipped_high
+    )
     if err.size:
         acc["err_sum"] = float(acc["err_sum"]) + float(np.sum(err, dtype=np.float64))
         acc["sq_err_sum"] = float(acc["sq_err_sum"]) + float(
             np.sum(np.square(err), dtype=np.float64)
         )
-        abs_errors = cast(list[np.ndarray], acc["abs_errors"])
-        abs_errors.append(abs_err.astype(np.float32, copy=False))
-    if conf is not None and conf.size:
-        conf_finite = conf[np.isfinite(conf)]
-        acc["conf_sum"] = float(acc["conf_sum"]) + float(
-            np.sum(conf_finite, dtype=np.float64)
+        ms_scale = float(dt_sec) * 1000.0
+        acc["sq_err_ms_sum"] = float(acc["sq_err_ms_sum"]) + float(
+            np.sum(np.square(err * ms_scale), dtype=np.float64)
         )
-        acc["conf_count"] = int(acc["conf_count"]) + int(conf_finite.size)
-    acc_hits = cast(dict[float, int], acc["hit_counts"])
-    for th, value in hit_counts.items():
-        acc_hits[float(th)] = int(acc_hits[float(th)]) + int(value)
+        abs_errors = cast("list[np.ndarray]", acc["abs_errors"])
+        abs_errors.append(abs_err.astype(np.float32, copy=False))
+        abs_errors_ms = cast("list[np.ndarray]", acc["abs_errors_ms"])
+        abs_errors_ms.append((abs_err * ms_scale).astype(np.float32, copy=False))
 
 
-def accumulator_row(
-    acc: dict[str, object],
+def metric_values(
     *,
-    thresholds_samples: tuple[float, ...],
+    n_traces: int,
+    n_teacher: int,
+    n_pred_finite: int,
+    n_pick_clipped_low: int,
+    n_pick_clipped_high: int,
+    err: np.ndarray,
+    abs_err: np.ndarray,
+    dt_sec: float,
 ) -> dict[str, object]:
+    out: dict[str, object] = {
+        "n_traces": int(n_traces),
+        "n_teacher": int(n_teacher),
+        "n_pred_finite": int(n_pred_finite),
+        "n_pick_clipped_low": int(n_pick_clipped_low),
+        "n_pick_clipped_high": int(n_pick_clipped_high),
+        "n_pick_clipped": int(n_pick_clipped_low + n_pick_clipped_high),
+        "coverage": "" if n_teacher == 0 else float(n_pred_finite / n_teacher),
+    }
+    out.update(error_metric_values(err=err, abs_err=abs_err, dt_sec=dt_sec))
+    return out
+
+
+def error_metric_values(
+    *,
+    err: np.ndarray,
+    abs_err: np.ndarray,
+    dt_sec: float,
+) -> dict[str, object]:
+    if err.size == 0:
+        return {
+            "mae_samples": "",
+            "rmse_samples": "",
+            "median_abs_samples": "",
+            "p90_abs_samples": "",
+            "p95_abs_samples": "",
+            "p99_abs_samples": "",
+            "max_abs_samples": "",
+            "mae_ms": "",
+            "rmse_ms": "",
+            "median_abs_ms": "",
+            "p90_abs_ms": "",
+            "p95_abs_ms": "",
+            "p99_abs_ms": "",
+            "max_abs_ms": "",
+        }
+
+    sample_metrics = {
+        "mae_samples": float(np.mean(abs_err)),
+        "rmse_samples": float(np.sqrt(np.mean(np.square(err)))),
+        "median_abs_samples": float(np.percentile(abs_err, 50)),
+        "p90_abs_samples": float(np.percentile(abs_err, 90)),
+        "p95_abs_samples": float(np.percentile(abs_err, 95)),
+        "p99_abs_samples": float(np.percentile(abs_err, 99)),
+        "max_abs_samples": float(np.max(abs_err)),
+    }
+    ms_scale = float(dt_sec) * 1000.0
+    return {
+        **sample_metrics,
+        "mae_ms": sample_metrics["mae_samples"] * ms_scale,
+        "rmse_ms": sample_metrics["rmse_samples"] * ms_scale,
+        "median_abs_ms": sample_metrics["median_abs_samples"] * ms_scale,
+        "p90_abs_ms": sample_metrics["p90_abs_samples"] * ms_scale,
+        "p95_abs_ms": sample_metrics["p95_abs_samples"] * ms_scale,
+        "p99_abs_ms": sample_metrics["p99_abs_samples"] * ms_scale,
+        "max_abs_ms": sample_metrics["max_abs_samples"] * ms_scale,
+    }
+
+
+def evaluate_stage_metrics(
+    *,
+    fb_i: np.ndarray,
+    pick_i: np.ndarray,
+    teacher_mask: np.ndarray,
+    n_samples_orig: int,
+    n_traces: int,
+    dt_sec: float,
+) -> tuple[dict[str, object], np.ndarray, np.ndarray]:
+    pick_finite_mask = np.isfinite(pick_i)
+    eval_mask = teacher_mask & pick_finite_mask
+    pick_eval_i = np.clip(
+        pick_i.astype(np.float64, copy=False),
+        0.0,
+        float(n_samples_orig - 1),
+    )
+    err = pick_eval_i[eval_mask] - fb_i[eval_mask]
+    abs_err = np.abs(err)
+    n_pick_clipped_low = int(np.count_nonzero(eval_mask & (pick_i < 0.0)))
+    n_pick_clipped_high = int(
+        np.count_nonzero(eval_mask & (pick_i > float(n_samples_orig - 1)))
+    )
+    values = metric_values(
+        n_traces=n_traces,
+        n_teacher=int(np.count_nonzero(teacher_mask)),
+        n_pred_finite=int(np.count_nonzero(eval_mask)),
+        n_pick_clipped_low=n_pick_clipped_low,
+        n_pick_clipped_high=n_pick_clipped_high,
+        err=err,
+        abs_err=abs_err,
+        dt_sec=dt_sec,
+    )
+    return values, err, abs_err
+
+
+def accumulator_row(acc: dict[str, object]) -> dict[str, object]:
     n_teacher = int(acc["n_teacher"])
-    n_pred_accepted = int(acc["n_pred_accepted"])
+    n_pred_finite = int(acc["n_pred_finite"])
     out: dict[str, object] = {
         "n_files": int(acc["n_files"]),
         "n_traces": int(acc["n_traces"]),
         "n_teacher": n_teacher,
-        "n_pred_valid": int(acc["n_pred_valid"]),
-        "n_pred_accepted": n_pred_accepted,
-        "coverage": "" if n_teacher == 0 else float(n_pred_accepted / n_teacher),
+        "n_pred_finite": n_pred_finite,
+        "n_pick_clipped_low": int(acc["n_pick_clipped_low"]),
+        "n_pick_clipped_high": int(acc["n_pick_clipped_high"]),
+        "n_pick_clipped": int(acc["n_pick_clipped_low"])
+        + int(acc["n_pick_clipped_high"]),
+        "coverage": "" if n_teacher == 0 else float(n_pred_finite / n_teacher),
     }
 
-    if n_pred_accepted > 0:
-        abs_error_parts = cast(list[np.ndarray], acc["abs_errors"])
+    if n_pred_finite > 0:
+        abs_error_parts = cast("list[np.ndarray]", acc["abs_errors"])
         abs_all = np.concatenate(abs_error_parts, axis=0).astype(
+            np.float64,
+            copy=False,
+        )
+        abs_error_ms_parts = cast("list[np.ndarray]", acc["abs_errors_ms"])
+        abs_ms_all = np.concatenate(abs_error_ms_parts, axis=0).astype(
             np.float64,
             copy=False,
         )
         out.update(
             {
-                "accepted_mae_samples": float(np.mean(abs_all)),
-                "accepted_bias_samples": float(acc["err_sum"]) / n_pred_accepted,
-                "accepted_rmse_samples": float(
-                    np.sqrt(float(acc["sq_err_sum"]) / n_pred_accepted)
+                "mae_samples": float(np.mean(abs_all)),
+                "rmse_samples": float(
+                    np.sqrt(float(acc["sq_err_sum"]) / n_pred_finite)
                 ),
-                "accepted_median_abs_samples": float(np.percentile(abs_all, 50)),
-                "accepted_p90_abs_samples": float(np.percentile(abs_all, 90)),
-                "accepted_p95_abs_samples": float(np.percentile(abs_all, 95)),
-                "accepted_p99_abs_samples": float(np.percentile(abs_all, 99)),
-                "accepted_max_abs_samples": float(np.max(abs_all)),
+                "median_abs_samples": float(np.percentile(abs_all, 50)),
+                "p90_abs_samples": float(np.percentile(abs_all, 90)),
+                "p95_abs_samples": float(np.percentile(abs_all, 95)),
+                "p99_abs_samples": float(np.percentile(abs_all, 99)),
+                "max_abs_samples": float(np.max(abs_all)),
+                "mae_ms": float(np.mean(abs_ms_all)),
+                "rmse_ms": float(
+                    np.sqrt(float(acc["sq_err_ms_sum"]) / n_pred_finite)
+                ),
+                "median_abs_ms": float(np.percentile(abs_ms_all, 50)),
+                "p90_abs_ms": float(np.percentile(abs_ms_all, 90)),
+                "p95_abs_ms": float(np.percentile(abs_ms_all, 95)),
+                "p99_abs_ms": float(np.percentile(abs_ms_all, 99)),
+                "max_abs_ms": float(np.max(abs_ms_all)),
             }
         )
     else:
         out.update(
-            {
-                "accepted_mae_samples": "",
-                "accepted_bias_samples": "",
-                "accepted_rmse_samples": "",
-                "accepted_median_abs_samples": "",
-                "accepted_p90_abs_samples": "",
-                "accepted_p95_abs_samples": "",
-                "accepted_p99_abs_samples": "",
-                "accepted_max_abs_samples": "",
-            }
-        )
-
-    conf_count = int(acc["conf_count"])
-    out["mean_conf"] = (
-        float(acc["conf_sum"]) / conf_count if conf_count > 0 else ""
-    )
-
-    acc_hits = cast(dict[float, int], acc["hit_counts"])
-    for th in thresholds_samples:
-        out[f"within_{th:g}_samples"] = (
-            "" if n_teacher == 0 else float(int(acc_hits[float(th)]) / n_teacher)
+            error_metric_values(
+                err=np.asarray([]),
+                abs_err=np.asarray([]),
+                dt_sec=0.0,
+            )
         )
     return out
-
-
-def require_payload_vector(
-    payload: dict[str, np.ndarray],
-    key: str,
-    *,
-    n_traces: int,
-    tag: str,
-) -> np.ndarray:
-    if key not in payload:
-        raise KeyError(f"{tag}: missing key {key}")
-    arr = np.asarray(payload[key])
-    if arr.shape != (n_traces,):
-        raise ValueError(f"{tag}: {key} shape {arr.shape} != ({n_traces},)")
-    return arr
-
-
-def scalar_payload_value(
-    payload: dict[str, np.ndarray],
-    key: str,
-    trace_idx: int,
-) -> object:
-    if key not in payload:
-        return ""
-    return np.asarray(payload[key])[trace_idx].item()
 
 
 def main() -> int:
@@ -400,23 +379,7 @@ def main() -> int:
     parser.add_argument(
         "--stages",
         default="final,robust,coarse",
-        help="comma-separated stages: final,robust,coarse,center",
-    )
-    parser.add_argument(
-        "--thresholds-samples",
-        default=",".join(f"{x:g}" for x in DEFAULT_THRESHOLDS_SAMPLES),
-        help="coverage thresholds in samples",
-    )
-    parser.add_argument(
-        "--topk-per-file",
-        type=int,
-        default=20,
-        help="number of worst final-pick traces to keep per file",
-    )
-    parser.add_argument(
-        "--include-high-conf-final",
-        action="store_true",
-        help="also evaluate final picks only where high_conf_mask is true",
+        help="comma-separated stages: final,robust,coarse",
     )
     args = parser.parse_args()
 
@@ -433,18 +396,12 @@ def main() -> int:
         if args.out_dir
         else run_root / "aggregate" / "08_eval"
     )
-    thresholds_samples = parse_csv_numbers(args.thresholds_samples, dtype=float)
 
     specs = stage_specs(args.stages.split(","))
-    acc_stages = list(specs)
-    if args.include_high_conf_final:
-        acc_stages.append("final_high_conf")
 
     per_data_rows: list[dict[str, object]] = []
-    top_error_rows: list[dict[str, object]] = []
-    fold_accs: dict[tuple[str, str], dict[str, object]] = {}
     global_accs: dict[str, dict[str, object]] = {
-        stage: new_accumulator(thresholds_samples) for stage in acc_stages
+        stage: new_accumulator() for stage in specs
     }
 
     fold_dirs = sorted(p for p in fold_list_root.glob("fold??") if p.is_dir())
@@ -485,13 +442,14 @@ def main() -> int:
                 )
 
             teacher_mask = (
-                np.isfinite(fb_i) & (fb_i >= 0.0) & (fb_i < float(n_samples_orig))
+                np.isfinite(fb_i) & (fb_i > 0.0) & (fb_i < float(n_samples_orig))
             )
             n_teacher = int(np.count_nonzero(teacher_mask))
 
-            file_stage_cache: dict[str, FileStageCacheValue] = {}
+            if n_samples_orig <= 0:
+                raise ValueError(f"{tag}: n_samples_orig must be positive")
 
-            for stage, (pick_key, conf_key) in specs.items():
+            for stage, pick_key in specs.items():
                 if pick_key not in payload:
                     if stage == "final" and pick_key == "final_pick_i":
                         raise KeyError("final stage evaluation requires final_pick_i")
@@ -503,243 +461,69 @@ def main() -> int:
                         f"{tag}: {pick_key} shape {pick.shape} != ({n_traces},)"
                     )
 
-                valid_pick = (
-                    np.isfinite(pick) & (pick >= 0.0) & (pick < float(n_samples_orig))
-                )
-                reject_mask = np.zeros(n_traces, dtype=np.bool_)
-                if stage in REJECT_MASK_STAGES:
-                    if "reject_mask" not in payload:
-                        raise KeyError(f"{final_path} missing reject_mask")
-                    reject_mask = np.asarray(payload["reject_mask"], dtype=np.bool_)
-                    if reject_mask.shape != (n_traces,):
-                        raise ValueError(
-                            f"{tag}: reject_mask shape {reject_mask.shape} "
-                            f"!= ({n_traces},)"
-                        )
-                accepted_mask = valid_pick & (~reject_mask)
-
-                conf_arr = None
-                if conf_key is not None and conf_key in payload:
-                    candidate = np.asarray(payload[conf_key], dtype=np.float64)
-                    if candidate.shape == (n_traces,):
-                        conf_arr = candidate
-
-                metrics, err, abs_err, conf, valid_indices, hit_counts = (
-                    evaluate_stage_metrics(
-                        fb_i=fb_i,
-                        pick=pick,
-                        teacher_mask=teacher_mask,
-                        valid_pick=valid_pick,
-                        accepted_mask=accepted_mask,
-                        conf_arr=conf_arr,
-                        n_traces=n_traces,
-                        thresholds_samples=thresholds_samples,
-                    )
+                metrics, err, abs_err = evaluate_stage_metrics(
+                    fb_i=fb_i,
+                    pick_i=pick,
+                    teacher_mask=teacher_mask,
+                    n_samples_orig=n_samples_orig,
+                    n_traces=n_traces,
+                    dt_sec=dt_sec,
                 )
 
                 row = {
                     "run_id": args.run_id,
                     "fold": fold,
-                    "data_name": tag,
+                    "data_key": tag,
                     "stage": stage,
-                    "segy": segy,
-                    "fb": fb_path,
-                    "final_npz": str(final_path),
+                    "segy_path": segy,
+                    "fb_path": fb_path,
+                    "pred_path": str(final_path),
                     "dt_sec": dt_sec,
                     "n_samples_orig": n_samples_orig,
                     **metrics,
                 }
                 per_data_rows.append(row)
-                fold_acc = fold_accs.setdefault(
-                    (fold, stage), new_accumulator(thresholds_samples)
-                )
-                for acc in (fold_acc, global_accs[stage]):
-                    update_accumulator(
-                        acc,
-                        n_traces=n_traces,
-                        n_teacher=int(metrics["n_teacher"]),
-                        n_pred_valid=int(metrics["n_pred_valid"]),
-                        n_pred_accepted=int(metrics["n_pred_accepted"]),
-                        err=err,
-                        abs_err=abs_err,
-                        conf=conf,
-                        hit_counts=hit_counts,
-                    )
-
-                file_stage_cache[stage] = (err, abs_err, conf, valid_indices)
-
-            if args.include_high_conf_final and "final" in file_stage_cache:
-                if "high_conf_mask" not in payload:
-                    raise KeyError(f"{final_path} missing high_conf_mask")
-                if "final_pick_i" not in payload:
-                    raise KeyError("final_high_conf evaluation requires final_pick_i")
-                pick = np.asarray(payload["final_pick_i"], dtype=np.float64)
-                conf_arr = np.asarray(
-                    payload.get("final_conf", np.full(n_traces, np.nan)),
-                    dtype=np.float64,
-                )
-                high_conf = np.asarray(payload["high_conf_mask"], dtype=np.bool_)
-                valid_pick = (
-                    np.isfinite(pick) & (pick >= 0.0) & (pick < float(n_samples_orig))
-                )
-                metrics, err, abs_err, conf, _, hit_counts = evaluate_stage_metrics(
-                    fb_i=fb_i,
-                    pick=pick,
-                    teacher_mask=teacher_mask,
-                    valid_pick=valid_pick,
-                    accepted_mask=valid_pick & high_conf,
-                    conf_arr=conf_arr if conf_arr.shape == (n_traces,) else None,
+                update_accumulator(
+                    global_accs[stage],
                     n_traces=n_traces,
-                    thresholds_samples=thresholds_samples,
+                    n_teacher=int(metrics["n_teacher"]),
+                    n_pred_finite=int(metrics["n_pred_finite"]),
+                    n_pick_clipped_low=int(metrics["n_pick_clipped_low"]),
+                    n_pick_clipped_high=int(metrics["n_pick_clipped_high"]),
+                    err=err,
+                    abs_err=abs_err,
+                    dt_sec=dt_sec,
                 )
-
-                per_data_rows.append(
-                    {
-                        "run_id": args.run_id,
-                        "fold": fold,
-                        "data_name": tag,
-                        "stage": "final_high_conf",
-                        "segy": segy,
-                        "fb": fb_path,
-                        "final_npz": str(final_path),
-                        "dt_sec": dt_sec,
-                        "n_samples_orig": n_samples_orig,
-                        **metrics,
-                    }
-                )
-                fold_acc = fold_accs.setdefault(
-                    (fold, "final_high_conf"), new_accumulator(thresholds_samples)
-                )
-                for acc in (fold_acc, global_accs["final_high_conf"]):
-                    update_accumulator(
-                        acc,
-                        n_traces=n_traces,
-                        n_teacher=int(metrics["n_teacher"]),
-                        n_pred_valid=int(metrics["n_pred_valid"]),
-                        n_pred_accepted=int(metrics["n_pred_accepted"]),
-                        err=err,
-                        abs_err=abs_err,
-                        conf=conf,
-                        hit_counts=hit_counts,
-                    )
-
-            # worst trace list for final stage only
-            if "final" in file_stage_cache and args.topk_per_file > 0:
-                err, abs_err, conf, valid_indices = file_stage_cache["final"]
-                k = min(int(args.topk_per_file), int(abs_err.size))
-                if k > 0:
-                    if k < abs_err.size:
-                        sel = np.argpartition(abs_err, -k)[-k:]
-                        sel = sel[np.argsort(abs_err[sel])[::-1]]
-                    else:
-                        sel = np.argsort(abs_err)[::-1]
-
-                    final_pick_i = require_payload_vector(
-                        payload,
-                        "final_pick_i",
-                        n_traces=n_traces,
-                        tag=tag,
-                    )
-                    for j in sel:
-                        trace_idx = int(valid_indices[j])
-                        top_error_rows.append(
-                            {
-                                "run_id": args.run_id,
-                                "fold": fold,
-                                "data_key": tag,
-                                "stage": "final",
-                                "segy_file": segy,
-                                "fb_file": fb_path,
-                                "final_npz": str(final_path),
-                                "trace_index": trace_idx,
-                                "ffid": scalar_payload_value(
-                                    payload,
-                                    "ffid_values",
-                                    trace_idx,
-                                ),
-                                "chno": scalar_payload_value(
-                                    payload,
-                                    "chno_values",
-                                    trace_idx,
-                                ),
-                                "fb_i": float(fb_i[trace_idx]),
-                                "final_pick_i": int(final_pick_i[trace_idx]),
-                                "error_samples": float(err[j]),
-                                "abs_error_samples": float(abs_err[j]),
-                                "error_ms": float(err[j] * dt_sec * 1000.0),
-                                "abs_error_ms": float(abs_err[j] * dt_sec * 1000.0),
-                                "coarse_pick_i": scalar_payload_value(
-                                    payload,
-                                    "coarse_pick_i",
-                                    trace_idx,
-                                ),
-                                "robust_pick_i": scalar_payload_value(
-                                    payload,
-                                    "robust_pick_i",
-                                    trace_idx,
-                                ),
-                                "window_start_i": scalar_payload_value(
-                                    payload,
-                                    "window_start_i",
-                                    trace_idx,
-                                ),
-                                "window_end_i": scalar_payload_value(
-                                    payload,
-                                    "window_end_i",
-                                    trace_idx,
-                                ),
-                                "fine_pick_local_i": scalar_payload_value(
-                                    payload,
-                                    "fine_pick_local_i",
-                                    trace_idx,
-                                ),
-                                "final_conf": (
-                                    float(payload["final_conf"][trace_idx])
-                                    if "final_conf" in payload
-                                    else ""
-                                ),
-                                "reject_mask": (
-                                    bool(payload["reject_mask"][trace_idx])
-                                    if "reject_mask" in payload
-                                    else ""
-                                ),
-                                "reason_mask": (
-                                    int(payload["reason_mask"][trace_idx])
-                                    if "reason_mask" in payload
-                                    else ""
-                                ),
-                            }
-                        )
 
             n_files += 1
             print(f"[eval] {fold} {tag} done n_teacher={n_teacher}")
 
-    per_fold_rows = [
-        {
-            "run_id": args.run_id,
-            "fold": fold,
-            "stage": stage,
-            **accumulator_row(acc, thresholds_samples=thresholds_samples),
-        }
-        for (fold, stage), acc in sorted(fold_accs.items())
-    ]
     summary_rows = [
         {
             "run_id": args.run_id,
             "stage": stage,
-            **accumulator_row(
-                global_accs[stage],
-                thresholds_samples=thresholds_samples,
-            ),
+            **accumulator_row(global_accs[stage]),
         }
-        for stage in acc_stages
+        for stage in specs
     ]
 
     out_dir.mkdir(parents=True, exist_ok=True)
-    write_csv(out_dir / "per_data.csv", per_data_rows)
-    write_csv(out_dir / "per_fold.csv", per_fold_rows)
-    write_csv(out_dir / "summary.csv", summary_rows)
-    write_csv(out_dir / "top_errors_final.csv", top_error_rows)
+    write_csv(out_dir / "per_data.csv", per_data_rows, columns=METRIC_COLUMNS)
+    write_csv(
+        out_dir / "summary_by_stage.csv",
+        summary_rows,
+        columns=["run_id", "stage", "n_files", *METRIC_COLUMNS[9:]],
+    )
+    for stale_name in (
+        "per_fold.csv",
+        "summary.csv",
+        "top_errors_final.csv",
+        "top_errors_robust.csv",
+        "top_errors_coarse.csv",
+    ):
+        stale_path = out_dir / stale_name
+        if stale_path.exists():
+            stale_path.unlink()
 
     meta = {
         "run_id": args.run_id,
@@ -749,15 +533,20 @@ def main() -> int:
         "pred_stage_subdir": str(args.pred_stage_subdir),
         "out_dir": str(out_dir),
         "n_files": n_files,
-        "stages": acc_stages,
-        "thresholds_samples": list(thresholds_samples),
-        "final_pick_key": "final_pick_i",
-        "include_high_conf_final": bool(args.include_high_conf_final),
+        "teacher_mask": "finite & fb_i > 0 & fb_i < n_samples_orig",
+        "pick_mask": "finite only",
+        "out_of_record_pick_policy": "clip_to_record_edge_before_error",
+        "clip_low": 0,
+        "clip_high": "n_samples_orig - 1",
+        "eval_mask": "teacher_mask & finite(pick_i)",
+        "stage_pick_keys": STAGE_PICK_KEYS,
+        "reject_mask_used": False,
+        "high_conf_used": False,
+        "top_errors_written": False,
         "outputs": {
             "per_data_csv": str(out_dir / "per_data.csv"),
-            "per_fold_csv": str(out_dir / "per_fold.csv"),
-            "summary_csv": str(out_dir / "summary.csv"),
-            "top_errors_final_csv": str(out_dir / "top_errors_final.csv"),
+            "summary_by_stage_csv": str(out_dir / "summary_by_stage.csv"),
+            "eval_meta_json": str(out_dir / "eval_meta.json"),
         },
     }
     (out_dir / "eval_meta.json").write_text(
@@ -768,9 +557,7 @@ def main() -> int:
     print()
     print("wrote:")
     print(" ", out_dir / "per_data.csv")
-    print(" ", out_dir / "per_fold.csv")
-    print(" ", out_dir / "summary.csv")
-    print(" ", out_dir / "top_errors_final.csv")
+    print(" ", out_dir / "summary_by_stage.csv")
     print(" ", out_dir / "eval_meta.json")
     print()
     print("summary:")
@@ -778,12 +565,11 @@ def main() -> int:
         print(
             row["stage"],
             "n_teacher=", row.get("n_teacher"),
-            "n_pred_accepted=", row.get("n_pred_accepted"),
+            "n_pred_finite=", row.get("n_pred_finite"),
             "coverage=", row.get("coverage"),
-            "accepted_mae_samples=", row.get("accepted_mae_samples"),
-            "accepted_p90_abs_samples=", row.get("accepted_p90_abs_samples"),
-            "within_4_samples=", row.get("within_4_samples"),
-            "within_8_samples=", row.get("within_8_samples"),
+            "mae_samples=", row.get("mae_samples"),
+            "p90_abs_samples=", row.get("p90_abs_samples"),
+            "n_pick_clipped=", row.get("n_pick_clipped"),
         )
 
     return 0

--- a/tests/test_site54_fine_oof_eval_metrics.py
+++ b/tests/test_site54_fine_oof_eval_metrics.py
@@ -33,6 +33,7 @@ def _write_case(
     coarse_pick: list[float],
     reject_mask: list[bool],
     final_pick_f: list[float] | None = None,
+    n_samples_orig: int = 1200,
 ) -> None:
     fold_dir = fold_list_root / fold
     fold_dir.mkdir(parents=True, exist_ok=True)
@@ -62,7 +63,7 @@ def _write_case(
     np.savez(
         final_npz,
         dt_sec=np.asarray(0.004, dtype=np.float32),
-        n_samples_orig=np.asarray(1200, dtype=np.int32),
+        n_samples_orig=np.asarray(n_samples_orig, dtype=np.int32),
         n_traces=np.asarray(n_traces, dtype=np.int32),
         final_pick_i=final_pick_i,
         final_pick_f=final_pick_f_arr,
@@ -85,7 +86,7 @@ def _read_csv(path: Path) -> list[dict[str, str]]:
         return list(csv.DictReader(f))
 
 
-def test_fine_oof_eval_uses_teacher_denominator_and_weighted_summary(
+def test_fine_oof_eval_uses_teacher_only_mask_and_clips_out_of_record_picks(
     tmp_path: Path,
 ) -> None:
     cv_root = tmp_path / "oof"
@@ -101,23 +102,23 @@ def test_fine_oof_eval_uses_teacher_denominator_and_weighted_summary(
         fold_list_root=fold_list_root,
         fold="fold00",
         data_name="a",
-        teacher=[10, 20, 30, 40],
-        final_pick=[10, 21, np.nan, 100],
-        robust_pick=[10, np.nan, 31, 100],
-        coarse_pick=[10, 21, np.nan, 100],
-        reject_mask=[False, False, False, True],
+        teacher=[0, 10, 20, 1199, 1200, np.nan],
+        final_pick=[500, -5, 25, 1300, 100, 100],
+        robust_pick=[500, -5, 25, 1300, 100, 100],
+        coarse_pick=[500, -5, 25, 1300, 100, 100],
+        reject_mask=[False, False, True, False, False, False],
+        n_samples_orig=1200,
     )
-    _write_case(
-        run_root=run_root,
-        fold_list_root=fold_list_root,
-        fold="fold00",
-        data_name="b",
-        teacher=[50],
-        final_pick=[50],
-        robust_pick=[50],
-        coarse_pick=[50],
-        reject_mask=[False],
-    )
+
+    for stale_name in (
+        "per_fold.csv",
+        "summary.csv",
+        "top_errors_final.csv",
+        "top_errors_robust.csv",
+        "top_errors_coarse.csv",
+    ):
+        (out_dir / stale_name).parent.mkdir(parents=True, exist_ok=True)
+        (out_dir / stale_name).write_text("stale\n", encoding="utf-8")
 
     result = subprocess.run(
         [
@@ -146,39 +147,59 @@ def test_fine_oof_eval_uses_teacher_denominator_and_weighted_summary(
     final_a = next(
         row
         for row in per_data
-        if row["stage"] == "final" and row["data_name"] == "fold00__a"
+        if row["stage"] == "final" and row["data_key"] == "fold00__a"
     )
-    assert final_a["n_teacher"] == "4"
-    assert final_a["n_pred_valid"] == "3"
-    assert final_a["n_pred_accepted"] == "2"
-    assert float(final_a["coverage"]) == 0.5
-    assert float(final_a["within_1_samples"]) == 0.5
-    assert float(final_a["accepted_mae_samples"]) == 0.5
-    assert math.isclose(float(final_a["accepted_rmse_samples"]), math.sqrt(0.5))
+    assert final_a["n_teacher"] == "3"
+    assert final_a["n_pred_finite"] == "3"
+    assert final_a["n_pick_clipped_low"] == "1"
+    assert final_a["n_pick_clipped_high"] == "1"
+    assert final_a["n_pick_clipped"] == "2"
+    assert float(final_a["coverage"]) == 1.0
+    assert float(final_a["mae_samples"]) == 5.0
+    assert math.isclose(float(final_a["rmse_samples"]), math.sqrt(125.0 / 3.0))
+    assert float(final_a["max_abs_samples"]) == 10.0
+    assert math.isclose(float(final_a["mae_ms"]), 20.0, abs_tol=1e-5)
 
     n_teacher_by_stage = {
         row["stage"]: row["n_teacher"]
         for row in per_data
-        if row["data_name"] == "fold00__a"
+        if row["data_key"] == "fold00__a"
     }
-    assert n_teacher_by_stage == {"coarse": "4", "final": "4", "robust": "4"}
+    assert n_teacher_by_stage == {"coarse": "3", "final": "3", "robust": "3"}
 
-    summary = _read_csv(out_dir / "summary.csv")
+    summary = _read_csv(out_dir / "summary_by_stage.csv")
     final_summary = next(row for row in summary if row["stage"] == "final")
-    assert final_summary["n_teacher"] == "5"
-    assert final_summary["n_pred_accepted"] == "3"
-    assert float(final_summary["within_1_samples"]) == 0.6
+    assert final_summary["n_files"] == "1"
+    assert final_summary["n_teacher"] == "3"
+    assert final_summary["n_pred_finite"] == "3"
+    assert final_summary["n_pick_clipped"] == "2"
+    assert float(final_summary["mae_samples"]) == 5.0
 
-    per_fold = _read_csv(out_dir / "per_fold.csv")
-    final_fold = next(row for row in per_fold if row["stage"] == "final")
-    assert final_fold["n_teacher"] == "5"
-    assert float(final_fold["coverage"]) == 0.6
+    for name in (
+        "per_fold.csv",
+        "summary.csv",
+        "top_errors_final.csv",
+        "top_errors_robust.csv",
+        "top_errors_coarse.csv",
+    ):
+        assert not (out_dir / name).exists()
 
-    for name in ("per_data.csv", "per_fold.csv", "summary.csv"):
-        rows = _read_csv(out_dir / name)
-        assert rows
-        assert not any("_ms" in column for column in rows[0])
-        assert "n_eval" not in rows[0]
+    assert not any(column.startswith("accepted_") for column in per_data[0])
+    assert "n_pred_accepted" not in per_data[0]
+    assert "high_conf_used" not in per_data[0]
+
+    meta = json.loads((out_dir / "eval_meta.json").read_text(encoding="utf-8"))
+    assert meta["teacher_mask"] == "finite & fb_i > 0 & fb_i < n_samples_orig"
+    assert meta["pick_mask"] == "finite only"
+    assert meta["out_of_record_pick_policy"] == "clip_to_record_edge_before_error"
+    assert meta["stage_pick_keys"] == {
+        "final": "final_pick_i",
+        "robust": "robust_pick_i",
+        "coarse": "coarse_pick_i",
+    }
+    assert meta["reject_mask_used"] is False
+    assert meta["high_conf_used"] is False
+    assert meta["top_errors_written"] is False
 
 
 def test_fine_oof_eval_final_stage_uses_final_pick_i(tmp_path: Path) -> None:
@@ -226,22 +247,17 @@ def test_fine_oof_eval_final_stage_uses_final_pick_i(tmp_path: Path) -> None:
 
     assert result.returncode == 0, result.stderr
 
-    summary = _read_csv(out_dir / "summary.csv")
+    summary = _read_csv(out_dir / "summary_by_stage.csv")
     final_summary = next(row for row in summary if row["stage"] == "final")
-    assert float(final_summary["accepted_mae_samples"]) == 10.0
-
-    top_errors = _read_csv(out_dir / "top_errors_final.csv")
-    assert top_errors
-    assert "final_pick_i" in top_errors[0]
-    assert "final_pick_f" not in top_errors[0]
-    assert {float(row["abs_error_samples"]) for row in top_errors} == {10.0}
+    assert float(final_summary["mae_samples"]) == 10.0
 
     per_data = _read_csv(out_dir / "per_data.csv")
     assert not any(row["stage"] == "final_high_conf" for row in per_data)
+    assert not (out_dir / "top_errors_final.csv").exists()
 
     meta = json.loads((out_dir / "eval_meta.json").read_text(encoding="utf-8"))
-    assert meta["final_pick_key"] == "final_pick_i"
-    assert meta["include_high_conf_final"] is False
+    assert meta["stage_pick_keys"]["final"] == "final_pick_i"
+    assert meta["high_conf_used"] is False
 
 
 def test_fine_oof_eval_final_stage_requires_final_pick_i(tmp_path: Path) -> None:


### PR DESCRIPTION
Closes #199

## Summary
- Issue: site54 08_eval を教師FBのみで評価し、raw record外pickは端にclipして誤差計算する

## Changed files
- `proc/fbpick/site54/oof/README.md`
- `proc/fbpick/site54/oof/scripts/check_cv_outputs.py`
- `proc/fbpick/site54/oof/scripts/evaluate_fine_oof.py`
- `tests/test_site54_fine_oof_eval_metrics.py`

## Checks
- `.work/codex/checks.log`: 1456 passed, 2 skipped, 5 warnings in 92.86s (0:01:32)

## Review
- `.work/codex/review.txt`: accept: yes
- findings: blocker 0, major 0, minor 0
